### PR TITLE
.model takes an optional remove attribute, which is passed into .attr

### DIFF
--- a/model/model.js
+++ b/model/model.js
@@ -821,9 +821,11 @@ steal('can/util','can/observe', function( can ) {
 		 * 
 		 *      {id: 1, name : "dishes"}
 		 * 
+		 * @param {Object} [remove] if provided, merges properties into existing properties.
+		 * 
 		 * @return {model} a model instance.
 		 */
-		model: function( attributes ) {
+		model: function( attributes, remove ) {
 			if ( ! attributes ) {
 				return;
 			}
@@ -831,7 +833,7 @@ steal('can/util','can/observe', function( can ) {
 				attributes = attributes.serialize();
 			}
 			var id = attributes[ this.id ],
-			    model = id && this.store[id] ? this.store[id].attr(attributes) : new this( attributes );
+			    model = id && this.store[id] ? this.store[id].attr(attributes, remove) : new this( attributes );
 			if(this._reqs){
 				this.store[attributes[this.id]] = model;
 			}


### PR DESCRIPTION
This allows you to call model and tell it to merge existing params, just like you can when calling .attr if it finds an instance in the store.  This may be something we should add to .models as well, for consistency.
