### PR TITLE
Item.List splice method does not convert inserted elements to Item type

### DIFF
--- a/observe/observe.js
+++ b/observe/observe.js
@@ -1143,14 +1143,14 @@ steal('can/util','can/construct', function(can) {
 			for ( i = 2; i < args.length; i++ ) {
 				var val = args[i];
 				if ( canMakeObserve(val) ) {
-					args[i] = hookupBubble(val, "*", this)
+					args[i] = hookupBubble(val, "*", this, this.constructor.Observe, this.constructor)
 				}
 			}
 			if ( howMany === undefined ) {
 				howMany = args[1] = this.length - index;
 			}
 			var removed = splice.apply(this, args);
-			can.Observe.startBatch()
+			can.Observe.startBatch();
 			if ( howMany > 0 ) {
 				this._triggerChange(""+index, "remove", undefined, removed);
 				unhookup(removed, this._cid);

--- a/observe/observe_test.js
+++ b/observe/observe_test.js
@@ -421,6 +421,30 @@ test("instantiating can.Observe.List of correct type", function() {
 	equal(list[1].getName(), 'Another test', 'Pushed item gets converted as well');
 });
 
+test("can.Observe.List.prototype.splice converts objects (#253)", function() {
+	var Ob = can.Observe({
+		getAge : function() {
+			return this.attr('age') + 10;
+		}
+	});
+
+	var list = new Ob.List([ {
+		name: 'Tester',
+		age: 23
+	}, {
+		name: 'Tester 2',
+		age: 44
+	}]);
+
+	equal(list[0].getAge(), 33, 'Converted age');
+
+	list.splice(1, 1, {
+		name: 'Spliced',
+		age: 92
+	});
+
+	equal(list[1].getAge(), 102, 'Converted age of spliced');
+});
 
 test("removing an already missing attribute does not cause an event", function(){
 	var ob = new can.Observe();


### PR DESCRIPTION
New elements inserted List of Observe inheritor with splice method is not converted to base class.

push and unshift do the conversion.

http://jsfiddle.net/qYdwR/646/
