### PR TITLE
Prevent errors if destroy is called multiple times on a Control instance

### DIFF
--- a/control/control.js
+++ b/control/control.js
@@ -701,6 +701,9 @@ steal('can/util','can/construct', function( can ) {
 		destroy: function() {
 			//Control already destroyed
 			if(this.element === null) {
+				//!steal-remove-start
+				steal.dev.warn("Control.js - Control already destroyed");
+				//!steal-remove-end
 				return;
 			}
 			var Class = this.constructor,

--- a/control/control_test.js
+++ b/control/control_test.js
@@ -343,7 +343,7 @@
 		equal(c._bindings.length, 1, 'There is only one binding');
 	});
 
-	test("Multiple calls to destroy", 3, function() {
+	test("Multiple calls to destroy", 2, function() {
 
 		var Control = can.Control({
 			destroy: function() {
@@ -354,7 +354,6 @@
 		div = document.createElement('div'),
 		c = new Control(div);
 
-		can.$(div).remove();
 		c.destroy();
 		c.destroy();
 	});


### PR DESCRIPTION
Calling `destroy()` more than once on a control instance results in a JavaScript error in `can.Control.prototype.off` as seen in this [fiddle](http://jsfiddle.net/pNdjr/).

This is a foot gun that is easily disarmed by checking if `this.element === null` before attempting to do anything in `destroy`.

This typically happens when an instances' element is destroyed via DOM manipulation followed by one or more calls to `destroy()`.
