### PR TITLE
can.Observe.List.Sort: fix for case when comparator is not a function

### DIFF
--- a/observe/sort/sort.js
+++ b/observe/sort/sort.js
@@ -36,8 +36,8 @@ can.extend(proto,{
 	sort: function(method, silent){
 		var comparator = this.comparator,
 			args = comparator ? [function(a, b){
-				a = typeof(a[comparator] === 'function')?a[comparator]():a[comparator];
-				b = typeof(b[comparator] === 'function')?b[comparator]():b[comparator];
+				a = (typeof a[comparator] === 'function')?a[comparator]():a[comparator];
+				b = (typeof b[comparator] === 'function')?b[comparator]():b[comparator];
 				return a === b ? 0 : (a < b ? -1 : 1);
 			}] : [method],
 			res = [].sort.apply(this, args);


### PR DESCRIPTION
The test for can.Observe.List.Sort did not work. Sorting like

```
    this.comparator = 'name';
```

did not work as typeof(a===b) === 'boolean'
