### PR TITLE
Null objects within observes weren't working properly with Mustache sections #307

### DIFF
--- a/view/mustache/mustache.js
+++ b/view/mustache/mustache.js
@@ -787,11 +787,11 @@ function( can ){
         }
 
 				// Make sure the context isn't a failed object before diving into it.
-				if (value !== undefined) {
+				if (typeof value !== 'undefined' && value !== null) {
 					var isHelper = Mustache.getHelper(ref,options);
 					for (j = 0; j < namesLength; j++) {
 						// Keep running up the tree while there are matches.
-						if (typeof value[names[j]] != 'undefined') {
+						if (typeof value[names[j]] !== 'undefined' && value[names[j]] !== null) {
 							lastValue = value;
 							value = value[name = names[j]];
 						}
@@ -850,7 +850,7 @@ function( can ){
 			return defaultObserve.compute(defaultObserveName);
 		}
 		// Support helper-like functions as anonymous helpers
-		if (obj !== undefined && can.isFunction(obj[ref])) {
+		if (typeof obj !== 'undefined' && obj !== null && can.isFunction(obj[ref])) {
 			return obj[ref];
 		}
 		// Support helpers without arguments, but only if there wasn't a matching data reference.

--- a/view/mustache/test/mustache_test.js
+++ b/view/mustache/test/mustache_test.js
@@ -1733,4 +1733,26 @@ test("Empty strings in arrays within Observes that are iterated should return bl
 	equal(div.getElementsByTagName('option')[0].innerHTML, "", "Blank string should return blank");
 });
 
+test("Null properties do not throw errors in Mustache.get", function() {
+	var renderer = can.view.mustache("Foo bar {{#foo.bar}}exists{{/foo.bar}}{{^foo.bar}}does not exist{{/foo.bar}}")
+	, div = document.createElement('div')
+	, div2 = document.createElement('div')
+	, frag, frag2;
+
+	try {
+		frag = renderer(new can.Observe({
+			foo : null
+		}))
+	} catch(e) {
+		ok(false, "rendering with null threw an error");
+	}
+	frag2 = renderer(new can.Observe({
+		foo : {bar : "baz"}
+	}))
+	div.appendChild(frag);
+	div2.appendChild(frag2);
+	equal(div.innerHTML, "Foo bar does not exist");
+	equal(div2.innerHTML, "Foo bar exists");
+})
+
 });


### PR DESCRIPTION
This fixes sections in Mustache when the tested value is a null property within an Observe. #307 
