### PR TITLE
template files relative to requirejs baseUrl

### DIFF
--- a/view/view.js
+++ b/view/view.js
@@ -559,13 +559,18 @@ steal("can/util", function( can ) {
 			// Convert to a unique and valid id.
 			id = $view.toId(url);
 	
-			// If an absolute path, use `steal` to get it.
-			// You should only be using `//` if you are using `steal`.
+			// If an absolute path, use `steal`/`require` to get it.
+			// You should only be using `//` if you are using an AMD loader like `steal` or `require` (not almond).
 			if ( url.match(/^\/\//) ) {
-				var sub = url.substr(2);
-				url = ! window.steal ? 
-					sub :
-					steal.config().root.mapJoin(""+steal.id(sub));
+				url = url.substr(2);
+				url = !window.steal ? 
+					url :  
+					steal.config().root.mapJoin(""+steal.id(url));
+			}
+			
+			// Localize for `require` (not almond)
+			if (window.require) {
+				if (require.toUrl) url = require.toUrl(url);
 			}
 	
 			// Set the template engine type.

--- a/view/view_test.js
+++ b/view/view_test.js
@@ -733,9 +733,15 @@
 		
 	})
 	
-	
-	
-	
-	
+	if (window.require) {
+		if (window.require.config && window.require.toUrl) {
+			test("template files relative to requirejs baseUrl (#647)", function() {
+				var oldBaseUrl = requirejs.s.contexts._.config.baseUrl;
+				require.config({ baseUrl:"/view/test/" });
+				ok( can.isFunction( can.view("template") ) );
+				require.config({ baseUrl:oldBaseUrl });
+			});
+		}
+	}
 	
 })();


### PR DESCRIPTION
Adds support for relative URLs in templates loaded with RequireJS. Allows us to work with custom `baseUrl`s in `require.config()`. For development environments only, but it's not necessary for production if using can-compile.
