### PR TITLE
test for inserted event bug

### DIFF
--- a/component/component_test.js
+++ b/component/component_test.js
@@ -805,5 +805,33 @@ test("scope not rebound correctly (#550)", function(){
 	equal(nameChanges, 2)
 })
 
-	
+test("inserted event fires more than once", function(){
+
+    var inited = 0,
+        inserted = 0
+
+    can.Component({
+        tag: 'my-inserted',
+
+        scope: {
+            init: function(){
+                inited++
+                console.log('scope init')
+            }
+        },
+        events: {
+            'inserted': function() {
+                inserted++
+                console.log('inserted')
+            }
+        }
+    });
+
+    $('body').append(can.view.mustache("<my-inserted></my-inserted>"));
+
+    equal(inited, 1)
+    equal(inserted, 1)
+})
+
+
 })()

--- a/component/test.html
+++ b/component/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="..///code.jquery.com/qunit/qunit-1.12.0.css"/>
+	<link rel="stylesheet" type="text/css" href="http://code.jquery.com/qunit/qunit-1.12.0.css"/>
 	<style>.active {
 		border: solid 1px red;
 	}</style>
@@ -17,7 +17,7 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../lib/steal/steal.js"></script>
-<script type="text/javascript" src="..///code.jquery.com/qunit/qunit-1.12.0.js"></script>
+<script type="text/javascript" src="http://code.jquery.com/qunit/qunit-1.12.0.js"></script>
 <script type="text/javascript">
 	QUnit.config.autostart = false;
 	steal("can/component").then("can/component/component_test.js", function() {


### PR DESCRIPTION
This test shows that when can.Component is inserted into DOM "inserted" event fires twice.
