### PR TITLE
fix computes that use other computes

### DIFF
--- a/observe/compute/compute.js
+++ b/observe/compute/compute.js
@@ -285,6 +285,10 @@ steal('can/util', function(can) {
 			// we just gave it a value
 			computed = function(val){
 				if(val === undefined){
+					// If observing, record that the value is being read.
+					if(can.Observe.__reading) {
+						can.Observe.__reading(computed,'change');
+					}
 					return getterSetter;
 				} else {
 					var old = getterSetter;

--- a/observe/compute/compute_test.js
+++ b/observe/compute/compute_test.js
@@ -116,3 +116,21 @@ test("compute a compute", function() {
 	equals(project.attr('progress'),0.15,'progress updated');
 	equals(percent(),15,'% updated');
 });
+
+test("compute with a simple compute", function() {
+	expect(4);
+	var a = can.compute(5);
+	var b = can.compute(function() {
+		return a() * 2;
+	});
+
+	equal(b(),10,'b starts correct');
+	a(3);
+	equal(b(),6,'b updates');
+
+	b.bind('change',function() {
+		equal(b(),24,'b fires change');
+	});
+	a(12);
+	equal(b(),24,'b updates when bound');
+});


### PR DESCRIPTION
Computes are awesome. This lets you use other (bound and cached) computes in your compute.
