### PR TITLE
data-view-id being rendered in tag closing

### DIFF
--- a/view/ejs/test/ejs_test.js
+++ b/view/ejs/test/ejs_test.js
@@ -1341,4 +1341,16 @@ test("Interpolated values when iterating through an Observe.List should still re
 	equal(div.innerHTML, "DishesGlassesKnives", 'New list item rendered without DOM container');
 });
 
+test("correctness of data-view-id and only in tag opening", function(){
+	var text = ["<textarea><select><% can.each(this.items, function(item) { %>",
+				"<option<%= (el) -> el.data('item', item) %>><%= item.title %></option>",
+				"<% }) %></select></textarea>"],
+		items = [{id: 1, title: "One"}, {id: 2, title: "Two"}],
+		compiled = new can.EJS({text: text.join("")}).render({items: items}),
+		expected = "^<textarea data-view-id='[0-9]+'><select><option data-view-id='[0-9]+'>One</option>" +
+			"<option data-view-id='[0-9]+'>Two</option></select></textarea>$";
+
+	ok(compiled.search(expected) === 0, "Rendered output is as expected");
+});
+
 })();

--- a/view/mustache/test/mustache_test.js
+++ b/view/mustache/test/mustache_test.js
@@ -1691,6 +1691,18 @@ test("HTML comment with helper", function(){
 
 	Todos.splice(0, 2);
 	equals(div.getElementsByTagName("ul")[0].getElementsByTagName("li").length, 0, "0 items in list");
-})
+});
+
+test("correctness of data-view-id and only in tag opening", function(){
+	var text = ["<textarea><select>{{#items}}",
+				"<option{{data 'item'}}>{{title}}</option>",
+				"{{/items}}</select></textarea>"],
+		items = [{id: 1, title: "One"}, {id: 2, title: "Two"}],
+		compiled = new can.Mustache({text: text.join("")}).render({items: items}),
+		expected = "^<textarea data-view-id='[0-9]+'><select><option data-view-id='[0-9]+'>One</option>" +
+			"<option data-view-id='[0-9]+'>Two</option></select></textarea>$";
+
+	ok(compiled.search(expected) === 0, "Rendered output is as expected");
+});
 
 });

--- a/view/scanner.js
+++ b/view/scanner.js
@@ -201,6 +201,8 @@ Scanner.prototype = {
 			tagName = '',
 			// stack of tagNames
 			tagNames = [],
+			// Pop from tagNames?
+			popTagName = false,
 			// Declared here.
 			bracketCount,
 			i = 0,
@@ -265,7 +267,7 @@ Scanner.prototype = {
 					// but content is not other tags add a hookup
 					// TODO: we should only add `can.EJS.pending()` if there's a magic tag 
 					// within the html tags.
-					if(magicInTag || tagToContentPropMap[ tagNames[tagNames.length -1] ]){
+					if(magicInTag || !popTagName && tagToContentPropMap[ tagNames[tagNames.length -1] ]){
 						// make sure / of /> is on the left of pending
 						if(emptyElement){
 							put(content.substr(0,content.length-1), ",can.view.pending(),\"/>\"");
@@ -278,11 +280,13 @@ Scanner.prototype = {
 						content += token;
 					}
 					// if it's a tag like <input/>
-					if(emptyElement){
+					if(emptyElement || popTagName){
 						// remove the current tag in the stack
 						tagNames.pop();
 						// set the current tag to the previous parent
 						tagName = tagNames[tagNames.length-1];
+						// Don't pop next time
+						popTagName = false;
 					}
 					break;
 				case "'":
@@ -304,10 +308,11 @@ Scanner.prototype = {
 					// Track the current tag
 					if(lastToken === '<'){
 						tagName = token.split(/\s/)[0];
-						if( tagName.indexOf("/") === 0 && tagNames.pop() === tagName.substr(1) ) {
+						if( tagName.indexOf("/") === 0 && tagNames[tagNames.length-1] === tagName.substr(1) ) {
 							// set tagName to the last tagName
 							// if there are no more tagNames, we'll rely on getTag.
 							tagName = tagNames[tagNames.length-1];
+							popTagName = true;
 						} else {
 							tagNames.push(tagName);
 						}


### PR DESCRIPTION
The scanner wrongly adds `data-view-id='X'` to a tag close `</TAGNAME>`.

In EJS, for example, if you have:

``` ejs
<textarea>
  <select>
    <% can.each(this.items, function(item) { %>
      <option <%= (el) -> el.data('item', item) %>>
        <%= item.title %>
      </option>
    <% }) %>
  </select>
<textarea>
```

it gets wrongly rendered:

``` html
<textarea>
  <select>

      <option  data-view-id='3'>
        One
      </option>

      <option  data-view-id='4'>
        Two
      </option>

  </select data-view-id='5'>
</textarea>
```

It goes the same with Mustache. The bug can be seen in [this fiddle](http://jsfiddle.net/scorphus/QvhHA/2/). And the fix is available in [this fiddle](http://jsfiddle.net/scorphus/QvhHA/3/).
