### PR TITLE
Fixed observe.js typos and renamed a variable to add clarity.

### DIFF
--- a/observe/observe.js
+++ b/observe/observe.js
@@ -874,9 +874,9 @@ steal('can/construct', function() {
 		 * The following creates a list of numbers and replaces 2 and 3 with
 		 * "a", and "b".
 		 * 
-		 *     var l = new can.Observe.List([0,1,2,3]);
+		 *     var list = new can.Observe.List([0,1,2,3]);
 		 *     
-		 *     l.splice(1,2, "a", "b"); // results in [0,"a","b",3]
+		 *     list.splice(1,2, "a", "b"); // results in [0,"a","b",3]
 		 *     
 		 * This creates 2 change events.  The first event is the removal of 
 		 * numbers one and two where it's callback is 
@@ -1085,11 +1085,11 @@ steal('can/construct', function() {
 		 * @function push
 		 * Add items to the end of the list.
 		 * 
-		 *     var l = new can.Observe.List([]);
+		 *     var list = new can.Observe.List([]);
 		 *     
-		 *     l.attr() // -> []
+		 *     list.attr() // -> []
 		 *     
-		 *     l.bind('change', function( 
+		 *     list.bind('change', function( 
 		 *         ev,        // the change event
 		 *         attr,      // the attr that was changed,
 		 *     			   // for multiple items, "*" is used 
@@ -1101,8 +1101,8 @@ steal('can/construct', function() {
 		 *     
 		 *     })
 		 *     
-		 *     l.push('0','1','2'); 
-		 *     l.attr() // -> ['0', '1', '2']
+		 *     list.push('0','1','2'); 
+		 *     list.attr() // -> ['0', '1', '2']
 		 * 
 		 * @return {Number} the number of items in the array
 		 */
@@ -1112,9 +1112,9 @@ steal('can/construct', function() {
 		 * Add items to the start of the list.  This is very similar to
 		 * [can.Observe.List::push can.Observe.prototype.List].  Example:
 		 * 
-		 *     var l = new can.Observe.List(["a","b"]);
-		 *     l.unshift(1,2,3) //-> 5
-		 *     l.attr() //-> [1,2,3,"a","b"]
+		 *     var list = new can.Observe.List(["a","b"]);
+		 *     list.unshift(1,2,3) //-> 5
+		 *     .attr() //-> [1,2,3,"a","b"]
 		 * 
 		 * @param {Object} [items...] items to add to the start of the list.
 		 * @return {Number} the length of the array.
@@ -1156,13 +1156,13 @@ steal('can/construct', function() {
 		 * 
 		 * Removes an item from the end of the list. Example:
 		 * 
-		 *     var l = new can.Observe.List([0,1,2]);
-		 *     l.pop() //-> 2;
-		 *     l.attr() //-> [0,1]
+		 *     var list = new can.Observe.List([0,1,2]);
+		 *     list.pop() //-> 2;
+		 *     list.attr() //-> [0,1]
 		 * 
 		 * This produces a change event like
 		 * 
-		 *     l.bind('change', function( 
+		 *     list.bind('change', function( 
 		 *         ev,        // the change event
 		 *         attr,      // the attr that was changed, 
 		 *     			   // for multiple items, "*" is used 
@@ -1183,9 +1183,9 @@ steal('can/construct', function() {
 		 * Removes an item from the start of the list.  This is very similar to
 		 * [can.Observe.List::pop]. Example:
 		 * 
-		 *     var l = new can.Observe.List([0,1,2]);
-		 *     l.shift() //-> 0;
-		 *     l.attr() //-> [1,2]
+		 *     var list = new can.Observe.List([0,1,2]);
+		 *     list.shift() //-> 0;
+		 *     list.attr() //-> [1,2]
 		 * 
 		 * @return {Object} the element at the start of the list
 		 */


### PR DESCRIPTION
The word "where" was originally meant to be "were" in a few places. 

Renamed variable "l" to "list" for consistency and to avoid visual ambiguity with certain fonts, including the one used on the documentation site.
