### PR TITLE
test for component content extension stack overflow bug

### DIFF
--- a/component/component_test.js
+++ b/component/component_test.js
@@ -805,5 +805,33 @@ test("scope not rebound correctly (#550)", function(){
 	equal(nameChanges, 2)
 })
 
+
+test("content extension stack overflow error", function(){
+
+    can.Component({
+        tag: 'more-extended-feature',
+        template: '<extended-feature>even more</extended-feature>'
+        //template: '<div>here is more</div>'
+    })
+
+    can.Component({
+        tag: 'extended-feature',
+        template: '<some-feature>extended <content></content></some-feature>'
+            //<content></content>
+        //template: '<div>extended: <content></content></div>'
+    })
+
+    can.Component({
+        tag: 'some-feature',
+        template: 'content <content></content>'
+    })
+
+    // currently causes Maximum call stack size exceeded
+    var template = can.view.mustache("<more-extended-feature></more-extended-feature>");
+    var frag = template();
+
+    equal(frag.childNodes[0].childNodes[0].childNodes[0].innerHTML, 'content extended even more')
+
+})
 	
 })()

--- a/component/test.html
+++ b/component/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="..///code.jquery.com/qunit/qunit-1.12.0.css"/>
+	<link rel="stylesheet" type="text/css" href="http://code.jquery.com/qunit/qunit-1.12.0.css"/>
 	<style>.active {
 		border: solid 1px red;
 	}</style>
@@ -17,7 +17,7 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../lib/steal/steal.js"></script>
-<script type="text/javascript" src="..///code.jquery.com/qunit/qunit-1.12.0.js"></script>
+<script type="text/javascript" src="http://code.jquery.com/qunit/qunit-1.12.0.js"></script>
 <script type="text/javascript">
 	QUnit.config.autostart = false;
 	steal("can/component").then("can/component/component_test.js", function() {


### PR DESCRIPTION
The test shows that when component supposed to extend other component's content and contains <content/> tag in template, it causes Maximum call stack size exceeded error in client browser.
