### PR TITLE
Updated Model.findOne docs for when implementing as a function.

### DIFF
--- a/model/model.js
+++ b/model/model.js
@@ -411,12 +411,13 @@ steal('can/observe',function(){
 		 * 
 		 * To implement with a function, `findOne` is passed __params__ to specify
 		 * the instance retrieved from the server and it should return a
-		 * deferred that resolves to the model data. For example:
+		 * deferred that resolves to the model data.  Also notice that you now need to
+		 * build the URL manually. For example:
 		 * 
 		 *     Recipe = can.Model({
 		 *       findOne : function(params){
 		 *         return $.ajax({
-		 *           url: '/recipes/{id}.json',
+		 *           url: '/recipes/' + params.id,
 		 *           type: 'get',
 		 *           dataType: 'json'})
 		 *       }


### PR DESCRIPTION
Updated the docs to show that URL must be manually built when Model.findOne is implemented as a function.

See the related code here:
https://www.stypi.com/marshallswain/Model%20findOne.js

Related IRC discussion:
[09:35] <marshallswain> I'm having some trouble implementing Model findOne as a function.
[09:35] <marshallswain> The URL parameters are being escaped.
[09:35] <marshallswain> http://www.stypi.com/marshallswain/Model%20findOne.js
[09:36] @ralphholzmann marshallswain: take a look now
[09:39] <marshallswain> Ok.  How can I help update the docs?
[09:39] <marshallswain> http://donejs.com/docs.html#!can.Model.static.findOne
[09:39] <marshallswain> I pulled that from the "Implement with a Function" section
[09:40] @ralphholzmann ah, i see
[09:41] <marshallswain> Thanks for the help.  I have that working, now.
[09:42] @ralphholzmann our docs are generated from the source
[09:42] @ralphholzmann you can fork and pull request them
[09:43] @ralphholzmann https://github.com/jupiterjs/canjs/blob/master/model/model.js#L194
[09:43] @ralphholzmann written in markdown
[09:45] <marshallswain> thanks.
