### PR TITLE
can.sub fix remove param. Allow only to remove properties + tests

### DIFF
--- a/util/string/string.js
+++ b/util/string/string.js
@@ -170,7 +170,7 @@ steal('can/util',function(can) {
 				obs.push( str.replace( strReplacer, function( whole, inside ) {
 
 					// Convert inside to type.
-					var ob = can.getObject( inside, data, remove === undefined? remove : !remove );
+          var ob = can.getObject( inside, data, remove === true ? false : undefined );
 
 					if(ob === undefined) {
 						obs = null;

--- a/util/string/string_test.js
+++ b/util/string/string_test.js
@@ -24,6 +24,14 @@ test("String.underscore", function(){
 	equals(can.underscore("Foo.Bar.ZarDar"),"foo.bar.zar_dar")
 });
 
+test("can.sub remove", function(){
+  var obj = {a: 'a'}
+  equals(can.sub("{a}", obj, false), "a");
+  deepEqual(obj, {a: 'a'});
+
+  equals(can.sub("{a}", obj, true), "a");
+  deepEqual(obj, {});
+});
 
 test("can.getObject", function(){
 	var obj = can.getObject("foo", [{a: 1}, {foo: 'bar'}]);


### PR DESCRIPTION
Fix can.sub remove param.

Because now the remove param propagate into can.getObject as undefined or negate of given value you will get this weird behaviour when pass anything else than undefined or true into remove param.

``` javascript
obj = {}
can.sub("{a}", obj, false) // -> [{}, ""]
obj // -> {a: {}}
```

This will trigger adding functionality inside can.getObject
