### PR TITLE
Functions globally defined when it shouldn't be

### DIFF
--- a/map/map.js
+++ b/map/map.js
@@ -70,7 +70,7 @@ steal('can/util','can/util/bind','can/construct', 'can/util/batch',function(can,
 				}
 			}
 			return teardown;
-		};
+		},
 		teardownMap = function(){
 			for(var cid in madeMap){
 				if(madeMap[cid].added) {
@@ -81,7 +81,7 @@ steal('can/util','can/util/bind','can/construct', 'can/util/batch',function(can,
 		},
 		getMapFromObject = function(obj){
 			return madeMap && madeMap[obj._cid] && madeMap[obj._cid].instance
-		}
+		};
 	/**
 	 * @add can.Map
 	 */

--- a/model/model.js
+++ b/model/model.js
@@ -206,7 +206,7 @@ steal('can/util','can/map', 'can/list',function( can ) {
 					return model;
 				}
 			}
-		}
+		},
 		
 		
 	// This object describes how to make an ajax request for each ajax method.  
@@ -833,7 +833,7 @@ steal('can/util','can/map', 'can/list',function( can ) {
 				// Return the ajax method with `data` and the `type` provided.
 				return ajax(str || this[ajaxMethod.url || "_url"], data, ajaxMethod.type || "get")
 			}
-		}
+		};
 
 
 	

--- a/view/live/live.js
+++ b/view/live/live.js
@@ -51,7 +51,7 @@ steal('can/util', 'can/view/elements.js','can/view','can/view/node_lists.js',
 		// Breaks up a string like foo='bar' into ["foo","'bar'""]
 		getAttributeParts = function(newVal){
 			return (newVal|| "").replace(/['"]/g, '').split('=')
-		}
+		},
 		// #### insertElementsAfter
 		// Appends elements after the last item in oldElements.
 		insertElementsAfter = function(oldElements, newFrag){

--- a/view/render.js
+++ b/view/render.js
@@ -57,7 +57,7 @@ var pendingHookups = [],
 	};
 
 
-var current;
+var current, lastHookups;
 
 can.extend(can.view, {
 	live: live,


### PR DESCRIPTION
The functions `updateList` and `teardownList` are meant to be local variables in this context but are added to the window due to not being declared. Causes hard to track down issues when you have multiple lists being bound at the time same time.
