### PR TITLE
findOne and findAll in can/model don't work with can/construct/super. The context (thisArg) is set incorrectly

### DIFF
--- a/construct/super/super_test.js
+++ b/construct/super/super_test.js
@@ -41,7 +41,30 @@ test("static super", function(){
 	
 	equal(Second.raise(2), 4)
 	
-})
+});
+
+test("findAll super", function(){
+
+  var Parent = can.Model({
+    findAll: function(){
+      equal(this.shortName, 'child');
+      return new can.Deferred();
+    },
+    shortName : 'parent'
+  },{});
+
+  var Child = Parent({
+    findAll: function(){
+      return this._super();
+    },
+     shortName : 'child'
+  },{});
+
+  stop();
+  expect(1);
+  Child.findAll({});
+  start();
+});
 
 /* Not sure I want to fix this yet.
 test("Super in derived when parent doesn't have init", function(){

--- a/model/model.js
+++ b/model/model.js
@@ -498,8 +498,8 @@ steal('can/observe',function(){
 					// Increment requests.
 					self._reqs++;
 					// Make the request.
-					return pipe( old.call(self,params),
-						self, 
+					return pipe( old.call(this,params),
+						this,
 						method ).then(success,error).then(clean, clean);
 				}
 				


### PR DESCRIPTION
We're using can/construct/super in our can.Models and think we've found a problem with the context that is set in model.js. The qunit test hopefully makes it clear.
