### PR TITLE
Makes attribute arguments passed to a component two way binding

### DIFF
--- a/component/component_test.js
+++ b/component/component_test.js
@@ -556,7 +556,57 @@ test("self closing content tags", function(){
 	equal(can.$("#qunit-test-area span").length, 1, "there is an h1")
 })
 
-
+test("setting passed variables - two way binding", function(){
+	can.Component({
+	    tag: "my-toggler",
+	    template: "{{#if visible}}<content/>{{/if}}",
+	    scope: {
+	        visible: true,
+	        show: function(){
+	            this.attr('visible', true)
+	        },
+	        hide: function(){
+	            this.attr("visible", false)
+	        }
+	    }
+	})
+	
+	
+	can.Component({
+	    tag: "my-app",
+	    scope: {
+	        visible: true,
+	        show: function(){
+	          this.attr('visible', true)              
+	        }
+	    }
+	})
+    var template = can.view.mustache("<my-app>"+
+        '{{^visible}}<button can-click="show">show</button>{{/visible}}'+
+        '<my-toggler visible="visible">'+
+        	'content'+
+            '<button can-click="hide">hide</button>'+
+        '</my-toggler>'+
+    '</my-app>')
+    
+    
+    can.append(can.$("#qunit-test-area"), template({}));
+    
+    var testArea = can.$("#qunit-test-area")[0],
+		buttons = testArea.getElementsByTagName("button")
+    
+    equal(buttons.length, 1, "there is one button")
+    equal(buttons[0].innerHTML, "hide", "the button's text is hide")
+    
+    can.trigger(buttons[0],"click");
+    
+    equal(buttons.length, 1, "there is one button")
+    equal(buttons[0].innerHTML, "show", "the button's text is show");
+    
+    can.trigger(buttons[0],"click");
+    equal(buttons.length, 1, "there is one button")
+    equal(buttons[0].innerHTML, "hide", "the button's text is hide")
+})
 
 	
 })()

--- a/observe/observe_test.js
+++ b/observe/observe_test.js
@@ -1336,6 +1336,7 @@ test("compute bound to input value",function(){
 })
 
 test("compute on the prototype", function(){
+	expect(4)
 	var Person = can.Map.extend({
 		fullName: can.compute(function(fullName){
 			if(arguments.length){
@@ -1365,8 +1366,18 @@ test("compute on the prototype", function(){
 	equal(me.attr("first"),"Brian","set first name");
 	equal(me.attr("last"),"Moschel","set last name")
 	
+	var handler = function(ev, newVal, oldVal){
+		ok(newVal,"Brian M")
+	}
+	me.bind("fullName", handler);
 	
-})
+	me.attr("last","M")
+	
+	me.unbind("fullName", handler);
+	
+	me.attr("first","B");
+	
+});
 
 
 


### PR DESCRIPTION
If you have a "master" component with a scope value like:

``` js
scope: {
  visible: true
}
```

Pass that property to a low-level compute like:

``` html
<low-level showing='visible'></low-level>
```

If low-level has code like

``` js
this.attr('showing', true)
```

it should change the parent scope's `visible` property.
