### PR TITLE
canMakeObserve: should fail on DOM elements

### DIFF
--- a/observe/observe.js
+++ b/observe/observe.js
@@ -6,12 +6,7 @@ steal('can/util','can/construct', function(can, Construct) {
 	//  
 	// Returns `true` if something is an object with properties of its own.
 	var canMakeObserve = function( obj ) {
-			return ( obj
-				&& !obj.nodeType
-				&& !can.isWindow( obj )
-				&& !(obj instanceof can.$ )
-				&& !(obj instanceof Date)
-				&& ( "object" === typeof obj ));
+			return obj && ( can.isPlainObject( obj ) || ( obj instanceof can.Observe ));
 		},
 
 		// Removes all listeners.


### PR DESCRIPTION
The `canMakeObserve` function should fail on DOM elements, the `window` object and `can.$` element collections.

Allowing `can.Observe` to recurse into these data types causes an inevitable reference loop when encountering the `window` property, which results in infinite recursion and a stack overflow.

Moreover, binding to all possible properties on a DOM object is a bad idea in general (performance, stability, etc.) and probably not what your library user was after in the first place.
