### PR TITLE
Add can.Observe.List.sort() method

### DIFF
--- a/observe/observe.js
+++ b/observe/observe.js
@@ -1215,21 +1215,41 @@ steal('can/construct', function() {
 			return res;
 		}
 	});
-	
+
 	list.prototype.
 	/**
 	 * @function indexOf
 	 * Returns the position of the item in the array.  Returns -1 if the
 	 * item is not in the array.  Examples:
-	 * 
+	 *
 	 *     list = new can.Observe.List(["a","b","c"]);
 	 *     list.indexOf("b") //-> 1
 	 *     list.indexOf("f") //-> -1
-	 * 
+	 *
 	 * @param {Object} item the item to look for
 	 * @return {Number} the index of the object in the array or -1.
 	 */
 	indexOf = [].indexOf || function(item){
 		return can.inArray(item, this)
+	};
+
+  list.prototype.
+	/**
+	 * @function sort
+	 * Sorts the elements of a List in place and returns the List.
+	 *
+	 *     list = new can.Observe.List(["z","y","x"]);
+	 *     list.sort() //-> ["x", "y", "z"]
+	 *
+	 * @param {Function} compareFunction Specifies a function that
+	 *     defines the sort order. If omitted, the array is sorted
+	 *     lexicographically (in dictionary order) according to the
+	 *     string conversion of each element.
+	 * @return {can.Observe.List} the list, which has been sorted.
+	 */
+	sort = function() {
+		[].sort.apply(this, arguments);
+		batchTrigger(this, "length", [this.length]);
+		return this;
 	};
 });

--- a/observe/observe_test.js
+++ b/observe/observe_test.js
@@ -339,3 +339,41 @@ test("bind to specific attribute changes when an attribute is removed", function
 	paginate.removeAttr( 'offset' );
 });
 
+test("list sort", function(){
+	var l = new can.Observe.List([42,2,28,9]),
+		triggered = false,
+		result;
+
+	var str = function(num) { return  "" + num; };
+
+	l.bind('length', function( ev, newLength ) {
+		var i;
+		equals(newLength, 4)
+
+		for (i = 1; i < l.length; i++) {
+			ok(str(l[i-1]) <= str(l[i]), "in order " + i);
+			triggered = true;
+		}
+	});
+
+	result = l.sort();
+
+	ok(triggered, "event triggered");
+	same(result, l);
+});
+
+test("list sort compareFunction", function(){
+	var l = new can.Observe.List([42,2,28,9]),
+		cmp = function(a, b) { return a - b; };
+
+	l.bind('length', function( ev, newLength ) {
+		var i;
+		equals(newLength, 4)
+
+		for (i = 1; i < l.length; i++) {
+			ok(l[i-1] <= l[i], "in order " + i);
+		}
+	});
+
+	result = l.sort(cmp);
+});


### PR DESCRIPTION
I have some jmvc code which I'm porting to canjs.

It needs to sort the model list which in jmvc was just a plain array. Not so in canjs, hence the patch.

I'm not sure what the event name and args should be... so I use
"length" for now.

Please let me know and I will update the patch.
