### PR TITLE
Calling destroy on non persisted model

### DIFF
--- a/model/model.js
+++ b/model/model.js
@@ -958,7 +958,7 @@ steal('can/util','can/observe', function( can ) {
 				var self = this;
 				return can.Deferred().done(function(data) {
 					self.destroyed(data)
-				}).resolve({});
+				}).resolve(self);
 			}
 			return makeRequest(this, 'destroy', success, error, 'destroyed');
 		},

--- a/model/model_test.js
+++ b/model/model_test.js
@@ -967,12 +967,19 @@ test(".models updates existing list if passed", 4, function() {
 test("calling destroy with unsaved model triggers destroyed event (#181)", function() {
 	var MyModel = can.Model({}, {}),
 		newModel = new MyModel(),
-		list = new MyModel.List();
+		list = new MyModel.List(),
+		deferred;
 
 	list.push(newModel);
 	equal(list.attr('length'), 1, "List length as expected");
-	ok(can.isDeferred(newModel.destroy()), ".destroy returned a Deferred");
+
+	deferred = newModel.destroy();
+
+	ok(deferred, ".destroy returned a Deferred");
 	equal(list.attr('length'), 0, "Unsaved model removed from list");
+	deferred.done(function(data) {
+		ok(data == newModel, "Resolved with destroyed model as described in docs");
+	});
 });
 
 })();


### PR DESCRIPTION
At the moment if I try to call destroy() on a model that is not persisted CanJS will try to send an AJAX request. This works well when a model is persisted. 

In order to remove a non-persisted model from a list I need to:

```
if (model.isNew()) {
        //find the object in the list
        //splice the list
  } else {
        model.destroy();
  }
```

 It would be nice if destroy could work transparently for non persisted models. So all that is needed would be:

```
model.destroy();
```
