### PR TITLE
Catch only exceptions thrown by model[func]() (fix #454 and re #384)

### DIFF
--- a/model/model.js
+++ b/model/model.js
@@ -12,12 +12,16 @@ steal('can/util','can/observe', function( can ) {
 	var	pipe = function( def, model, func ) {
 		var d = new can.Deferred();
 		def.then(function(){
-			var args = can.makeArray( arguments );
+			var args = can.makeArray( arguments ),
+			    success = true;
 			try {
 				args[0] = model[func](args[0]);
-				d.resolveWith(d, args);
 			} catch(e) {
+				success = false;
 				d.rejectWith(d, [e].concat(args));
+			}
+			if (success) {
+				d.resolveWith(d, args);
 			}
 		},function(){
 			d.rejectWith(this, arguments);


### PR DESCRIPTION
Catch only exceptions thrown by model[func](), and not by d.resolvWith(). The Deferred is resolved only if model[func]() succeeds.

/re #454 and #384
/cc @daffl and @thecountofzero thanks for reviewing any comments are welcome
