### PR TITLE
restore will not remove properties that were added since the last backup

### DIFF
--- a/map/backup/backup.js
+++ b/map/backup/backup.js
@@ -1,10 +1,12 @@
 //allows you to backup and restore a map instance
 steal('can/util', 'can/map', 'can/util/object', function (can) {
-	var flatProps = function (a) {
+	var flatProps = function (a, cur) {
 		var obj = {};
 		for (var prop in a) {
 			if (typeof a[prop] !== 'object' || a[prop] === null || a[prop] instanceof Date) {
 				obj[prop] = a[prop]
+			} else {
+				obj[prop] = cur.attr(prop)
 			}
 		}
 		return obj;
@@ -193,10 +195,12 @@ steal('can/util', 'can/map', 'can/util/object', function (can) {
 		 * _change_, _add_, and _set_) as if the values of the properties had been set using `[can.Map.prototype.attr attr]`.
 		 */
 		restore : function (restoreAssociations) {
-			var props = restoreAssociations ? this._backupStore : flatProps(this._backupStore)
+			var props = restoreAssociations ? 
+				this._backupStore : 
+				flatProps(this._backupStore, this)
 
 			if (this.isDirty(restoreAssociations)) {
-				this._attrs(props);
+				this._attrs(props, true);
 			}
 
 			return this;

--- a/map/backup/backup_test.js
+++ b/map/backup/backup_test.js
@@ -117,4 +117,25 @@ test("backup restore nested observables", function() {
 	equal(observe.attr('nested').attr('test'), 'property', 'Nested object got restored');
 });
 
+test("backup removes properties that were added (#607)", function(){
+	
+	var map = new can.Map({});
+	
+	map.backup();
+	
+	map.attr("foo","bar")
+	
+	ok( map.isDirty(), "the map with an additional property is dirty");
+	
+	map.restore();
+	
+	ok(! map.attr("foo"), "there is no foo property")
+	
+	
+	
+	
+})
+
+
+
 })();


### PR DESCRIPTION
restore will not remove properties that were added since the last backup

Per http://canjs.com/docs/can.Map.backup.prototype.restore.html

This is never the behavior I would want from backup/restore.  In restore, `this._attrs(props);` could be called with 'true' as the second argument to remove new properties, and that could be an optional attribute on restore.
