### PR TITLE
Preloaded recursive views fail to render their recursions

### DIFF
--- a/view/ejs/ejs_test.js
+++ b/view/ejs/ejs_test.js
@@ -916,13 +916,45 @@ test("indirectly recursive views", function() {
 	var div = document.createElement('div');	
 	div.appendChild(can.view(can.test.path('view/ejs/test/indirect1.ejs'), {unordered: unordered}));
 	document.getElementById('qunit-test-area').appendChild(div);
-	ok(can.trim(can.$('#qunit-test-area ul > li > ol > li > ul > li > ol > li')[0].innerHTML) === "1", "Uncached indirectly recursive EJS working.");
+	var el = can.$('#qunit-test-area ul > li > ol > li > ul > li > ol > li')[0];
+	ok(!!el && can.trim(el.innerHTML) === "1", "Uncached indirectly recursive EJS working.");
 	
 	can.view.cache = true;
 	div.appendChild(can.view(can.test.path('view/ejs/test/indirect1.ejs'), {unordered: unordered}));
-	ok(can.trim(can.$('#qunit-test-area ul + ul > li > ol > li > ul > li > ol > li')[0].innerHTML) === "1", "Cached indirectly recursive EJS working.");
+	el = can.$('#qunit-test-area ul + ul > li > ol > li > ul > li > ol > li')[0];
+	ok(!!el && can.trim(el.innerHTML) === "1", "Cached indirectly recursive EJS working.");
 	document.getElementById('qunit-test-area').removeChild(div);
 
+});
+
+test("recursive views of previously stolen files shouldn't fail", function() {
+	stop();
+	steal(
+		'view/ejs/test/indirect1.ejs', 
+		'view/ejs/test/indirect2.ejs',
+		function() {
+			start();
+			var unordered = new can.Observe.List([
+				{ ol: [
+					{ ul: [
+						{ ol: [1, 2, 3] }
+					]}
+				]}
+			]);
+			can.view.cache = false;
+			var div = document.createElement('div');	
+			div.appendChild(can.view(can.test.path('view/ejs/test/indirect1.ejs'), {unordered: unordered}));
+			document.getElementById('qunit-test-area').appendChild(div);
+			var el = can.$('#qunit-test-area ul > li > ol > li > ul > li > ol > li')[0];
+			ok(!!el && can.trim(el.innerHTML) === "1", "Uncached indirectly recursive EJS working.");
+			
+			can.view.cache = true;
+			div.appendChild(can.view(can.test.path('view/ejs/test/indirect1.ejs'), {unordered: unordered}));
+			el = can.$('#qunit-test-area ul + ul > li > ol > li > ul > li > ol > li')[0];
+			ok(!!el && can.trim(el.innerHTML) === "1", "Cached indirectly recursive EJS working.");
+			document.getElementById('qunit-test-area').removeChild(div);
+		}
+	);
 });
 
 test("live binding select", function(){

--- a/view/view.js
+++ b/view/view.js
@@ -665,7 +665,7 @@ steal("can/util", function( can ) {
 			return "can.view.preload('" + id + "'," + $view.types["." + type].script(id, src) + ");";
 		},
 		preload: function( id, renderer ) {
-			$view.cached[id] = new can.Deferred().resolve(function( data, helpers ) {
+			var def = $view.cached[id] = new can.Deferred().resolve(function( data, helpers ) {
 				return renderer.call(data, data, helpers);
 			});
 			function frag(){
@@ -673,6 +673,11 @@ steal("can/util", function( can ) {
 			}
 			// expose the renderer for mustache
 			frag.render = renderer;
+
+			// set cache references (otherwise preloaded recursive views won't recurse properly)
+			def.__view_id = id;
+			$view.cachedRenderers[id] = renderer;
+
 			return frag;
 		}
 


### PR DESCRIPTION
Whenever a recursive **can.view** is stolen (or preloaded via production build) prior to being used in the page, it will only render the top level pass, ignoring all recursions.

This will fail (where indirect1 and indirect2 recursively call each other inside their templates):

``` javascript
    steal(
        'view/ejs/test/indirect1.ejs', 
        'view/ejs/test/indirect2.ejs',
        function() {
            var unordered = new can.Observe.List([
                { ol: [
                    { ul: [
                        { ol: [1, 2, 3] }
                    ]}
                ]}
            ]);
            can.view.cache = false;
            var div = document.createElement('div');    
            div.appendChild(can.view(can.test.path('view/ejs/test/indirect1.ejs'), {unordered: unordered}));
            document.getElementById('qunit-test-area').appendChild(div);
            var el = can.$('#qunit-test-area ul > li > ol > li > ul > li > ol > li')[0];
            ok(!!el && can.trim(el.innerHTML) === "1", "Uncached indirectly recursive EJS working.");

            can.view.cache = true;
            div.appendChild(can.view(can.test.path('view/ejs/test/indirect1.ejs'), {unordered: unordered}));
            el = can.$('#qunit-test-area ul + ul > li > ol > li > ul > li > ol > li')[0];
            ok(!!el && can.trim(el.innerHTML) === "1", "Cached indirectly recursive EJS working.");
            document.getElementById('qunit-test-area').removeChild(div);
        }
    );
```

I will be checking in a fix shortly.
