### PR TITLE
fix return of identity hash in the destroy method

### DIFF
--- a/model/model.js
+++ b/model/model.js
@@ -281,7 +281,7 @@ steal('can/observe',function(){
 		destroy : {
 			type : "delete",
 			data : function(id){
-                                args = {};
+                                var args = {};
                                 args[this.id] = id;
                                 return args;
 			}


### PR DESCRIPTION
Scenario:

var Todo = can.Model({
        destroy : "DELETE /todos/{id}",
    },{});

todo = new Todo({id: 1});
todo.destroy();

The problem occurs because the return of identity hash into AjaxMethods.destroy return only id. so, when ajax method tries to fill values in the url, the id is filled with undefined value.
