### PR TITLE
Serialization

### DIFF
--- a/model/queue/queue.js
+++ b/model/queue/queue.js
@@ -23,7 +23,7 @@ steal('can/util', 'can/model', 'can/map/backup', function(can){
 
 			var def          = new can.Deferred,
 				self         = this,
-				attrs        = this.attr(),
+				attrs        = this.serialize(),
 				queue        = this._requestQueue,
 				changedAttrs = this._changedAttrs,
 				reqFn, index;

--- a/model/queue/queue_test.js
+++ b/model/queue/queue_test.js
@@ -175,6 +175,30 @@ test("id will be set correctly, although update data is serialized before create
 	stop();
 
 
+});
+
+test("queue uses serialize (#611)", function(){
+	
+	can.fixture("POST /mymodel", function(request){
+		equal(request.data.foo,"bar");
+		start();
+	})
+	
+	var MyModel = can.Model.extend({
+		create: "/mymodel"
+	},{
+		serialize: function(){
+			return {
+				foo:"bar"
+			}
+		}
+	});
+	
+	stop();
+	new MyModel().save();
+	
 })
+
+
 
 })();


### PR DESCRIPTION
can.Model doesn't use serialize object while saving and using can.Model.Queue plugin
