### PR TITLE
fix IE8 - doesn't support array map or indexOf

### DIFF
--- a/model/list/list.js
+++ b/model/list/list.js
@@ -550,12 +550,12 @@ steal('can/util', 'can/observe/elements', function(can) {
         var existingIds = this.map(function(element) {
               return getId(element);
             }),
-            itemIds = items.map(function(element){
+            itemIds = can.map(items, function(element){
               return getId(element);
             });
 
         can.each(existingIds, $.proxy(function(id){
-          if(itemIds.indexOf(id) == -1){
+          if(!~can.inArray(id,itemIds)){
             this.remove(id);
           }
         }, this));


### PR DESCRIPTION
I hope this is self explanatory. 
