### PR TITLE
Fix for Model.List.findAll push to List on success return

### DIFF
--- a/model/list/list.js
+++ b/model/list/list.js
@@ -446,7 +446,7 @@ steal('can/model/elements').then(function( $ ) {
 		findAll: function( params, success, error ) {
 			var self = this;
 			this.model().findAll(params, function( items ) {
-				self.push(items);
+				self.push.apply(self, items);
 				success && success(self)
 			}, error)
 		},


### PR DESCRIPTION
Made a fix for the Model.List.findAll success push into List
