### PR TITLE
amd build: added control/route, control/plugin, can/observe/list

### DIFF
--- a/build/make/amd.js
+++ b/build/make/amd.js
@@ -1,9 +1,10 @@
 steal('can/can.js', 'can/construct/proxy', 'can/construct/super', 'can/control', 'can/control/plugin',
-	'can/control/view', 'can/view/modifiers', 'can/model', 'can/view/ejs', 'can/view/mustache',
-	'can/observe/attributes', 'can/observe/delegate', 'can/observe/setter',
-	'can/observe/validations', 'can/route', 'can/view/modifiers', 'can/observe/backup',
-	'can/util/fixture', 'can/util/library.js', 'can/util/mootools', 'can/util/dojo', 'can/util/yui',
-	'can/util/zepto', 'can/util/jquery',
+    'can/control/route', 'can/control/view', 'can/view/modifiers', 'can/model',
+    'can/view/ejs', 'can/view/mustache', 'can/observe/attributes', 'can/observe/delegate', 'can/observe/list',
+    'can/observe/setter', 'can/observe/validations', 'can/route', 'can/view/modifiers', 'can/observe/backup',
+    'can/util/fixture', 'can/util/library.js', 'can/util/mootools', 'can/util/dojo', 'can/util/yui',
+    'can/util/zepto', 'can/util/jquery',
+    
 function(can) {
-	return can;
+    return can;
 });


### PR DESCRIPTION
I started a new pull request after (initial one was https://github.com/bitovi/canjs/pull/189): I started for scratch, it seems that 3 files were missing: control/route, control/plugin, can/observe/list.

I made sure that only official plugins were included.
