### PR TITLE
adding greedy space to model url splitter

### DIFF
--- a/model/model.js
+++ b/model/model.js
@@ -43,7 +43,7 @@ steal('can/util','can/observe', function( can ) {
 			// If we get a string, handle it.
 			if ( typeof ajaxOb == "string" ) {
 				// If there's a space, it's probably the type.
-				var parts = ajaxOb.split(/\s/);
+				var parts = ajaxOb.split(/\s+/);
 				params.url = parts.pop();
 				if ( parts.length ) {
 					params.type = parts.pop();


### PR DESCRIPTION
I am migrating a JMVC app over to CanJS and encountered strange DOM Exception 12 errors on model CRUD events.  It took me a while to chase them down and discovered that the splitter employed in CanJS was failing to properly spit on my URLs because I used multiple spaces.  I like all my routes to line up "just so" for better readability:

``` javascript
        findAll:  "GET    /api/" + AWT.api_version + "/advertisements.json",
        findOne : "GET    /api/" + AWT.api_version + "/advertisements/{id}.json",
        create :  "POST   /api/" + AWT.api_version + "/advertisements/advertisement.json",
        update :  "PUT    /api/" + AWT.api_version + "/advertisements/{id}.json",
        destroy : "DELETE /api/" + AWT.api_version + "/advertisements/{id}.json",
```

JMVC handled these routes okay.  

This little fix just makes the splitter greedier to handle the extra spaces.
