### PR TITLE
can.Model Fails Silently When Server Doesn't Return an Array for findAll

### DIFF
--- a/model/model.js
+++ b/model/model.js
@@ -13,8 +13,12 @@ steal('can/util','can/observe', function( can ) {
 		var d = new can.Deferred();
 		def.then(function(){
 			var args = can.makeArray( arguments );
-			args[0] = model[func](args[0]);
-			d.resolveWith(d, args);
+			try {
+				args[0] = model[func](args[0]);
+				d.resolveWith(d, args);
+			} catch(e) {
+				d.rejectWith(d, [e].concat(args));
+			}
 		},function(){
 			d.rejectWith(this, arguments);
 		});
@@ -927,6 +931,10 @@ steal('can/util','can/observe', function( can ) {
 				// Get the object's data.
 				instancesRawData.data),
 				i = 0;
+
+			if(typeof raw === 'undefined') {
+				throw new Error('Could not get any raw data while converting using .models');
+			}
 
 			//!steal-remove-start
 			if ( ! raw.length ) {

--- a/model/model_test.js
+++ b/model/model_test.js
@@ -47,6 +47,29 @@ test("findAll deferred", function(){
 	})
 });
 
+test("findAll rejects non-array (#384)", function() {
+	var Person = can.Model({
+		findAll : function(params, success, error){
+			var dfd = can.Deferred();
+			setTimeout(function() {
+				dfd.resolve({
+					stuff: {}
+				});
+			}, 100);
+			return dfd;
+		}
+	},{});
+
+	stop();
+	Person.findAll({}).then(function() {
+		ok(false, 'This should not succeed');
+	}, function(err) {
+		ok(err instanceof Error, 'Got an error');
+		equal(err.message, 'Could not get any raw data while converting using .models');
+		start();
+	});
+});
+
 asyncTest("findAll deferred reject", function() {
 	// This test is automatically paused
 


### PR DESCRIPTION
No deferred method is executed if invalid data is returned. For example:

``` javascript
myModel.findAll({myData: 'myValue'}, function(result) {
    // do something here
}).fail(function(xhr, textStatus, errorThrown) {
  // do something here
});
```

Success callback or fail callback not called. This hold true for 'then'.
