### PR TITLE
Nested live binding error after destroying parent 

### DIFF
--- a/view/render.js
+++ b/view/render.js
@@ -223,7 +223,9 @@ can.extend(can.view, {
 		var binding = can.compute.binder(func, self, function(newVal, oldVal){
 			// call the update method we will define for each
 			// type of attribute
-			update(newVal, oldVal);
+			if (update) {
+				update(newVal, oldVal);
+			}
 		});
 		
 		// If we had no observes just return the value returned by func.


### PR DESCRIPTION
```
TypeError: update is not a function
[Break On This Error]   

update(newVal, oldVal);
```

This happens when there is a nested (non related) live binding, for example

``` html
<% items.each(function(item) { %>
    <li>
        <%= item.attr('something') %>
        <%= SomeGlobalObservable.attr('foo') %>
    </li>
<% }) %>
```

Now if item is destroyed, the other live binding stays bound, and when it's updated, causes the error as the element doesn't exist anymore. Now, my fix might not be perfect, it would be better to unbind it from there, but i'm not really sure how to do that.
