### PR TITLE
pushstate() and preventDefault() were not working on default route becau...

### DIFF
--- a/route/pushstate/pushstate.js
+++ b/route/pushstate/pushstate.js
@@ -93,7 +93,7 @@ steal('can/util', 'can/route', function(can) {
                 if( window.location.host == linksHost ) {
                     var curParams = can.route.deparam(node.pathname+node.search);
                     // if a route matches
-                    if(curParams.route) {
+                    if(curParams.hasOwnProperty('route')) {
                     	// make it possible to have a link with a hash
                     	includeHash = true;
                     	// update the data


### PR DESCRIPTION
Using hasOwnProperty() to prevent comparison of default route empty string "".

AKA.  pushstate() now works for the default route.

Here is a fiddle demonstrating it's previous behavior:
http://jsfiddle.net/marshallswain/RdEax/4/
