### PR TITLE
Implement can.Mustache.safeString

### DIFF
--- a/view/mustache/mustache.js
+++ b/view/mustache/mustache.js
@@ -1689,6 +1689,52 @@ function( can ){
 		return can.view.render(partial, context/*, options*/);
 	};
 
+	/**
+   * @function can.Mustache.safeString
+   * @signature `can.Mustache.safeString(str)`
+   *
+   * @param {String} str A string you don't want to become escaped.
+   * @return {String} A string flagged by `can.Mustache` as safe, which will
+   * not become escaped, even if you use [can.Mustache.tags.unescaped](triple slash).
+   *
+   * @body
+   * If you write a helper that generates its own HTML, you will
+   * usually want to return a `can.Mustache.safeString.` In this case,
+   * you will want to manually escape parameters with `[can.esc].`
+   *
+   * @codestart
+   * can.Mustache.registerHelper('link', function(text, url) {
+   *   text = can.esc(text);
+   *   url  = can.esc(url);
+   *
+   *   var result = '&lt;a href="' + url + '"&gt;' + text + '&lt;/a&gt;';
+   *   return new can.Mustache.safeString(result);
+   * });
+   * @codeend
+   *
+   * Rendering:
+   * @codestart
+   * &lt;div&gt;{{link "Google", "http://google.com"}}&lt;/div&gt;
+   * @codeend
+   *
+   * Results in:
+   *
+   * @codestart
+   * &lt;div&gt;&lt;a href="http://google.com"&gt;Google&lt;/a&gt;&lt;/div&gt;
+   * @codeend
+   *
+   * As an anchor tag whereas if we would have just returned the result rather than a new
+   * `can.Mustache.safeString` our template would have rendered a div with the escaped anchor tag.
+   *
+   */
+  Mustache.safeString = function(str) {
+    return {
+      toString: function() {
+        return str;
+      }
+    }
+  };
+
 	Mustache.renderPartial = function(partialName,scope,options) {
 		var partial = options.attr("partials."+partialName)
 		if(partial){

--- a/view/mustache/mustache_test.js
+++ b/view/mustache/mustache_test.js
@@ -2261,6 +2261,33 @@ test("incremental updating of #each within an if", function(){
 	
 });
 
+test("can.Mustache.safeString", function() {
+  var text = "Google",
+    url = "http://google.com/",
+    templateEscape = can.view.mustache('{{link "' + text + '" "' + url + '"}}'),
+    templateUnescape = can.view.mustache('{{{link "' + text + '" "' + url + '"}}}');
+  can.Mustache.registerHelper('link', function(text, url) {
+    var link = '<a href="' + url + '">' + text + '</a>';
+    return new can.Mustache.safeString(link);
+  });
+
+  var div = document.createElement('div');
+  div.appendChild(templateEscape({}));
+
+  equal(div.children.length, 1, 'rendered a DOM node');
+  equal(div.children[0].nodeName, 'A', 'rendered an anchor tag');
+  equal(div.children[0].innerHTML, text, 'rendered the text properly');
+  equal(div.children[0].getAttribute('href'), url, 'rendered the href properly');
+
+  div = document.createElement('div');
+  div.appendChild(templateUnescape({}));
+
+  equal(div.children.length, 1, 'rendered a DOM node');
+  equal(div.children[0].nodeName, 'A', 'rendered an anchor tag');
+  equal(div.children[0].innerHTML, text, 'rendered the text properly');
+  equal(div.children[0].getAttribute('href'), url, 'rendered the href properly');
+});
+
 
 
 


### PR DESCRIPTION
This implements can.Mustache.safeString, as requested by #468, as well as provides API documentation and a test to make sure it works as expected.
