### PR TITLE
Allow for implicit route-definition in can.Control

### DIFF
--- a/control/route/route.js
+++ b/control/route/route.js
@@ -3,6 +3,24 @@ steal('can/util','can/route','can/control', function(can){
 	// ## control/route.js  
 	// _Controller route integration._
 	
+	var
+		// `RegExp` used to match route variables of the type ':name'.
+		// Any word character or a period is matched.
+		matcher = /\:([\w\.]+)/g,
+		// This function will replace parts of the route for up to 'max' times
+		// so you can match different lengths of routes
+		replaceParts = function (route, data, max) {
+			var max = (max && max > 0 && max) || 0,
+				count = 0;
+
+			return route.replace(matcher, function( whole, name ) {
+				if(!max || max && ++count>max) {
+					return whole;
+				}
+				return encodeURIComponent( data[name] );
+			}).replace("\\","");
+		};
+
 	can.Control.processors.route = function( el, event, selector, funcName, controller ) {
 		selector = selector || "";
 		if ( !can.route.routes[selector] ) {
@@ -10,19 +28,37 @@ steal('can/util','can/route','can/control', function(can){
 		}
 		var batchNum,
 			check = function( ev, attr, how ) {
-				if ( can.route.attr('route') === ( selector ) && 
-					( ev.batchNum === undefined || ev.batchNum !== batchNum ) ) {
-					
-					batchNum = ev.batchNum;
-					
-					var d = can.route.attr();
-					delete d.route;
-					if ( can.isFunction( controller[ funcName ] )) {
-						controller[funcName]( d );
-					} else {
-						controller[controller[funcName]](d);
+				if(ev.batchNum === undefined || ev.batchNum !== batchNum ) {
+					var data = can.route.attr(),
+						route = data.route,
+						_t, //don't call route.match twice, as this may impact performance
+						max = (route && route.match && (_t = route.match(matcher)) && _t.length) || 0,
+						matched = false;
+
+					if(can.route.routes[selector].length-1 != max) {
+						//no need to check this route.
+						// it cannot match, because it has more parts than the current selector
+						return;
 					}
 					
+					//route and current select have the same length
+					// replace every part of the route (from the left) with it's value
+					// and check the result against the selector
+					// if a match was found, there's no need to search any further
+					for(var i = 0; i <= max; i++) {
+						if(matched = (replaceParts(route, data, i) === selector)) break;
+					}
+
+					if (matched) {
+						batchNum = ev.batchNum;
+
+						delete data.route;
+						if (can.isFunction(controller[funcName])) {
+							controller[funcName](data);
+						} else {
+							controller[controller[funcName]](data);
+						}
+					}
 				}
 			};
 		can.route.bind( 'change', check );

--- a/control/route/route_test.js
+++ b/control/route/route_test.js
@@ -81,5 +81,82 @@ test("dont overwrite defaults (#474)", function(){
 	
 })
 
+test("routes with implicit matches", function () {
+	expect(8);
+
+	//setup controller, note: we're *not* using :view here
+	// but instead we bind to a specific view
+	can.Control.extend("Router1", {
+		"/r1 route" : function () {
+			ok(true, 'route updated to /r1')
+		},
+
+		"/r1/:id route" : function () {
+			ok(true, 'route updated to /r1/:id');
+		},
+
+		"/r1/:action/:id route" : function () {
+			ok(true, 'route updated to /r1/:action/:id')
+		}
+	});
+	can.Control.extend("Router2", {
+		"/r2 route" : function () {
+			ok(true, 'route updated to /r2')
+		},
+
+		"/r2/:id route" : function () {
+			ok(true, 'route updated to /r2/:id');
+		},
+
+		"/r2/action1/:id route" : function () {
+			ok(true, 'route updated to /r2/action1/:id')
+		},
+
+		"/r2/action2/:id route" : function () {
+			ok(true, 'route updated to /r2/action2/:id')
+		},
+
+		"/r2/action3/:id route" : function () {
+			ok(false, 'route was not updated to /r2/action3/:id')
+		}
+	});
+
+	can.route('/:view');
+	can.route('/:view/:id');
+	can.route('/:view/:action/:id');
+
+	// init controller
+	var router1 = new Router1(document.body),
+		router2 = new Router2(document.body);
+
+	window.location.hash = '!/r1';
+	can.trigger(window, 'hashchange');
+
+	window.location.hash = '!/r1/id1';
+	can.trigger(window, 'hashchange');
+
+	window.location.hash = '!/r1/action1/id1';
+	can.trigger(window, 'hashchange');
+
+	window.location.hash = '!/r1/action2/id1';
+	can.trigger(window, 'hashchange');
+
+	window.location.hash = '!/r2';
+	can.trigger(window, 'hashchange');
+
+	window.location.hash = '!/r2/id2';
+	can.trigger(window, 'hashchange');
+
+	window.location.hash = '!/r2/action1/id2';
+	can.trigger(window, 'hashchange');
+
+	window.location.hash = '!/r2/action2/id2';
+	can.trigger(window, 'hashchange');
+
+	router1.destroy();
+	router2.destroy();
+
+});
+
 
 })();


### PR DESCRIPTION
This change will allow for way easier organization of multiple controls. Instead of binding every control to `/:view/:action`, you can now bind specific routes that still are matched through the default `/:view/:action/:id` route.
This allows very easy control-segmentation (one control only occupies the routes that are specifically defined for it) while also allowing to "extract" the parameters via `route.attr('view')` and alike.

Quick example:

``` javascript
    can.Control.extend("Router1", {
        "/r1 route" : function () {
            console.log('route updated to /r1')
        },

        "/r1/:id route" : function () {
            console.log('route updated to /r1/:id');
        },

        "/r1/:action/:id route" : function () {
            console.log('route updated to /r1/:action/:id')
        }
    });
    can.Control.extend("Router2", {
        "/r2 route" : function () {
            console.log('route updated to /r2')
        },

        "/r2/:id route" : function () {
            console.log('route updated to /r2/:id');
        },

        "/r2/action1/:id route" : function () {
            console.log('route updated to /r2/action1/:id')
        },

        "/r2/action2/:id route" : function () {
            console.log('route updated to /r2/action2/:id')
        },

        "/r2/action3/:id route" : function () {
            console.log('route updated to /r2/action3/:id')
        }
    });
    can.route('/:view');
    can.route('/:view/:id');
    can.route('/:view/:action/:id');
```

What do you think, would it make sense to allow for this kind of rules? The patches should not break any existing tests (they don't locally), but I do know this is probably not the most performant way to implement it.

Would you be open to a feature like this anyway?
I was not able to achieve similar behavior using only can.route+can.Map.delegate, it would have been way more complex, so brute-force-trying every possible match seems not too bad to me.
