### PR TITLE
Resetting a live-bound <textarea> changes its value to __!!__

### DIFF
--- a/view/render.js
+++ b/view/render.js
@@ -48,7 +48,7 @@ var attrMap = {
 			if (prop) {
 				// set the value as true / false
 				el[prop] = can.inArray(attrName, bool) > -1 ? true : val;
-				if(prop === "value" && tagName === "input") {
+				if(prop === "value" && (tagName === "input" || tagName === "textarea")) {
 					el.defaultValue = val;
 				}
 			} else {

--- a/view/view_test.js
+++ b/view/view_test.js
@@ -273,11 +273,31 @@
 		div = document.createElement('div');
 
 		div.appendChild(frag);
-can.append( can.$("#qunit-test-area"), div)
+		can.append( can.$("#qunit-test-area"), div)
 		equal(div.outerHTML.match(/__!!__/g), null, 'No __!!__ contained in HTML content')
 
 		//equal(can.$('#test-dropdown')[0].outerHTML, can.$('#test-dropdown2')[0].outerHTML, 'Live bound select and non-live bound select the same');
 
 		
-	})
+	});
+
+	test("Resetting a live-bound <textarea> changes its value to __!!__ (#223)", function() {
+		var template = can.view.ejs("<form><textarea><%= this.attr('test') %></textarea></form>"),
+			frag = template(new can.Observe({
+				test : 'testing'
+			})),
+			form, textarea;
+
+		can.append(can.$("#qunit-test-area"), frag);
+
+		form = document.getElementById('qunit-test-area').getElementsByTagName('form')[0];
+		textarea = form.children[0];
+
+		equal(textarea.value, 'testing', 'Textarea value set');
+		textarea.value = 'blabla';
+		equal(textarea.value, 'blabla', 'Textarea value updated');
+
+		form.reset();
+		equal(form.children[0].value, 'testing', 'Textarea value set back to original live-bound value');
+	});
 })();


### PR DESCRIPTION
Demo:
http://jsfiddle.net/5vD9u/2/

Threads:
https://forum.javascriptmvc.com/topic/1-1-1-resetting-a-form-changes-input-values-to#32525000001098027
https://forum.javascriptmvc.com/topic/1-1-3-resetting-a-live-bound-textarea-changes-its-value-to

In the first thread above, Curtis Cummings wrote:
"When the <textarea> is created it is given a placeholder value of **!!** and then is quickly updated with the proper value. Because **!!** was technically the original value, reseting that textarea displays **!!**."
