### PR TITLE
Needed host check for pushstate.js

### DIFF
--- a/route/pushstate/pushstate.js
+++ b/route/pushstate/pushstate.js
@@ -35,7 +35,9 @@ steal('can/util', 'can/route', function(can) {
                 // intercept routable links
                 can.$('body').on('click', 'a', function(e) {
                     // Fix for ie showing blank host, but blank host means current host.
-                    this.host == '' ? this.host = window.location.host : null;
+                    if(!this.host) {
+                      this.host = window.location.host;
+                    }
                     // HTML5 pushstate requires host to be the same. Don't prevent default for other hosts.
                     if(can.route.updateWith(this.pathname+this.search) && window.location.host == this.host) {
                         e.preventDefault();


### PR DESCRIPTION
pushstate.js was only checking the pathname.  Since HTML5 pushstate only works on the same hostname, other links should be allowed to work as normal.  Links to other domains will now work.  Also updated the variable name at lines 46 and 47 to be the pathname instead of the href, since that's what we are really working with at that point in the code.
