### PR TITLE
Removed some global, undefined, and unused variables

### DIFF
--- a/control/plugin/plugin.js
+++ b/control/plugin/plugin.js
@@ -10,9 +10,6 @@ var i,
 		}
 		return false;
 	},
-	data = function(el, data){
-		return $el.data('controls');
-	},
 	makeArray = can.makeArray,
 	old = can.Control.setup;
 

--- a/model/list/local/local.js
+++ b/model/list/local/local.js
@@ -26,7 +26,7 @@ $.Model.List("jQuery.Model.List.Local",
 		//  go through and listen to instance updating
 		var ids = [], days = this.days;
 		this.each(function(i, inst){
-			window.localStorage[inst.identity()] = instance.attrs();
+			window.localStorage[inst.identity()] = inst.attrs();
 			ids.push(inst.identity());
 		});
 		window.localStorage[name] = {

--- a/observe/delegate/delegate.js
+++ b/observe/delegate/delegate.js
@@ -73,7 +73,6 @@ steal('can/util', 'can/observe', function(can) {
 				// reset match and values tests
 				hasMatch = undefined;
 				valuesEqual = true;
-				delegateMatches = false;
 
 				// yeah, all this under here has to be redone v
 				

--- a/util/dojo/dojo.js
+++ b/util/dojo/dojo.js
@@ -183,7 +183,7 @@ steal('can/util/dojo/dojo-1.8.1.js', 'can/util/event.js', 'can/util/fragment.js'
 
 	// Map array helpers.
 	can.makeArray = function( arr ) {
-		array = [];
+		var array = [];
 		dojo.forEach(arr, function( item ) {
 			array.push(item)
 		});

--- a/util/fixture/fixture.js
+++ b/util/fixture/fixture.js
@@ -31,7 +31,7 @@ steal('can/util','can/util/string','can/util/object', function (can) {
 					_logger( "log", Array.prototype.slice.call(arguments) );
 				}
 				else if (window.opera && window.opera.postError) {
-					opera.postError("fixture INFO: " + out);
+					opera.postError("fixture INFO: " + Array.prototype.join.call(arguments, ','));
 				}
 			}
 

--- a/util/fragment.js
+++ b/util/fragment.js
@@ -51,7 +51,7 @@ steal('./can.js',function(can){
 	
 	can.buildFragment = function(html, nodes){
 		var parts = fragment(html),
-			hasSpecial = html.toString().match(/@@!!@@/g);
+			hasSpecial = html.toString().match(/@@!!@@/g),
 			frag = document.createDocumentFragment();
 		hasSpecial = hasSpecial === null ? 0 : hasSpecial.length;
 		can.each(parts, function(part){


### PR DESCRIPTION
After some jsLinting, I found and removed some globals, undefined and unused variables.

Is there a reason you often do hoisting a la:

``` javascript
var func = function () {
    var1.slice();
}, var1 = [];
```

instead of

``` javascript
var var1 = [],
    func = function () {
        var1.slice();
    };
```

?

That seems to be hard to lint.
