### PR TITLE
ejs tests: test attribute quoting

### DIFF
--- a/view/ejs/ejs_test.js
+++ b/view/ejs/ejs_test.js
@@ -842,4 +842,21 @@ test("trailing text", function(){
 	ok(/There are 2 todos/.test(div.innerHTML), "got all text")
 })
 
+test("attribute unquoting", function() {
+	var text = '<input type="radio" ' +
+		'<%= facet.single ? \'name="facet-\' + facet.id + \'"\' : "" %> ' +
+		'value="<%= facet.single ? "facet-" + facet.id : "" %>" />',
+	facet = new can.Observe({
+		id: 1,
+		single: true
+	});
+
+	compiled = new can.EJS({text: text}).render({ facet: facet }),
+	div = document.createElement('div');
+	div.appendChild(can.view.frag(compiled))
+
+	equals(div.children[0].name, "facet-1");
+	equals(div.children[0].value, "facet-1");
+})
+
 })()


### PR DESCRIPTION
I think something is wrong with the quoting in EJS.

The test is failing with the following result:

```
1. failed
Expected: "facet-1"
Result: "\"facet-1\""

2. okay
Expected: "facet-1"
```

Forum thread here:
https://forum.javascriptmvc.com/#Topic/32525000001013093
