### PR TITLE
Update pushstate.js ( Fix for firefox push/replacestate override problem...

### DIFF
--- a/route/pushstate/pushstate.js
+++ b/route/pushstate/pushstate.js
@@ -45,25 +45,14 @@ steal('can/util', 'can/route', function(can) {
                 can.delegate.call(can.$(document.documentElement),'a', 'click', anchorClickFix);
                 
                 // popstate only fires on back/forward.
-		        // To detect when someone calls push/replaceState, we need to wrap each method.
-		        can.each(['pushState','replaceState'],function(method) {
-		            originalMethods[method] = window.history[method];
-		            window.history[method] = function(state) {
-		                var result = originalMethods[method].apply(window.history, arguments);
-		                can.route.setState();
-		                return result;
-		            };
-		        });
-		        
+		        // To detect when someone calls push/replaceState, we need to wrap each method. Not really needed, as listeners for click are existing
+
 		        // Bind to popstate for back/forward
 		        can.bind.call(window, 'popstate', can.route.setState);
             },
 	        unbind: function(){
         		can.undelegate.call(can.$(document.documentElement),'click', 'a', anchorClickFix);
         	
-            	can.each(['pushState','replaceState'],function(method) {
-		            window.history[method] = originalMethods[method];
-		        });
             	can.unbind.call(window, 'popstate', can.route.setState);
             },
 	        matchingPartOfURL: function(){
@@ -98,6 +87,7 @@ steal('can/util', 'can/route', function(can) {
                     	includeHash = true;
                     	// update the data
                     	window.history.pushState(null, null, node.href);
+                    	can.route.setState();
                     	// test if you can preventDefault
                     	// our tests can't call .click() b/c this
                     	// freezes phantom


### PR DESCRIPTION
...)

Hi I was using canjs with new pushstate functionality. All is working well in chrome / opera but not in firefox. The browser stopped listening to url changes all of the sudden after a couple of seconds of inactivity. The most bizzare situation which I am still not familiar with was when I changed any map property with attr the setState was called, otherwise not.

Anyway I deleted the push/replacestate override and call the setState in the click handler.