### PR TITLE
missing dependency to can/model

### DIFF
--- a/observe/attributes/attributes.js
+++ b/observe/attributes/attributes.js
@@ -1,4 +1,4 @@
-steal('can/util', 'can/observe', function(can, Observe) {
+steal('can/util', 'can/observe', 'can/model', function(can, Observe) {
 
 can.each([ can.Observe, can.Model ], function(clss){
 	// in some cases model might not be defined quite yet.


### PR DESCRIPTION
in my case this missing dependency is causing that model instances, unless "'can/model'" explicitly stealed before validations.js, do not have validations

i see you have this comment in attibutes.js

``` javascript
// in some cases model might not be defined quite yet.
    if(clss === undefined){
        return;
    }
```

but was there a reason for not including dependency to can/model instead of that comment?
