### PR TITLE
can.Observe makes can.Deferred into an observable

### DIFF
--- a/observe/observe.js
+++ b/observe/observe.js
@@ -6,7 +6,7 @@ steal('can/util','can/util/bind','can/construct', function(can, bind) {
 	//  
 	// Returns `true` if something is an object with properties of its own.
 	var canMakeObserve = function( obj ) {
-			return obj && (can.isArray(obj) || can.isPlainObject( obj ) || ( obj instanceof can.Observe ));
+			return obj && !can.isDeferred(obj) && (can.isArray(obj) || can.isPlainObject( obj ) || ( obj instanceof can.Observe ));
 		},
 		
 		// Removes all listeners.

--- a/observe/observe_test.js
+++ b/observe/observe_test.js
@@ -812,9 +812,14 @@ test("cycle binding",function(){
 	ok(!first._bindings,"bindings removed");
 });
 
+test("Deferreds are not converted", function() {
+	var dfd = can.Deferred(),
+		ob = new can.Observe({
+			test: dfd
+		});
 
-
-
-
+	ok(can.isDeferred(ob.attr('test')), 'Attribute is a deferred');
+	ok(!ob.attr('test')._cid, 'Does not have a _cid');
+});
 
 })();


### PR DESCRIPTION
The current implementation of `canMakeObserve` is:

``` javascript
canMakeObserve = function( obj ) {
  return obj && (can.isArray(obj) || can.isPlainObject( obj ) || ( obj instanceof can.Observe ));
}
```

As `can.isPlainObject` returns true for a `can.Deferred`, a promise that is part of a model's raw data values will be treated as a plain object to be wrapped as a child `can.Observe` with observable members itself. This is almost certainly not the intention.
