### PR TITLE
Allow to pass an array index to removeAttr in Observe and Observe.List

### DIFF
--- a/observe/observe.js
+++ b/observe/observe.js
@@ -555,18 +555,22 @@ steal('can/util','can/construct', function(can) {
 		 * @return {Object} the value that was removed.
 		 */
 		removeAttr: function( attr ) {
-			// Convert the `attr` into parts (if nested).
-			var parts = attrParts(attr),
+				// Info if this is List or not
+			var isList = this instanceof can.Observe.List,
+				// Convert the `attr` into parts (if nested).
+				parts = attrParts(attr),
 				// The actual property to remove.
 				prop = parts.shift(),
 				// The current value.
-				current = this._data[prop];
+				current = isList ? this[prop] : this._data[prop];
 
 			// If we have more parts, call `removeAttr` on that part.
 			if ( parts.length ) {
 				return current.removeAttr(parts)
 			} else {
-				if( prop in this._data ){
+				if(isList) {
+					this.splice(prop, 1)
+				} else if( prop in this._data ){
 					// Otherwise, `delete`.
 					delete this._data[prop];
 					// Create the event.

--- a/observe/observe_test.js
+++ b/observe/observe_test.js
@@ -193,6 +193,68 @@ test("remove attr", function(){
 	equals(undefined,  state.attr("properties") );
 });
 
+test("remove nested attr", function(){
+	var state = new can.Observe({
+		properties : {
+			nested: true
+		}
+	});
+	
+	state.bind("change", function(ev, attr, how, newVal, old){
+		equals(attr, "properties.nested");
+		equals(how, "remove")
+		same(old , true);
+	})
+	
+	state.removeAttr("properties.nested");
+	equals(undefined,  state.attr("properties.nested") );
+});
+
+test("remove item in nested array", function(){
+	var state = new can.Observe({
+		array : ["a", "b"]
+	});
+	
+	state.bind("change", function(ev, attr, how, newVal, old){
+		equals(attr, "array.1");
+		equals(how, "remove")
+		same(old, ["b"]);
+	})
+	
+	state.removeAttr("array.1");
+	equals(undefined,  state.attr("array.1") );
+});
+
+test("remove nested property in item of array", function(){
+	var state = new can.Observe({
+		array : [{
+			nested: true
+		}]
+	});
+	
+	state.bind("change", function(ev, attr, how, newVal, old){
+		equals(attr, "array.0.nested");
+		equals(how, "remove")
+		same(old, true);
+	})
+	
+	state.removeAttr("array.0.nested");
+	equals(undefined,  state.attr("array.0.nested") );
+});
+
+test("remove nested property in item of array observe", function(){
+	var state = new can.Observe.List([{nested: true}]);
+	
+	state.bind("change", function(ev, attr, how, newVal, old){
+		equals(attr, "0.nested");
+		equals(how, "remove")
+		same(old, true);
+	})
+	
+	state.removeAttr("0.nested");
+	equals(undefined,  state.attr("0.nested") );
+});
+
 test("attr with an object", function(){
 	var state = new can.Observe({
 		properties : {


### PR DESCRIPTION
With this you can pass arrays into removeAttr method

``` javascript
o = new can.Observe({array:[{nested: "yes we can!"}]})
o.bind('change', fuction(ev, prop, type, newVal, oldVal) {console.log(arguments)})
o.removeAttr('array.0.nested') // -> "yes we can!"
// Event trigger arguments [{event object}, "array.0.nested", "remove", undefined, "yes we can!"]
o.attr('array.0.nested') // -> undefined
```

Fiddle with current state where this will throw an error http://jsfiddle.net/2a8TW/
