### PR TITLE
Sort plugin fix: length attribute triggering

### DIFF
--- a/observe/sort/sort.js
+++ b/observe/sort/sort.js
@@ -132,6 +132,7 @@ function( where , name ) {
 		if ( this.comparator && args.length ) {
 			this.sort(null, true);
 			batchTrigger(this,"reset", [args])
+			batchTrigger(this,'length',[this.length]);
 		}
 
 		return res;


### PR DESCRIPTION
When using the can/observe/sort plugin, upon adding / removing items from the List, no event is triggered for the length attribute. If it is live-bound, then there is no event triggered to update.
