### PR TITLE
HTML comments with either an element callback (EJS) or a helper (Mustache) rendered incorrectly

### DIFF
--- a/view/ejs/test/ejs_test.js
+++ b/view/ejs/test/ejs_test.js
@@ -1283,4 +1283,33 @@ test('live binding with html comment', function(){
 	equals(div.getElementsByTagName('table')[0].getElementsByTagName('td').length, 0, '0 items in list');
 })
 
+test("HTML comment with element callback", function(){
+	var text = ["<ul>",
+				"<% todos.each(function(todo) { %>",
+				"<li<%= (el) -> can.data(can.$(el),'todo',todo) %>>",
+				"<!-- html comment #1 -->",
+				"<%= todo.name %>",
+				"<!-- html comment #2 -->",
+				"</li>",
+				"<% }) %>",
+				"</ul>"],
+		Todos = new can.Observe.List([
+			{id: 1, name: "Dishes"}
+		]),
+		compiled = new can.EJS({text: text.join("\n")}).render({todos: Todos}),
+		div = document.createElement("div")
+
+	div.appendChild(can.view.frag(compiled));
+	equals(div.getElementsByTagName("ul")[0].getElementsByTagName("li").length, 1, "1 item in list");
+	equals(div.getElementsByTagName("ul")[0].getElementsByTagName("li")[0].childNodes.length, 5, "5 nodes in item #1");
+
+	Todos.push({id: 2, name: "Laundry"});
+	equals(div.getElementsByTagName("ul")[0].getElementsByTagName("li").length, 2, "2 items in list");
+	equals(div.getElementsByTagName("ul")[0].getElementsByTagName("li")[0].childNodes.length, 5, "5 nodes in item #1");
+	equals(div.getElementsByTagName("ul")[0].getElementsByTagName("li")[1].childNodes.length, 5, "5 nodes in item #2");
+
+	Todos.splice(0, 2);
+	equals(div.getElementsByTagName("ul")[0].getElementsByTagName("li").length, 0, "0 items in list");
+})
+
 })();

--- a/view/mustache/test/mustache_test.js
+++ b/view/mustache/test/mustache_test.js
@@ -1636,4 +1636,33 @@ test("avoid global helpers",function() {
 	equal(div2.innerHTML,"Ajax rules");
 });
 
+test("HTML comment with helper", function(){
+	var text = ["<ul>",
+				"{{#todos}}",
+				"<li {{data 'todo'}}>",
+				"<!-- html comment #1 -->",
+				"{{name}}",
+				"<!-- html comment #2 -->",
+				"</li>",
+				"{{/todos}}",
+				"</ul>"],
+		Todos = new can.Observe.List([
+			{id: 1, name: "Dishes"}
+		]),
+		compiled = new can.Mustache({text: text.join("\n")}).render({todos: Todos}),
+		div = document.createElement("div")
+
+	div.appendChild(can.view.frag(compiled));
+	equals(div.getElementsByTagName("ul")[0].getElementsByTagName("li").length, 1, "1 item in list");
+	equals(div.getElementsByTagName("ul")[0].getElementsByTagName("li")[0].childNodes.length, 7, "7 nodes in item #1");
+
+	Todos.push({id: 2, name: "Laundry"});
+	equals(div.getElementsByTagName("ul")[0].getElementsByTagName("li").length, 2, "2 items in list");
+	equals(div.getElementsByTagName("ul")[0].getElementsByTagName("li")[0].childNodes.length, 7, "7 nodes in item #1");
+	equals(div.getElementsByTagName("ul")[0].getElementsByTagName("li")[1].childNodes.length, 7, "7 nodes in item #2");
+
+	Todos.splice(0, 2);
+	equals(div.getElementsByTagName("ul")[0].getElementsByTagName("li").length, 0, "0 items in list");
+})
+
 });

--- a/view/scanner.js
+++ b/view/scanner.js
@@ -272,6 +272,7 @@ Scanner.prototype = {
 							put(content, ",can.view.pending(),\">\"");
 						}
 						content = '';
+						magicInTag = 0;
 					} else {
 						content += token;
 					}


### PR DESCRIPTION
In a Mustache template, for example, if you have:

```
<li {{data "item"}}>
    <!-- this is comment #1 -->
    {{title}}
    <!-- this is comment #2 -->
</li>
```

this gets incorrectly rendered:

``` html
<li  data-view-id='9'>
    <!-- this is comment #1 - data-view-id='10'/>
    One
    <!-- this is comment #2 -->
</li>
```

This bug is demonstrated, for both EJS and Mustache, in this fiddle: http://jsfiddle.net/scorphus/vmLvA/

The fix stops the effect of an element callback (in EJS templates) or a helper (in Mustache templates) and is demonstrated in this fiddle: http://jsfiddle.net/scorphus/vmLvA/1/
