### PR TITLE
Support for rendering document fragments (returned from the renderer function) in the templates

### DIFF
--- a/view/view.js
+++ b/view/view.js
@@ -56,9 +56,15 @@ steal("can/util", function( can ) {
 		// then hook it up
 		fragment: function(result){
 			var frag = can.buildFragment(result,document.body);
+			var dataId = $view.hook(function(el){
+				el.parentNode.replaceChild(frag, el);
+			})
 			// If we have an empty frag...
 			if(!frag.childNodes.length) { 
 				frag.appendChild(document.createTextNode(''));
+			}
+			frag.toString = function(){
+				return "<div" + dataId + "></div>";
 			}
 			return frag;
 		},

--- a/view/view_test.js
+++ b/view/view_test.js
@@ -300,4 +300,38 @@
 		form.reset();
 		equal(form.children[0].value, 'testing', 'Textarea value set back to original live-bound value');
 	});
+
+	test("Support passing document fragments created with can.view.fragment to templates", function(){
+		var mustache = can.view.mustache('<b>{{{ subview }}}</b>');
+		var ejs      = can.view.ejs('<b><%== subview() %></b>')
+
+		var subview   = can.view.mustache('Subview {{ foo }}');
+		var subviewFn = function(){
+			return subview({
+				foo : foo
+			})
+		}
+		var foo = can.compute("FOO")
+
+		var mustacheDiv = document.createElement('div');
+		var ejsDiv = document.createElement('div');
+
+		mustacheDiv.appendChild(mustache({
+			subview : subviewFn
+		}));
+
+		ejsDiv.appendChild(ejs({
+			subview : subviewFn
+		}));
+
+		equal(mustacheDiv.innerHTML, "<b>Subview FOO</b>", "Mustache works correctly")
+		equal(ejsDiv.innerHTML, "<b>Subview FOO</b>", "EJS works correctly")
+
+		foo("BAR")
+
+		equal(mustacheDiv.innerHTML, "<b>Subview BAR</b>", "Live binding in mustache works correctly")
+		equal(ejsDiv.innerHTML, "<b>Subview BAR</b>", "Live binding in EJS works correctly")
+
+	})
+
 })();


### PR DESCRIPTION
This change allows passing of document fragments directly to the template layer. They are live bound as they are never converted to the string. It allows syntax that looks like this:

```
var renderer = can.view.mustache('<b>{{{ subview }}}</b>');
var subview = can.view.mustache('Subview {{ foo }}');
var foo = can.compute("FOO")
var div = document.createElement('div');
div.appendChild(renderer({
    subview : function(){
        return subview({
            foo : foo
        })
    }
}));

div.innerHTML // <b>Subview FOO</b>

foo("BAR")

div.innerHTML // <b>Subview BAR</b>    
```
