### PR TITLE
insert mapped list items at the correct index

### DIFF
--- a/observe/list/list.js
+++ b/observe/list/list.js
@@ -71,7 +71,7 @@ steal('can/util', 'can/observe', 'can/observe/compute', function(can) {
 					mapped.splice(index, 1, val);
 				});
 
-				mapped.push(compute());
+				mapped.splice(index, 0, compute());
 			}
 
 			this.forEach(generator);


### PR DESCRIPTION
Line 90 says: // The indices in the mapped list are the same so lets just splice it out

Which is wrong without this fix, as items are always added to the end of the list.
