### PR TITLE
can.route.ready called multiple times

### DIFF
--- a/route/route.js
+++ b/route/route.js
@@ -49,7 +49,6 @@ steal('can/util','can/observe', 'can/util/string/deparam', function(can) {
 			return count;
 		},
 		onready = !0,
-		readyCalled = 0,
 		location = window.location,
 		wrapQuote = function(str) {
 			return (str+'').replace(/([.?*+\^$\[\]\\(){}|\-])/g, "\\$1");
@@ -312,9 +311,8 @@ steal('can/util','can/observe', 'can/util/string/deparam', function(can) {
 			if( val === false ) {
 				onready = val;
 			}
-			if( !readyCalled && (val === true || onready === true) ) {
+			if( val === true || onready === true ) {
 				can.route._setup();
-				readyCalled = true;
 				setState();
 			}
 			return can.route;
@@ -506,7 +504,7 @@ steal('can/util','can/observe', 'can/util/string/deparam', function(can) {
 
 	// Libraries other than jQuery don't execute the document `ready` listener
 	// if we are already DOM ready
-	if( (document.readyState === 'complete' || document.readyState === "interactive") && onready) {
+	if( !window.jQuery && ((document.readyState === 'complete' || document.readyState === "interactive") && onready)) {
 		can.route.ready();
 	}
 


### PR DESCRIPTION
`can.route.ready` is being called twice (or more if the user calls it themselves) which calls `setState` and binds to the `hashChange` event each time.

`can.route.ready` is the handler for the `ready` event ([L503](https://github.com/bitovi/canjs/blob/master/route/route.js#L503)) and is then called on [L508](https://github.com/bitovi/canjs/blob/master/route/route.js#L508). This results in 2 bindings to the `hashChange` event (more if user calls `can.route.ready` themselves).

The other issue is that any modifications to the route before the `ready` event are wiped out by one of the other `setState` calls.

I've added a flag that only allows ready to be called once. 
