### PR TITLE
fixes for jQuery's inserted event and some quick inserted helpers

### DIFF
--- a/util/inserted/inserted_test.js
+++ b/util/inserted/inserted_test.js
@@ -1,0 +1,20 @@
+(function(){
+	
+	module("can/util/inserted")
+	
+	if(window.jQuery){
+		test("jquery", function(){
+			
+			var el = $("<div>");
+			
+			el.bind("inserted", function(){
+				ok(true,"inserted called")
+			})
+			
+			$("#qunit-test-area").append(el)
+			
+			
+		})
+	}
+	
+})()

--- a/util/inserted/test.html
+++ b/util/inserted/test.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+	<link rel="stylesheet" type="text/css" href="../../lib/qunit/qunit.css"/>
+</head>
+<body>
+<h1 id="qunit-header">inserted Test Suite</h1>
+
+<h2 id="qunit-banner"></h2>
+
+<div id="qunit-testrunner-toolbar"></div>
+<h2 id="qunit-userAgent"></h2>
+<ol id="qunit-tests"></ol>
+<div id="qunit-test-area"></div>
+
+<script type="text/javascript" src="../../lib/steal/steal.js"></script>
+<script type="text/javascript" src="../../lib/qunit/qunit.js"></script>
+<script type="text/javascript">
+	QUnit.config.autostart = false;
+	steal("can/util").then("can/test", "can/util/inserted/inserted_test.js", function() {
+		QUnit.start();
+	});
+</script>
+</body>
+</html>


### PR DESCRIPTION
Feature detects which argument domManip uses.  I tested this against 2.0.3, 1.10.2, and 1.9.1.  However, this needs automated tests added by @daffl 
