### PR TITLE
can:util:string set a value while getting an object from string

### DIFF
--- a/util/string/string.js
+++ b/util/string/string.js
@@ -65,9 +65,10 @@ steal('can/util',function(can) {
 			 * @param {Boolean} [add] true to add missing objects to 
 			 *  the path. false to remove found properties. undefined to 
 			 *  not modify the root object
+			 * @param {mixed} [value] Leaf value to add
 			 * @return {Object} The object.
 			 */
-			getObject : function( name, roots, add ) {
+			getObject : function( name, roots, add, value ) {
 			
 				// The parts of the name we are looking up  
 				// `['App','Models','Recipe']`
@@ -99,6 +100,11 @@ steal('can/util',function(can) {
 						
 						// Get (and possibly set) the property.
 						ret = getNext(current, parts[i], add); 
+						
+						// Set value a value is given in parameter
+						if ( add && value) {
+							current[parts[i]] = value;
+						}
 						
 						// If there is a value, we exit.
 						if ( ret !== undefined ) {


### PR DESCRIPTION
I needed to add a value when creating an object structure.
I found the getObject function of the can library to create the structure. And I override it to allow me to add a value to the leaf object.
It seems to make sens for me.
