### PR TITLE
Ability to escape periods in mustache templates

### DIFF
--- a/view/mustache/doc/basics.md
+++ b/view/mustache/doc/basics.md
@@ -81,6 +81,16 @@ then we could reference `author` and `publisher` like so:
 	{{book.author}}
 	{{book.publisher}}
 
+For keys containing periods, the period should be escaped with `\.`:
+
+	{
+		localization: {
+			"hello.world": "Hello World!"
+		}
+	}
+
+	{{localization.hello\.world}}
+
 
 __Context Jumping__
 

--- a/view/mustache/mustache_test.js
+++ b/view/mustache/mustache_test.js
@@ -1859,4 +1859,25 @@ test("a compute gets passed to a plugin",function(){
 
 });
 
+test("Object references can escape periods for key names containing periods", function() {
+	var template = can.view.mustache("{{#foo.bar}}" +
+			"{{some\\\\.key\\\\.name}} {{some\\\\.other\\\\.key.with\\\\.more}}" +
+		"{{/foo.bar}}"),
+		data = {
+			foo: {
+				bar: [{
+					"some.key.name": 100,
+					"some.other.key": {
+						"with.more": "values"
+					}
+				}]
+			}
+		};
+
+	var div = document.createElement('div');
+	div.appendChild(template(data))
+
+	equal( div.innerHTML, "100 values" );
+})
+
 })();


### PR DESCRIPTION
```
foo["foo.bar"] = true

{{#foo}}
    {{foo\.bar}}
{{/foo}}
```
