### PR TITLE
Hookup proxy 'this' correctly

### DIFF
--- a/view/ejs/test/ejs_test.js
+++ b/view/ejs/test/ejs_test.js
@@ -1263,4 +1263,15 @@ test("Observe with array attributes", function() {
 	equal(div.getElementsByTagName('div')[0].innerHTML, 'Hello again', 'Check updated message');
 })
 
+test('hookups `this` correctly', function(){
+	var milk = { from: "cows" };
+	var html = "<div <%= (el)-> can.append(can.$(el), this.from) %>></div>";
+	var compiled = new can.EJS({ text: html }).render(milk);
+
+	var div = document.createElement('div');
+	div.appendChild(can.view.frag(compiled));
+
+	equal(div.getElementsByTagName('div')[0].innerHTML, 'cows', 'Check html for from');
+});
+
 })();

--- a/view/scanner.js
+++ b/view/scanner.js
@@ -1,4 +1,4 @@
-steal('can/view', function(can){
+steal('can/view', 'can/construct/proxy', function(can){
 
 /**
  * Helper(s)
@@ -130,7 +130,7 @@ Scanner.prototype = {
 				var quickFunc = /\s*\(([\$\w]+)\)\s*->([^\n]*)/,
 					parts = content.match(quickFunc);
 
-				return "function(__){var " + parts[1] + "=can.$(__);" + parts[2] + "}";
+				return "can.proxy(function(__){var " + parts[1] + "=can.$(__);" + parts[2] + "}, this);";
 			}
 		}
 	],


### PR DESCRIPTION
When doing hookups in views, its useful to have the same context as when you had in the template.

For example:

```
 <div <%== (el) -> el.my_plugin(this.mypluginoptionspassedintoview) %>
```

`this` would be the same context as when called the plugin.
