### PR TITLE
Fixed typo in documentatin.

### DIFF
--- a/view/ejs/ejs.md
+++ b/view/ejs/ejs.md
@@ -88,9 +88,9 @@ helpful, but it does nothing fancy.
 Next, turn your teacher into a `new can.Observe(object)` and pass
 that to `can.view`:
 
-    var teacher = can.Observe({
+    var teacher = new can.Observe({
       name : "Mr. Smith",
-      grade : "a"
+      grade : "a",
       students : [
         {name : "Suzy"},
         {name : "Payal"},


### PR DESCRIPTION
When you try to run examples what wrote at documentation it'll throw error:

```
uncaught exception: can.view: No template or empty template:teacherEjs.ejs
```

I only fix the typo. 
