### PR TITLE
nested attr() call on a model with List attributes blows away existing List

### DIFF
--- a/observe/attributes/attributes_test.js
+++ b/observe/attributes/attributes_test.js
@@ -259,5 +259,26 @@ test("attr() should respect convert functions for lists when updating", function
     equal(task.project.members[1] instanceof ListTest.User, true, "The user was converted to a model object");
 });
 
+test("attr does not blow away old observable when going from empty to having items", function(){
+    can.Model('EmptyListTest.User', {}, {});
+    can.Model.List('EmptyListTest.User.List', {}, {});
+
+    can.Model('EmptyListTest.Project',{
+      attributes : {
+        members : "EmptyListTest.User.models"
+      }
+    }, {});
+
+    var project = ListTest.Project.model({
+      id : 789,
+      members : []
+    });
+
+    var oldCid = project.attr("members")._cid;
+    project.attr({members:['bob']});
+    same(project.attr("members")._cid, oldCid, "should be the same observe, so that views bound to the old one get updates")
+    equals(project.attr("members").length, 1, "list should have bob in it");
+});
+
 
 })();


### PR DESCRIPTION
https://github.com/bitovi/canjs/pull/151 fixed this issue with simple objects, but the test here shows it's still a problem when the attributes plugin is involved.

The failure is the same as before in that a new list (with a new _cid) is made.

I'm not quite sure how to address this one, so I'm just submitting the failing test.

Thanks!
