### PR TITLE
Outputting attribute and value containing '=' truncates the value (EJS & Mustache)

### DIFF
--- a/view/render.js
+++ b/view/render.js
@@ -362,7 +362,7 @@ can.extend(can.view, {
 			pendingHookups.push(function(el) {
 				update = function(newVal){
 					var parts = (newVal|| "").replace(/['"]/g, '').split('='),
-						newAttrName = parts[0];
+						newAttrName = parts.shift();
 					
 					// Remove if we have a change and used to have an `attrName`.
 					if((newAttrName != attrName) && attrName){
@@ -370,7 +370,7 @@ can.extend(can.view, {
 					}
 					// Set if we have a new `attrName`.
 					if(newAttrName){
-						setAttr(el, newAttrName, parts[1]);
+						setAttr(el, newAttrName, parts.join('='));
 						attrName = newAttrName;
 					}
 				};

--- a/view/view_test.js
+++ b/view/view_test.js
@@ -356,4 +356,20 @@
 		bar.resolve('Bar done');
 	});
 
+	test("Using '=' in attribute does not truncate the value", function() {
+		var template = can.view.ejs("<div id='equalTest' <%= this.attr('class') %>></div>"),
+			obs = new can.Observe({
+				class : 'class="someClass"'
+			}),
+			frag = template(obs), div;
+
+		can.append(can.$("#qunit-test-area"), frag);
+
+		div = document.getElementById('equalTest');
+		obs.attr('class', 'class="do=not=truncate=me"');
+
+		equal(div.className, 'do=not=truncate=me', 'class is right');
+	});
+
+
 })();


### PR DESCRIPTION
If an HTML attribute is output using EJS or Mustache, any value that has a '=' in it will be truncated when live binding updates it. This can be observed in the fiddle below:

http://jsfiddle.net/NMvAd/

This is a problem particularly for **src** since the workaround to avoid an initial 404 (#157) involves outputting `src=` along with the value.

The problem is in [render.js](https://github.com/bitovi/canjs/blob/master/view/render.js#L363), specifically the update function that runs when you are in a tag, but not an attribute.
