### PR TITLE
String parameter not working as expected for: jQuery.fn.control / jQuery.fn.controls

### DIFF
--- a/control/plugin/plugin.js
+++ b/control/plugin/plugin.js
@@ -3,8 +3,9 @@ steal('jquery', 'can/util', 'can/control', function($, can) {
 //controllers can be strings or classes
 var i, 
 	isAControllerOf = function( instance, controllers ) {
+		var name = instance.constructor.pluginName || instance.constructor._shortName;
 		for ( i = 0; i < controllers.length; i++ ) {
-			if ( typeof controllers[i] == 'string' ? instance.constructor._shortName == controllers[i] : instance instanceof controllers[i] ) {
+			if ( typeof controllers[i] == 'string' ? name == controllers[i] : instance instanceof controllers[i] ) {
 				return true;
 			}
 		}
@@ -75,28 +76,26 @@ $.fn.extend({
 	 * of control instance(s) with the DOM element it was initialized on using 
 	 * [can.data] method.
 	 *
-	 * The `controls` method allows you to get the control instance(s) for any element.  
+	 * The `controls` method allows you to get the control instance(s) for any element
+	 * either by their type or pluginName.
+	 *
+	 *      var MyBox = can.Control({
+	 *          pluginName : 'myBox'
+	 *      }, {});
+	 *
+	 *      var MyClock = can.Control({
+	 *          pluginName : 'myClock'
+	 *      }, {});
+	 *
 	 *
 	 *		//- Inits the widgets
-	 *		$('.widgets:eq(0)').my_box();
-	 *		$('.widgets:eq(1)').my_clock();
-	 *
-	 *		<div class="widgets my_box" />
-	 *		<div class="widgets my_clock" />
+	 *		$('.widgets:eq(0)').myBox();
+	 *		$('.widgets:eq(1)').myClock();
 	 *
 	 *		$('.widgets').controls() //-> [ MyBox, MyClock ]
+	 *	    $('.widgets').controls('myBox') // -> [MyBox]
+	 *	    $('.widgets').controls(MyClock) // -> MyClock
 	 *
-	 * Additionally, you can invoke it passing the name of a control
-	 * to fetch a specific instance(s).
-	 *
-	 *		//- Inits the widgets
-	 *		$('.widgets:eq(0)').my_box();
-	 *		$('.widgets:eq(1)').my_clock();
-	 *
-	 *		<div class="widgets my_box" />
-	 *		<div class="widgets my_clock" />
-	 *
-	 *		$('.widgets').controls('MyBox') //-> [ MyBox ]
 	 */
 	controls: function() {
 		var controllerNames = makeArray(arguments),

--- a/control/plugin/plugin_test.js
+++ b/control/plugin/plugin_test.js
@@ -1,5 +1,4 @@
 (function() {
-
 	module("can/control/plugin")
 
 	test("pluginName", function () {
@@ -74,5 +73,27 @@
 		ta.callTest();
 		ok(ta.callTest('setName', 'Tester') instanceof jQuery, 'Got jQuery element as return value');
 		equal(ta.callTest('returnTest'), 'Hi Tester', 'Got correct return value');
+	});
+
+	test('always use pluginName first in .control(name) (#448)', 4, function() {
+		var Control = can.Control('SomeName', {
+			pluginName : 'someTest'
+		}, {});
+
+		var OtherControl = can.Control( {
+			pluginName : 'otherTest'
+		}, {});
+
+		var ta = can.$("<div/>").appendTo($("#qunit-test-area"));
+		ta.someTest();
+		ta.otherTest();
+
+		var control = ta.control('someTest');
+		ok(control, 'Got a control from pluginName');
+		equal(control.constructor.pluginName, 'someTest', 'Got correct control');
+
+		control = ta.control('otherTest');
+		ok(control, 'Got a control from pluginName');
+		equal(control.constructor.pluginName, 'otherTest', 'Got correct control');
 	});
 })();


### PR DESCRIPTION
Using CanJS v1.1.6

String parameter not working as expected for: jQuery.fn.control / jQuery.fn.controls

Reference: http://canjs.com/docs/jQuery.fn.control.html

``` javascript

//
//  Define Plugin
//
var MyPlugin = can.Control.extend('MyPlugin', {
  pluginName: 'MyPlugin'
}, {});

// init plugin
$('body').MyPlugin();


//
//  Attempt to get defined plugin
//
$('body').control(); // returns MyPlugin (works as expected)
$('body').control(); // returns MyPlugin (works as expected)
$('body').control(MyPlugin); // returns MyPlugin (works as expected)

$('body').control('MyPlugin');  // returns undefined
$('body').control('myplugin'); // return undefined
```
