### PR TITLE
.attr() on an empty can.Model.List should only trigger one change event when an array is passed in

### DIFF
--- a/model/list/list.js
+++ b/model/list/list.js
@@ -518,7 +518,8 @@ steal('can/util', 'can/model/elements', function(can) {
     _updateAttrs :function(items, remove){
       var len = items.length,
           newVal,
-          curVal;
+          curVal,
+          itemsNotInList = [];
 
       for ( var i = 0; i < len; i++ ) {
         newVal = items[i];
@@ -529,9 +530,14 @@ steal('can/util', 'can/model/elements', function(can) {
           if (curVal){
             curVal.attr(newVal, remove)
           } else {
-            this.push(newVal)
+            itemsNotInList.push(newVal);
           }
         }
+      }
+
+      if (itemsNotInList.length > 0){
+        //splice everything onto end of list so as not to trigger change events for each push
+        this.splice.apply(this, [this.length, 0].concat(itemsNotInList));
       }
 
       if(remove){

--- a/model/list/list_test.js
+++ b/model/list/list_test.js
@@ -240,6 +240,29 @@ test("attr update a list when less things come back and remove is true", functio
   equal(people.attr('1.age'), 101, "Andy's age incremented by 100 years");
 });
 
+test("attr update an empty list only fires one change event", function(){
+  var people = Person.models([]);
+  var changeCount = 0;
+  people.bind('change', function(){
+    changeCount++
+  });
+
+  people.attr([
+    {
+      id : 3,
+      name : 'Andy',
+      age : 101
+    },
+    {
+      id : 1,
+      name : 'Michael',
+      age : 120
+    }]
+  );
+
+
+  equal(changeCount, 1, "Only one change event is fired even though two items added");
+});
 
 test("attr updates items based on id (when present), not position", function(){
     var people = Person.models([


### PR DESCRIPTION
Because _updateAttrs was using push, if you .attr()'ed a list with an array with 5 objects, 5 change events would get triggered. This meant our ejs template would re-render 5 times.

We modified the code to use splice instead. There's a test that captures the behavior.

Thanks!
-Amy & Michael
