### PR TITLE
Binding to an Observe.compute value is broken

### DIFF
--- a/observe/compute/compute_test.js
+++ b/observe/compute/compute_test.js
@@ -263,6 +263,9 @@ test("Generate computes from Observes with can.Observe.prototype.compute (#203)"
 	equal(compute(), 'testvalue', 'Value is as expected');
 	obs.attr('test', 'observeValue');
 	equal(compute(), 'observeValue', 'Value is as expected');
+	compute.bind('change', function(ev, newVal) {
+		equal(newVal, 'computeValue', 'new value from compute');
+	});
 	obs.bind('change', function(ev, name, how, newVal) {
 		equal(newVal, 'computeValue', 'Got new value from compute');
 	});


### PR DESCRIPTION
``` js
var person = new can.Observe({
    name: 'Jeeves'
});
var name = person.compute('name');
name.bind('change', function(ev, newVal, oldVal) {
    ...
});
name('Alfred');
```

The change handler in this example will be called twice. Once with the `newVal` as `Alfred` and a second time with `newVal` as the Observe instance (`person`).

**Here's how this happens:**

When the `name` compute is updated, we end up in [compute.js](https://github.com/bitovi/canjs/blob/master/observe/compute/compute.js#L342) and run the `set` function which is defined here in [observe.js](https://github.com/bitovi/canjs/blob/master/observe/observe.js#L919). This calls `attr` which fires a change event with `newVal === 'Alfred'`. 

`setVal` is now the Observe instance since [attr returns the Observe](https://github.com/bitovi/canjs/blob/master/observe/observe.js#L538), so when the execution reaches [here](https://github.com/bitovi/canjs/blob/master/observe/compute/compute.js#L353), a change event is triggered with `newVal` set to the Observe instance.

This code was added by @justinbmeyer [here](https://github.com/bitovi/canjs/commit/e73635f150744cb77f5b0bd7ce898942894cd47d) to extend can.compute.
