### PR TITLE
can.Model.List attr() behaves unexpectedly when passed an array of data that doesn't match the order of the list

### DIFF
--- a/model/list/list.js
+++ b/model/list/list.js
@@ -513,7 +513,43 @@ steal('can/util', 'can/model/elements', function(can) {
 			}
 
 			return this;
-		}
+		},
+
+    _updateAttrs :function(items, remove){
+      var len = items.length,
+          newVal,
+          curVal;
+
+      for ( var i = 0; i < len; i++ ) {
+        newVal = items[i];
+        curVal = null;
+
+        if ( can.Observe.canMakeObserve(newVal) ) {
+          curVal = this.get(newVal[this.constructor.id])[0];
+          if (curVal){
+            curVal.attr(newVal, remove)
+          } else {
+            this.push(newVal)
+          }
+        }
+      }
+
+      if(remove){
+        var id = this.constructor.id,
+            existingIds = this.map(function(element) {
+              return element[id];
+            }),
+            itemIds = items.map(function(element){
+              return element[id];
+            });
+
+        can.each(existingIds, $.proxy(function(id){
+          if(itemIds.indexOf(id) == -1){
+            this.remove(id);
+          }
+        }, this));
+      }
+    }
 	});
 
 	

--- a/model/list/list_test.js
+++ b/model/list/list_test.js
@@ -68,7 +68,7 @@ test("destroy a list", function(){
 	var people = Person.models([{id: 1}, {id: 2}]);
 	stop();
 	// make sure a request is made
-	$.fixture('DELETE /person/destroyAll', function(){
+	can.fixture('DELETE /person/destroyAll', function(){
 		
 		ok(true, "called right fixture");
 		return true;
@@ -94,7 +94,7 @@ test("destroy a list with nothing in it", function(){
 	stop();
 	
 	// make sure a request is made
-	$.fixture('DELETE /person/destroyAll', function(){
+	can.fixture('DELETE /person/destroyAll', function(){
 		ok(true, "called right fixture");
 		return true;
 	});
@@ -118,7 +118,7 @@ test("update a list", function(){
 	stop();
 	
 	// make sure a request is made
-	$.fixture('PUT /person/updateAll', function(orig){	
+	can.fixture('PUT /person/updateAll', function(orig){
 		ok(true, "called right fixture");
 		ok(orig.data.ids.length, 2, "got 2 ids")
 		same(orig.data.attrs, updateWith, "got the same attrs")
@@ -147,7 +147,7 @@ test("update a list with nothing in it", function(){
 	stop();
 	
 	// make sure a request is made
-	$.fixture('PUT /person/updateAll', function(orig){
+	can.fixture('PUT /person/updateAll', function(orig){
 		ok(true, "called right fixture");
 		return newProps;
 	});
@@ -157,7 +157,136 @@ test("update a list with nothing in it", function(){
 		equal(updated.length, people.length, "nothing updated");
 		start();
 	});
-})
+});
+
+test("attr update a list when more things come back", function(){
+  var people = Person.models([
+    {
+      id : 1,
+      name : 'Michael',
+      age : 20
+    },
+    {
+      id : 2,
+      name : 'Amy',
+      age : 80
+    }]);
+
+  people.attr([
+    {
+      id : 3,
+      name : 'Andy',
+      age : 101
+    },
+    {
+      id : 1,
+      name : 'Michael',
+      age : 120
+    },
+    {
+      id : 2,
+      name : 'Amy',
+      age : 180
+    }
+  ]);
+  equal(people.attr('0.id'), 1);
+  equal(people.attr('0.age'), 120, "Michael's age incremented by 100 years");
+
+  equal(people.attr('1.id'), 2);
+  equal(people.attr('1.age'), 180, "Amy's age incremented by 100 years");
+
+  equal(people.attr('2.id'), 3, "Added Andy to the end of the list");
+  equal(people.attr('2.age'), 101);
+});
+
+test("attr update a list when less things come back and remove is true", function(){
+  var people = Person.models([
+    {
+      id : 1,
+      name : 'Michael',
+      age : 20
+    },
+    {
+      id : 2,
+      name : 'Amy',
+      age : 80
+    },
+    {
+      id : 3,
+      name : 'Andy',
+      age : 1
+    }
+  ]);
+
+  people.attr([
+    {
+      id : 3,
+      name : 'Andy',
+      age : 101
+    },
+    {
+      id : 1,
+      name : 'Michael',
+      age : 120
+    }], true);
+
+
+  equal(people.length, 2, "Removed Amy");
+
+  equal(people.attr('0.id'), 1);
+  equal(people.attr('0.age'), 120, "Michael's age incremented by 100 years");
+
+  equal(people.attr('1.id'), 3, "Andy is now the 2nd person in the list");
+  equal(people.attr('1.age'), 101, "Andy's age incremented by 100 years");
+});
+
+
+test("attr updates items based on id (when present), not position", function(){
+    var people = Person.models([
+      {
+        id : 1,
+        name : 'Michael',
+        age : 20
+      },
+      {
+        id : 2,
+        name : 'Amy',
+        age : 80
+      },
+      {
+        id : 3,
+        name : 'Andy',
+        age : 1
+      }
+    ]);
+
+    people.attr([
+      {
+        id : 3,
+        name : 'Andy',
+        age : 101
+      },
+      {
+        id : 1,
+        name : 'Michael',
+        age : 120
+      },
+      {
+        id : 2,
+        name : 'Amy',
+        age : 180
+      }
+    ]);
+
+    equal(people.attr('0.id'), 1);
+    equal(people.attr('0.age'), 120, "Michael's age incremented by 100 years");
+
+    equal(people.attr('1.id'), 2);
+    equal(people.attr('1.age'), 180, "Amy's age incremented by 100 years");
+
+    equal(people.attr('2.id'), 3);
+    equal(people.attr('2.age'), 101, "Andy's age incremented by 100 years");
+  });
 
 test("events - add", 4, function(){
 	var list = new Person.List;

--- a/observe/list/list_test.js
+++ b/observe/list/list_test.js
@@ -53,6 +53,53 @@
 		equal(filtered[0].attr('name'), 'Test 2', 'Older element remains');
 	});
 
+  test("attr updates items in position order", function(){
+    var original = new can.Observe.List([
+      {
+        id : 1,
+        name : 'Test 1',
+        age : 20
+      },
+      {
+        id : 2,
+        name : 'Test 2',
+        age : 80
+      },
+      {
+        id : 3,
+        name : 'Test 3',
+        age : 1
+      }
+    ]);
+
+    original.attr([
+      {
+        id : 1,
+        name : 'Test 1',
+        age : 120
+      },
+      {
+        id : 2,
+        name : 'Test 2',
+        age : 180
+      },
+      {
+        id : 3,
+        name : 'Test 3',
+        age : 101
+      }
+    ]);
+
+    equal(original.attr('0.id'), 1);
+    equal(original.attr('0.age'), 120, "Test 1's age incremented by 100 years");
+
+    equal(original.attr('1.id'), 2);
+    equal(original.attr('1.age'), 180, "Test 2's age incremented by 100 years");
+
+    equal(original.attr('2.id'), 3);
+    equal(original.attr('2.age'), 101, "Test 3's age incremented by 100 years");
+  });
+
 	test("map", function() {
 		var original = new can.Observe.List([
 			{
@@ -76,11 +123,14 @@
 		equal(mapped.length, 3, 'All items mapped');
 		original.attr('0.name', 'Updated test');
 		original.attr('0.age', '24');
+
 		equal(mapped[0], 'Updated test (24)', 'Mapping got updated');
+
 		original.push({
 			name : 'Push test',
 			age : 99
 		});
+
 		equal(mapped[mapped.length - 1], 'Push test (' + 99 + ')');
 		original.shift();
 		equal(mapped.length, 3, 'Item got removed');

--- a/observe/observe.js
+++ b/observe/observe.js
@@ -138,7 +138,8 @@ steal('can/util','can/construct', function(can, Construct) {
 		},
 		bind : bind,
 		unbind: unbind,
-		id: "id"
+		id: "id",
+    canMakeObserve : canMakeObserve
 	},
 	/**
 	 * @prototype
@@ -1048,46 +1049,48 @@ steal('can/util','can/construct', function(can, Construct) {
 		 *      list = new can.Observe.List(["a", {foo: "bar"}])
 		 *      list.attr(0)  //-> "a",
 		 * 
-		 * @param {Array|Number} props
+		 * @param {Array|Number} items
 		 * @param {Boolean|Object} {optional:remove} 
 		 * @return {list|Array} returns the props on a read or the observe
 		 * list on a write.
 		 */
-		_attrs: function( props, remove ) {
-			if ( props === undefined ) {
+		_attrs: function( items, remove ) {
+			if ( items === undefined ) {
 				return serialize(this, 'attr', []);
 			}
 
 			// Create a copy.
-			props = can.makeArray( props );
+			items = can.makeArray( items );
 
-			var len = Math.min(props.length, this.length),
-				collectingStarted = collect(),
-				prop;
-
-			for ( var prop = 0; prop < len; prop++ ) {
-				var curVal = this[prop],
-					newVal = props[prop];
-
-				if ( canMakeObserve(curVal) && canMakeObserve(newVal) ) {
-					curVal.attr(newVal, remove)
-				} else if ( curVal != newVal ) {
-					this._set(prop, newVal)
-				} else {
-
-				}
-			}
-			if ( props.length > this.length ) {
-				// Add in the remaining props.
-				this.push.apply( this, props.slice( this.length ) );
-			} else if ( props.length < this.length && remove ) {
-				this.splice(props.length)
-			}
-
+      var collectingStarted = collect();
+			this._updateAttrs(items, remove);
 			if ( collectingStarted ) {
 				sendCollection()
 			}
-		}
+		},
+
+    _updateAttrs : function( items, remove ){
+      var len = Math.min(items.length, this.length);
+
+      for ( var prop = 0; prop < len; prop++ ) {
+        var curVal = this[prop],
+          newVal = items[prop];
+
+        if ( canMakeObserve(curVal) && canMakeObserve(newVal) ) {
+          curVal.attr(newVal, remove)
+        } else if ( curVal != newVal ) {
+          this._set(prop, newVal)
+        } else {
+
+        }
+      }
+      if ( items.length > this.length ) {
+        // Add in the remaining props.
+        this.push.apply( this, items.slice( this.length ) );
+      } else if ( items.length < this.length && remove ) {
+        this.splice(items.length)
+      }
+    }
 	}),
 
 


### PR DESCRIPTION
When you pass an array value to the attr() method of can.Observe.List, it iterates by position over both lists and updates each item in the list with the data from the item in the same position in the passed in array.

For a can.Model.List it seems like rather than going by position, attr() should look in the list and find the object based on its "id" field and then update it if it exists. The tests in model/list/list_test.js illustrate the issue and fail without the provided code changes.

The real world scenario for this is that we have a list of model objects (in our case Tasks) and the response from the server doesn't always match the order of our data. This is because new tasks could have been added or removed to the list or a user has re-ordered the list.
