### PR TITLE
Fix for can.Model.model to accomodate custom ids

### DIFF
--- a/model/model.js
+++ b/model/model.js
@@ -725,9 +725,9 @@ steal('can/observe',function(){
 			if ( attributes instanceof this ) {
 				attributes = attributes.serialize();
 			}
-			var model = this.store[attributes.id] || new this( attributes );
+			var model = this.store[attributes[this.id]] || new this( attributes );
 			if(this._reqs){
-				this.store[attributes.id] = model;
+				this.store[attributes[this.id]] = model;
 			}
 			return model;
 		}

--- a/model/model_test.js
+++ b/model/model_test.js
@@ -176,24 +176,22 @@ test("models", function(){
 	equals(people[0].prettyName(),"Mr. Justin","wraps wrapping works")
 });
 
-test(".model with custom id", function() {
+test(".models with custom id", function() {
 	can.Model("CustomId", {
+		findAll : steal.root.join("can/model/test") + "/customids.json",
 		id : '_id'
 	}, {
 		getName : function() {
 			return this.name;
 		}
 	});
-	var test = CustomId.model({
-		_id : 1,
-		name : 'Justin'
+	stop();
+	CustomId.findAll().done(function(results) {
+		equals(results.length, 2, 'Got two items back');
+		equals(results[0].name, 'Justin', 'First name right');
+		equals(results[1].name, 'Brian', 'Second name right');
+		start();
 	});
-	equal(test.getName(), 'Justin', 'Wrapping works and name set properly');
-	var test2 = CustomId.model({
-		_id : 2,
-		name : 'Brian'
-	});
-	equal(test.getName(), 'Brian', 'Warapped and name set');
 });
 
 

--- a/model/test/customids.json
+++ b/model/test/customids.json
@@ -1,0 +1,7 @@
+[{
+	"_id" : 1,
+	"name" : "Justin"
+}, {
+	"_id" : 2,
+	"name" : "Brian"
+}]


### PR DESCRIPTION
can.Model.model was using a hardcoded _id_ attribute to check the model store. This broke things when using a custom id property on the model. It now uses the static id property for the model store.
