### PR TITLE
docco gitsubmodule isn't heroku friendly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "util/docco/docco"]
 	path = util/docco/docco
-	url = git@github.com:jupiterjs/docco.git
+	url = https://github.com/jupiterjs/docco.git


### PR DESCRIPTION
Unfortunately, heroku does not like the git@github.com format and needs the https format instead. When you try to deploy an app with submodules in the earlier format you get this in heroku:

> > /usr/bin/git push -f dev HEAD:master
> > Counting objects: 16, done.
> > Delta compression using up to 4 threads.
> > Compressing objects: 100% (12/12), done.
> > Writing objects: 100% (12/12), 1.11 KiB, done.
> > Total 12 (delta 8), reused 0 (delta 0)

-----> Heroku receiving push
-----> Git submodules detected, installing
       Submodule 'public/js/can' (https://github.com/cohuman/canjs.git) registered for path 'public/js/can'
       Submodule 'public/js/cohuman/models' (https://cohumanjsmobile:asd&3sf1@github.com/cohuman/cohuman_js_models.git) registered for path 'public/js/cohuman/models'
       Submodule 'public/js/steal' (https://github.com/jupiterjs/steal.git) registered for path 'public/js/steal'
       Initialized empty Git repository in /disk1/tmp/build_34s125vxpi3cg/public/js/can/.git/
       Submodule path 'public/js/can': checked out '8e4c6ae36d6979b1bd1d9cbb722c807e6546142f'
       Submodule 'util/docco/docco' (https://github.com/jupiterjs/docco.git) registered for path 'util/docco/docco'
       Initialized empty Git repository in /disk1/tmp/build_34s125vxpi3cg/public/js/can/util/docco/docco/.git/
       Submodule path 'util/docco/docco': checked out 'cfa6aa22974288ae207b1411444d4411a90b6fee'
       Initialized empty Git repository in /disk1/tmp/build_34s125vxpi3cg/public/js/cohuman/models/.git/
       Submodule path 'public/js/cohuman/models': checked out 'd3979cdf66eea88f4f62a7e8e386e42bcce3d9f3'
       Initialized empty Git repository in /disk1/tmp/build_34s125vxpi3cg/public/js/steal/.git/
       Submodule path 'public/js/steal': checked out 'b91ad44abaadb74363d85fc961585f404bc32caf'
