### PR TITLE
Issue: can.view.ejs(str) and can.view.ejs(id, str) return different responses

### DIFF
--- a/view/view.js
+++ b/view/view.js
@@ -669,8 +669,7 @@ steal("can/util", function( can ) {
 					return renderer;
 				}
 
-				$view.preload(id, info.renderer(id, text));
-				return can.view(id);
+				return $view.preload(id, info.renderer(id, text));
 			}
 		},
 		registerScript: function( type, id, src ) {

--- a/view/view_test.js
+++ b/view/view_test.js
@@ -704,4 +704,16 @@
 		equal(div.getElementsByTagName("h3")[0].innerHTML, 'Hi test',
 			'Got expected test from extensionless template');
 	});
+
+	test("can.view[engine] always returns fragment renderers (#485)", 2, function() {
+		var template = "<h1>{{message}}</h1>";
+		var withId = can.view.mustache('test-485', template);
+		var withoutId = can.view.mustache(template);
+
+		ok(withoutId({ message: 'Without id'}) instanceof DocumentFragment,
+			'View without id returned document fragment');
+
+		ok(withId({ message: 'With id'}) instanceof DocumentFragment,
+			'View with id returned document fragment');
+	});
 })();


### PR DESCRIPTION
can.view.ejs(id, str) currently returns renderer function, while can.view.ejs(str) returns renderer function, wrapped with can.view.frag() call. This should be fixed in order to make return value consistent.

See more details at https://github.com/bitovi/canjs/issues/483
