### PR TITLE
can.Model.list should depend on can/model not jquery/model

### DIFF
--- a/model/list/list.js
+++ b/model/list/list.js
@@ -1,4 +1,4 @@
-steal('jquery/model').then(function( $ ) {
+steal('can/model').then(function( $ ) {
 
 	var getArgs = function( args ) {
 		if ( args[0] && ($.isArray(args[0])) ) {
@@ -16,7 +16,7 @@ steal('jquery/model').then(function( $ ) {
 		},
 		expando = jQuery.expando,
 		each = $.each,
-		ajax = $.Model._ajax,
+		ajax = can.Model._ajax,
 
 		/**
 		 * @class jQuery.Model.List


### PR DESCRIPTION
We were running into some minor steal loading issues when using can.Model.List because it depending on jquery/model instead of can/model. It meant we had use a tiered "stealing" when including files with can.Model.List e.g.

steal('can/model').then('can/model/list') rather than steal('can/model', 'can/model/list') or even just steal('can/model/list')
