### PR TITLE
fixing no arg helpers

### DIFF
--- a/view/mustache/mustache.js
+++ b/view/mustache/mustache.js
@@ -775,7 +775,7 @@ function( can ){
 				}
 				return '';
 			}
-		}	
+		} 
 		// Handle object resolution (like `a.b.c`).
 		else if (!isHelper) {
 			// Reverse iterate through the contexts (last in, first out).
@@ -790,11 +790,17 @@ function( can ){
 
 				// Make sure the context isn't a failed object before diving into it.
 				if (value !== undefined) {
+					var isHelper = Mustache.getHelper(ref,options);
 					for (j = 0; j < namesLength; j++) {
 						// Keep running up the tree while there are matches.
 						if (typeof value[names[j]] != 'undefined') {
 							lastValue = value;
 							value = value[name = names[j]];
+						}
+						// if there's a name conflict between property and helper
+						// property wins
+						else if(isHelper) {
+							return ref;
 						}
 						// If it's undefined, still match if the parent is an Observe.
 						else if ( isObserve(value) ) {

--- a/view/mustache/test/mustache_test.js
+++ b/view/mustache/test/mustache_test.js
@@ -369,7 +369,6 @@ test("Absolute partials", function() {
 });
 
 test("No arguments passed to helper", function() {
-
 	can.view.mustache("noargs","{{noargHelper}}");
 	can.Mustache.registerHelper("noargHelper", function(){
 		return "foo"
@@ -382,6 +381,24 @@ test("No arguments passed to helper", function() {
 
 	same(div1.innerHTML, "foo");
 	same(div2.innerHTML, "foo");
+});
+
+test("No arguments passed to helper with list", function() {
+	can.view.mustache("noargs","{{#items}}{{noargHelper}}{{/items}}");
+	var div = document.createElement('div');
+
+	div.appendChild( can.view("noargs", {
+		items: new can.Observe.List([{
+			name: "Brian"
+		}]) 
+	},
+	{
+		noargHelper: function(){
+			return "foo"
+		}
+	}) );
+
+	same(div.innerHTML, "foo");
 });
 
 test("Partials and observes", function() {


### PR DESCRIPTION
Getting helpers like {{noArgs}} without arguments working in mustache.  This was breaking in the case where no arg helpers were called within a data loop
