### PR TITLE
Passing correct remove parameter down in merge.

### DIFF
--- a/observe/observe.js
+++ b/observe/observe.js
@@ -822,7 +822,7 @@ steal('can/util','can/construct', function(can) {
 				self = this,
 				newVal;
 			Observe.startBatch();
-			this.each(function(curVal, prop, toRemove){
+			this.each(function(curVal, prop){
 				newVal = props[prop];
 
 				// If we are merging...
@@ -843,7 +843,7 @@ steal('can/util','can/construct', function(can) {
 						self._set(prop, newVal)
 					}
 					else if ( canMakeObserve(curVal) && canMakeObserve(newVal) ) {
-						curVal.attr(newVal, toRemove)
+						curVal.attr(newVal, remove)
 					} else if ( curVal != newVal ) {
 						self._set(prop, newVal)
 					}

--- a/observe/observe_test.js
+++ b/observe/observe_test.js
@@ -140,9 +140,34 @@ test("attr does not blow away old observable", function(){
 		}
 	});
 	var oldCid = state.attr("properties.brand")._cid;
-	state.attr({properties:{brand:[]}});
+	state.attr({properties:{brand:[]}}, true);
 	same(state.attr("properties.brand")._cid, oldCid, "should be the same observe, so that views bound to the old one get updates")
 	equals(state.attr("properties.brand").length, 0, "list should be empty");
+});
+
+test("sub observes respect attr remove parameter", function() {
+    var bindCalled = 0,
+        state = new can.Observe({
+        monkey : {
+            tail: 'brain'
+        }
+    });
+
+    state.bind("change", function(ev, attr, how, newVal, old){
+        bindCalled++;
+        equals(attr, "monkey.tail");
+        equals(old, "brain");
+        equals(how, "remove");
+    });
+
+    state.attr({monkey: {}});
+    equals("brain", state.attr("monkey.tail"), "should not remove attribute of sub observe when remove param is false");
+    equals(0, bindCalled, "remove event not fired for sub observe when remove param is false");
+
+    state.attr({monkey: {}}, true);
+
+    equals(undefined, state.attr("monkey.tail"), "should remove attribute of sub observe when remove param is false");
+    equals(1, bindCalled, "remove event fired for sub observe when remove param is false");
 });
 
 test("remove attr", function(){


### PR DESCRIPTION
The remove parameter was being ignored for the sub-observes. The toRemove parameter passed by each is all the elements of the current observe, so I'm not sure why it was being passed down instead.
