### PR TITLE
Added ability to set Observe property to undefined

### DIFF
--- a/observe/observe.js
+++ b/observe/observe.js
@@ -543,7 +543,7 @@ steal('can/util','can/util/bind','can/construct', function(can, bind) {
 			var type = typeof attr;
 			if ( type !== "string" && type !== "number" ) {
 				return this._attrs(attr, val)
-			} else if ( val === undefined ) {// If we are getting a value.
+			} else if ( arguments.length === 1 ) {// If we are getting a value.
 				// Let people know we are reading.
 				Observe.__reading && Observe.__reading(this, attr)
 				return this._get(attr)

--- a/observe/observe_test.js
+++ b/observe/observe_test.js
@@ -1,4 +1,4 @@
-(function() {
+(function(undefined) {
 module('can/observe')
 
 test("Basic Observe",9,function(){
@@ -821,6 +821,15 @@ test("Deferreds are not converted", function() {
 
 	ok(can.isDeferred(ob.attr('test')), 'Attribute is a deferred');
 	ok(!ob.attr('test')._cid, 'Does not have a _cid');
+});
+
+test("Setting property to undefined", function(){
+	var ob = new can.Observe({
+		"foo": "bar"
+	});
+	ob.attr("foo", undefined);
+
+	equal(ob.attr("foo"), undefined, "foo has a value.");
 });
 
 })();


### PR DESCRIPTION
The alternative is to use removeAttr, but this requires knowing that you want to remove it. Some times it is nice to set an attribute to a value without first checking the definedness of the value. First example.

``` javascript
state.attr('foo', someFunction()); // someFunction could return anything.
```

Fixes #413
