### PR TITLE
Prevent infinite recursion on unbindAndTeardown when Observe's _bindings is undefined and Observe is self-referential

### DIFF
--- a/util/bind/bind.js
+++ b/util/bind/bind.js
@@ -33,7 +33,11 @@ steal('can/util',function(can){
 		// Remove the event handler
 		can.removeEvent.apply(this, arguments);
 
-		this._bindings--;
+		if(this._bindings == null) {
+			this._bindings = 0;
+		} else {
+			this._bindings--;
+		}
 		// If there are no longer any bindings and
 		// there is a bindteardown method, call it.
 		if(!this._bindings){


### PR DESCRIPTION
Previously in util/bind/bind.js

```
                this._bindings--;
                // If there are no longer any bindings and
                // there is a bindteardown method, call it.
                if(!this._bindings){
```

If _bindings was undefined, this sets it to NaN and then does the teardown.  If in the teardown this object is touched again, having NaN for bindings will decrement to NaN again, still be falsy, and run the teardown again (eventually leading to a stack fault).

The code in this pull request sets _bindings to 0 if it is undefined.  Any subsequent visit to unbindAndTeardown will then decrement it to -1 or less, which is okay because we've already started the teardown process.
