### PR TITLE
Update sub to not break when str is undefined

### DIFF
--- a/util/string/string.js
+++ b/util/string/string.js
@@ -167,6 +167,8 @@ steal('can/util',function(can) {
 			 */
 			sub: function( str, data, remove ) {
 				var obs = [];
+				
+				str = str || '';
 
 				obs.push( str.replace( strReplacer, function( whole, inside ) {
 


### PR DESCRIPTION
For development reasons, I had a model without destroy defined, but I was calling `destroy()` on my test, canjs was breaking when calling sub with `str = undefined`.
