### PR TITLE
Don't treat links to "#" as "/"

### DIFF
--- a/route/pushstate/pushstate.js
+++ b/route/pushstate/pushstate.js
@@ -34,7 +34,7 @@ steal('can/util', 'can/route', function(can) {
             _setup: function() {
                 // intercept routable links
                 can.$('body').on('click', 'a', function(e) {
-                	if($(this).attr('href') != '#') {
+                	if(!e.isDefaultPrevented()) {
 	                    // Fix for ie showing blank host, but blank host means current host.
 	                    if(!this.host) {
 	                      this.host = window.location.host;


### PR DESCRIPTION
Breaks many places where "#" is placed as a dummy href and are handled through click events. It can be prevented with stopPropagation() but then it won't propagate to its parents. This fixes my case, but i'm not sure if it's desirable for others.
