### PR TITLE
Test & Fix: Value number 0 is not correctly escaped to empty string

### DIFF
--- a/util/string/string.js
+++ b/util/string/string.js
@@ -39,7 +39,7 @@ steal('can/util',function(can) {
 			 *     can.esc( "<foo>&<bar>" ) //-> "&lt;foo&lt;&amp;&lt;bar&lt;"
 			 */
 			esc : function( content ) {
-				return ( "" + (content || '') )
+				return ( "" + (content===null||content===undefined?'':content) )
 					.replace(/&/g, '&amp;')
 					.replace(/</g, '&lt;')
 					.replace(/>/g, '&gt;')

--- a/util/string/string_test.js
+++ b/util/string/string_test.js
@@ -33,6 +33,11 @@ test("can.getObject", function(){
 	equals(obj,0, 'got 0 (falsey stuff)')
 });
 
+test("rendering number 0 value",function(){
+	var text = can.esc(0);
+
+	equal(text,"0","0 value properly rendered");
+});
 /*
 test("$.String.niceName", function(){
 	var str = "some_underscored_string";


### PR DESCRIPTION
this was causing  following ejs to incorrectly render

```
<div id="<%= index %>" />'
 to
<div id="" />
```

when index was 0
