### PR TITLE
Added test for _cid added to original object

### DIFF
--- a/map/map_test.js
+++ b/map/map_test.js
@@ -102,4 +102,12 @@ test('Getting attribute that is a can.compute should return the compute and not 
 	equal(map.attr('time'), compute, '.attr() call of time is compute');
 })
 
+test('_cid add to original object', function() {
+	var map = new can.Map(),
+		obj = {'name': 'thecountofzero'};
+
+	map.attr('myObj', obj);
+	ok(!obj._cid, '_cid not added to original object');
+})
+
 })();


### PR DESCRIPTION
It seems _cid is being added to the original object when it is added to a can.Map
