### PR TITLE
can.Model.model attribute serialization fix

### DIFF
--- a/model/model.js
+++ b/model/model.js
@@ -1025,7 +1025,7 @@ steal('can/util','can/observe', function( can ) {
 			if ( ! attributes ) {
 				return;
 			}
-			if ( attributes instanceof this ) {
+			if ( typeof attributes.serialize === 'function' ) {
 				attributes = attributes.serialize();
 			}
 			var id = attributes[ this.id ],

--- a/model/model_test.js
+++ b/model/model_test.js
@@ -1156,4 +1156,15 @@ test("destroy not calling callback for new instances (#403)", function(){
 	});
 });
 
+test(".model should always serialize Observes (#444)", function() {
+	var ConceptualDuck = can.Model({
+		defaults: {
+			sayeth: "Abstractly 'quack'"
+		}
+	}, {});
+	var ObserveableDuck = can.Observe({}, {});
+
+	equal("quack", ConceptualDuck.model(new ObserveableDuck({sayeth: "quack"})).sayeth);
+});
+
 })();


### PR DESCRIPTION
Instead of checking instanceof, just check if it's something with a
serialize function attached to it. This allows can.Model.model to
accept can.Observe (and anything else that's "serializable").

This does have the side-effect that "serialize" becomes a reserved
property, but there's other parts of canjs where this happens, such as
can.Observe#bind

This should fix #444.
