### PR TITLE
Fixing can.ajax missing test for error handler with mootools

### DIFF
--- a/util/mootools/mootools.js
+++ b/util/mootools/mootools.js
@@ -268,7 +268,7 @@ steal('can/util/can.js', 'mootools', 'can/util/event.js','can/util/fragment.js',
 		requestOptions.onFailure = function(){
 			updateDeferred(request.xhr, d);
 			d.reject(request.xhr,"error");
-			error(request.xhr,"error");
+			error && error(request.xhr,"error");
 		}
 
 		if(options.dataType ==='json'){


### PR DESCRIPTION
The Can.Ajax code tests for the presence of a passed in success handler before calling it but not error. This causes an uncaught exception. This test exists for other libraries. 
