### PR TITLE
Date converter from string should return Date object

### DIFF
--- a/observe/attributes/attributes.js
+++ b/observe/attributes/attributes.js
@@ -159,7 +159,8 @@ can.each([ can.Observe, can.Model ], function(clss){
 			"date": function( str ) {
 				var type = typeof str;
 				if ( type === "string" ) {
-					return isNaN(Date.parse(str)) ? null : Date.parse(str)
+					str = Date.parse(str);
+					return isNaN(str) ? null : new Date(str);
 				} else if ( type === 'number' ) {
 					return new Date(str)
 				} else {

--- a/observe/attributes/attributes_test.js
+++ b/observe/attributes/attributes_test.js
@@ -93,6 +93,9 @@ var makeClasses= function(){
 test("default converters", function(){
 	var num = 1318541064012;
 	equal( can.Observe.convert.date(num).getTime(), num, "converted to a date with a number" );
+
+	var str = "Dec 25, 1995";
+	ok( can.Observe.convert.date(str) instanceof Date, "converted to a date with a string" );
 })
 
 test("basic observe associations", function(){

--- a/observe/attributes/test.html
+++ b/observe/attributes/test.html
@@ -21,7 +21,7 @@
 		steal.config({
 			root: '../../'
 		});
-	}, "can/observe/attributes", "can/model").then("can/test", "can/observe/attributes/attributes_test.js", function() {
+	}, "can/observe/attributes", "can/model", "can/util/fixture").then("can/test", "can/observe/attributes/attributes_test.js", function() {
 		QUnit.start();
 	});
 </script>


### PR DESCRIPTION
Bug was returning a Number when passed a valid date string, should be returning a `Date` instance. Fixes #381
