### PR TITLE
In pushstate check hostname before updating the route.

### DIFF
--- a/route/pushstate/pushstate.js
+++ b/route/pushstate/pushstate.js
@@ -40,7 +40,7 @@ steal('can/util', 'can/route', function(can) {
 	                      this.host = window.location.host;
 	                    }
 	                    // HTML5 pushstate requires host to be the same. Don't prevent default for other hosts.
-	                    if(can.route.updateWith(this.pathname+this.search) && window.location.host == this.host) {
+	                    if(window.location.host == this.host && can.route.updateWith(this.pathname+this.search)) {
 	                        e.preventDefault();
 	                    }
                 	}


### PR DESCRIPTION
On navigating to another domain (while pushstate is enabled) it first checked if pathname in URL exists among defined routes on current page, if so the user would be first redirected (in `can.route.updateWith`) to the matched route and then to another domain, so first the hostname should be checked to prevent that.

For example, navigating from `canjs.com/foo` to `bitovi.com/bar` would first redirect to `canjs.com/bar` (if route `/bar` exists on canjs.com) and then to `bitovi.com/bar`.
