### PR TITLE
Fixing can.ajax with mootools

### DIFF
--- a/util/mootools/mootools.js
+++ b/util/mootools/mootools.js
@@ -242,7 +242,8 @@ steal('can/util/can.js', 'mootools', 'can/util/event.js','can/util/fragment.js',
 	}
 	can.ajax = function(options){
 		var d = can.Deferred(),
-			requestOptions = can.extend({}, options);
+			requestOptions = can.extend({}, options),
+			request;
 		// Map jQuery options to MooTools options.
 
 		for(var option in optionsMap){
@@ -255,25 +256,26 @@ steal('can/util/can.js', 'mootools', 'can/util/event.js','can/util/fragment.js',
 		requestOptions.method = requestOptions.method || 'get';
 		requestOptions.url = requestOptions.url.toString();
 
-		var success = options.success,
-			error = options.error;
+		var success = options.onSuccess || options.success,
+			error = options.onFailure || options.error;
 
-		requestOptions.onSuccess = function(responseText, xml){
-			var data = responseText;
-			if(options.dataType ==='json'){
-				data = eval("("+data+")")
-			}
+		requestOptions.onSuccess = function(response, xml){
+			var data = response;
 			updateDeferred(request.xhr, d);
 			d.resolve(data,"success",request.xhr);
 			success && success(data,"success",request.xhr);
 		}
-		requestOptions.onError = function(){
+		requestOptions.onFailure = function(){
 			updateDeferred(request.xhr, d);
 			d.reject(request.xhr,"error");
 			error(request.xhr,"error");
 		}
 
-		var request = new Request(requestOptions);
+		if(options.dataType ==='json'){
+			request = new Request.JSON(requestOptions);
+		} else {
+			request = new Request(requestOptions);
+		}
 		request.send();
 		updateDeferred(request.xhr, d);
 		return d;


### PR DESCRIPTION
- onError is only for JSON parsing errors, Ajax communication errors are
  in onFailure. On Error was ignored for most errors.
- do not clobber mootools native onSuccess and onFailure if passed in
- remove local JSON parsing and use Mootools for it
