### PR TITLE
undefined list passed to {{#each}}

### DIFF
--- a/view/mustache/mustache.js
+++ b/view/mustache/mustache.js
@@ -1890,6 +1890,10 @@ function( can ){
 		 *     </ul>
 		 */
 		'each': function(expr, options) {
+			if(!expr) {
+				return;
+			}
+
 			if(expr.isComputed || isObserveLike(expr) && typeof expr.attr('length') !== 'undefined'){
 				return can.view.lists && can.view.lists(expr, function(item, key) {
 					// Create a compute that listens to whenever the index of the item in our list changes.

--- a/view/mustache/mustache_test.js
+++ b/view/mustache/mustache_test.js
@@ -2585,4 +2585,13 @@ test('html comments must not break mustache scanner', function(){
 	});	
 })
 
+test("{{each}} does not error with undefined list (#602)", function() {
+	var renderer = can.view.mustache('<div>{{#each data}}{{name}}{{/each}}</div>');
+
+	equal(renderer.render({}), '<div></div>', 'Empty text rendered');
+	equal(renderer.render({ data: false }), '<div></div>', 'Empty text rendered');
+	equal(renderer.render({ data: null }), '<div></div>', 'Empty text rendered');
+	equal(renderer.render({ data: [ { name: 'David' }] }), '<div>David</div>', 'Expected name rendered');
+});
+
 })();


### PR DESCRIPTION
If undefined is passed to `{#each}}`, it errors.  It needs to be fine with getting nothing.
