### PR TITLE
deparam: parse params with remaining ampersand

### DIFF
--- a/util/string/deparam/deparam.js
+++ b/util/string/deparam/deparam.js
@@ -43,20 +43,22 @@ steal('can/util','can/util/string', function( can ){
 						value = prep( parts.join("=")),
 						current = data;
 					
-					parts = key.match(keyBreaker);
-			
-					for ( var j = 0, l = parts.length - 1; j < l; j++ ) {
-						if (!current[parts[j]] ) {
-							// If what we are pointing to looks like an `array`
-							current[parts[j]] = digitTest.test(parts[j+1]) || parts[j+1] == "[]" ? [] : {};
+					if(key) {
+						parts = key.match(keyBreaker);
+				
+						for ( var j = 0, l = parts.length - 1; j < l; j++ ) {
+							if (!current[parts[j]] ) {
+								// If what we are pointing to looks like an `array`
+								current[parts[j]] = digitTest.test(parts[j+1]) || parts[j+1] == "[]" ? [] : {};
+							}
+							current = current[parts[j]];
 						}
-						current = current[parts[j]];
-					}
-					lastPart = parts.pop();
-					if ( lastPart == "[]" ) {
-						current.push(value);
-					} else {
-						current[lastPart] = value;
+						lastPart = parts.pop();
+						if ( lastPart == "[]" ) {
+							current.push(value);
+						} else {
+							current[lastPart] = value;
+						}
 					}
 				});
 			}

--- a/util/string/deparam/deparam_test.js
+++ b/util/string/deparam/deparam_test.js
@@ -32,6 +32,15 @@ test("Nested deparam",function(){
 	equals(data.a[1],2)
 });
 
+test("Remaining ampersand", function() {
+	var data = can.deparam("a[b]=1&a[c]=2&")
+	same(data, {
+		a: {
+			b: 1,
+			c: 2
+		}
+	})
+})
 
 /** /
 test("deparam an array", function(){


### PR DESCRIPTION
Pretty easy fix for https://github.com/bitovi/canjs/issues/331

can.deparam is not able to parse following params 

``` javascript
can.deparam("a=b&")
```

It fails with `Cannot read property 'length' of null` error.

This is pretty common case when somebody generate url wrong (in javacript, on server, or write bad url into browser)

Example http://jsfiddle.net/eRQBF/
