### PR TITLE
can.route references delegate but does not include it

### DIFF
--- a/route/route.js
+++ b/route/route.js
@@ -421,14 +421,13 @@ steal('can/util','can/observe', 'can/util/string/deparam', function(can) {
     // instead act on the `can.route.data` observe.
 	each(['bind','unbind','delegate','undelegate','attr','removeAttr'], function(name){
 		can.route[name] = function(){
-
-			// `delegate` and `undelegate` require 
+			// `delegate` and `undelegate` require
 			// the `can/observe/delegate` plugin
-			if(!can.isFunction(can.route.data[name])) {
+			if(!can.route.data[name]) {
             	return;
-        	}
+			}
 
-			return can.route.data[name].apply(can.route.data, arguments)
+			return can.route.data[name].apply(can.route.data, arguments);
 		}
 	})
 


### PR DESCRIPTION
Fix for can.route references delegate but does not include it

https://github.com/bitovi/canjs/issues/353
