### PR TITLE
Use .attr() when evaluating errors in validations

### DIFF
--- a/observe/validations/validations.js
+++ b/observe/validations/validations.js
@@ -373,7 +373,7 @@ steal('can/util', 'can/observe/attributes', function (can) {
 					can.each(funcs, function (func) {
 						var res = func.call(self, isTest ? ( self.__convert ?
 							self.__convert(attr, newVal) :
-							newVal ) : self[attr]);
+							newVal ) : self.attr(attr));
 						if (res) {
 							if (!errors[attr]) {
 								errors[attr] = [];


### PR DESCRIPTION
#410 in pull request form

In order to make it possible to bind a can.compute to error evaluations, switch the [attr] access of attributes to .attr(attr)  

I've been using this for a few weeks on reciprocity/ggrc-core and it seems to be working out without unintended side effects.
