### PR TITLE
IE8 error

### DIFF
--- a/observe/observe.js
+++ b/observe/observe.js
@@ -1029,7 +1029,7 @@ steal('can/util','can/construct', function(can) {
 			this.length = 0;
 			can.cid(this, ".observe")
 			this._init = 1;
-			this.push.apply(this, instances || []);
+			this.push.apply(this, can.makeArray(instances || []));
 			this.bind('change'+this._cid,can.proxy(this._changes,this));
 			can.extend(this, options);
 			delete this._init;

--- a/observe/observe_test.js
+++ b/observe/observe_test.js
@@ -591,4 +591,11 @@ test("replace with a deferred that resolves to an Observe.List", function(){
 	list.replace(def);
 });
 
+test("IE8 error on list setup with Observe.List (#226)", function() {
+	var list = new can.Observe.List(['first', 'second', 'third']),
+		otherList = new can.Observe.List(list);
+
+	deepEqual(list.attr(), otherList.attr(), 'Lists are the same');
+});
+
 })();


### PR DESCRIPTION
observe.js line 422 throws this error in IE9 (IE8 mode). I haven't had a chance to test it in the real IE8.

> SCRIPT5028: Function.prototype.apply: Array or arguments object expected 

I changed the line from this:

```
this.push.apply(this, instances || []);
```

to this:

```
this.push.apply(this, can.makeArray(instances || []));
```

and now it works fine. instances was an observable list so even though it had items (indexable items) IE doesn't recognize it as an array.
