### PR TITLE
can.compute error with can.Observe

### DIFF
--- a/observe/compute/compute.js
+++ b/observe/compute/compute.js
@@ -198,7 +198,7 @@ steal('can/util', 'can/util/bind', function(can, bind) {
 				return value;
 			} else {
 				// Let others know to listen to changes in this compute
-				if( can.Observe.__reading && canReadForChangeEvent) {
+				if(can.Observe && can.Observe.__reading && canReadForChangeEvent) {
 					can.Observe.__reading(computed,'change');
 				}
 				// if we are bound, use the cached value

--- a/observe/compute/compute_test.js
+++ b/observe/compute/compute_test.js
@@ -489,6 +489,15 @@ test("compute bound to input value",function(){
 
 })
 
+test("compute reads without observe", function() {
+	var oldObserve = can.Observe;
+	delete can.Observe;
 
+	var comp = can.compute(5);
+
+	equal(comp(), 5, "Got compute value");
+
+	can.Observe = oldObserve;
+})
 
 })();


### PR DESCRIPTION
https://github.com/bitovi/canjs/blob/master/observe/compute/compute.js#L338

```
if( can.Observe.__reading && canReadForChangeEvent) {
    can.Observe.__reading(computed,'change');
}
```

This conditional assumes can.Observe exists. Just need an extra if(can.Observe && can.Observe.__reading...

Noting this until I get back to it(unless someone beats me to this!)
