### PR TITLE
don't modify passed in array

### DIFF
--- a/model/list/list.js
+++ b/model/list/list.js
@@ -376,7 +376,7 @@ steal('can/util', 'can/observe/elements', function(can) {
 				underscored = constructor._fullName,
 				test = new RegExp(underscored + "_([^ ]+)"),
 				matches, val;
-			args = getArgs(arguments)
+			args = getArgs(arguments).slice(0)
 
 			//for performance, we will go through each and splice it
 			var i = 0;


### PR DESCRIPTION
This is an edge case, but really hard to debug when it happens. If you pass an array to Model.List.remove, the array is modified by remove (there is an args.splice a few lines down).  In our case, the array happened to be the removed list from another remove event, so the list ended up empty for subsequent listeners.
e.g.,

``` javascript
var listA = ...;
var listB = ...;

// whenever we remove from listA, we remove from listB
listA.bind("remove",function(ev,removed) {
   listB.remove(removed);
});
listA.bind("remove",function(ev,removed) {
   // removed is empty!
});
```
