### PR TITLE
routed links must descend from pushstate root

### DIFF
--- a/route/pushstate/pushstate.js
+++ b/route/pushstate/pushstate.js
@@ -91,18 +91,24 @@ steal('can/util', 'can/route', function(can) {
                 var linksHost = node.host || window.location.host;
                 // if link is within the same domain
                 if( window.location.host == linksHost ) {
-                    var curParams = can.route.deparam(node.pathname+node.search);
-                    // if a route matches
-                    if(curParams.hasOwnProperty('route')) {
-                    	// make it possible to have a link with a hash
-                    	includeHash = true;
-                    	// update the data
-                    	window.history.pushState(null, null, node.href);
-                    	// test if you can preventDefault
-                    	// our tests can't call .click() b/c this
-                    	// freezes phantom
-                    	e.preventDefault && e.preventDefault();
-                	}
+                    // if link is a descendant of `root`
+                    var root = can.route._call("root");
+                    if (node.pathname.indexOf(root) == 0) {
+                    	// remove `root` from url
+                    	var url = (node.pathname+node.search).substr(root.length);
+                        var curParams = can.route.deparam(url);
+                        // if a route matches
+                        if(curParams.hasOwnProperty('route')) {
+                        	// make it possible to have a link with a hash
+                        	includeHash = true;
+                        	// update the data
+                        	window.history.pushState(null, null, node.href);
+                        	// test if you can preventDefault
+                        	// our tests can't call .click() b/c this
+                        	// freezes phantom
+                        	e.preventDefault && e.preventDefault();
+                    	}
+                    }
                 }
         	}
 		},

--- a/route/pushstate/pushstate_test.js
+++ b/route/pushstate/pushstate_test.js
@@ -451,6 +451,96 @@ if(window.history && history.pushState) {
 			can.$("#qunit-test-area")[0].appendChild(iframe);
 		});
 
+		test("routed links must descend from pushstate root (#652)", function() {
+			stop();
+			var runs=0, testIndex=-1, linkIndex,timeout,iframe;
+			
+			iframe = document.createElement("iframe");
+			iframe.src = can.test.path("route/pushstate/testing.html");
+			can.$("#qunit-test-area")[0].appendChild(iframe);
+			
+			window.routeTestReady = function(iCanRoute, loc, hist, win) {
+				var tests = [
+					"/app/",
+					"/app/something/"
+				];
+				
+				var links = [
+					{
+						element:		addLink("/app/something/test/"),
+						test0_expect:	{section:"something", sub:"test", route:":section/:sub/"},
+						test1_expect:	{section:"test", route:":section/"}
+					},
+					{
+						element:		addLink("/app/test/"),
+						test0_expect:	{section:"test", route:":section/"},
+						test1_expect:	{}
+					},
+					{
+						element:		addLink("/test/"),
+						test0_expect:	{},
+						test1_expect:	{}
+					}
+				];
+				
+				win.can.route(":section/");
+				win.can.route(":section/:sub/");
+				
+				// if called after a redirect (non-route)
+				if (++runs > 1) {
+					// go back to test route
+					win.history.pushState(null,null, tests[testIndex]);
+					nextLink();
+				}
+				else nextTest();
+				
+				function addLink(href) {
+					var link = win.document.createElement("a");
+					link.href = href;
+					win.document.body.appendChild(link);
+					return win.can.$(link);
+				}
+				
+				function nextLink() {
+					if (++linkIndex < links.length) {
+						var link = links[linkIndex];
+						// if not routed (page change) .. non-jquery needs this
+						iframe.onload = function() {
+							this.onload = null;
+							clearTimeout(timeout);
+							// there is no route
+							deepEqual( {}, link["test"+testIndex+"_expect"] );
+							// go back to original url
+							win.location.href = iframe.getAttribute("src");
+							// window.routeTestReady gets called again
+						}
+						// if routed
+						timeout = setTimeout( function() {
+							deepEqual( can.extend({},win.can.route.attr()), link["test"+testIndex+"_expect"] );
+							// go back to test route
+							win.history.pushState(null,null, tests[testIndex]);
+							nextLink();
+						},1500);
+						win.can.trigger(link.element, "click");
+					} else {
+						nextTest();
+					}
+				}
+				
+				function nextTest() {
+					if (++testIndex < tests.length) {
+						win.can.route.bindings.pushstate.root = tests[testIndex];
+						win.can.route.ready();
+						linkIndex = -1;
+						nextLink();
+					} else {
+						can.remove( can.$(iframe) );
+						start();
+					}
+				}
+			}
+		});
+
 	}
 
 	test("empty default is matched even if last", function(){


### PR DESCRIPTION
If we have:

``` javascript
can.route.bindings.pushstate.root = "/bitovi/src/app/";
```

and a link like:

``` html
<a href="/bitovi/test/"></a>
```

When that link is clicked on, it will call `ev.preventDefault()` and do a `pushState()` instead of letting the link behave normally.

---

Additionally, if we have the same `root` listed above and:

``` html
<a href="/bitovi/src/app/test/"></a>
<!-- or -->
<a href="test/"></a>
```

`can.route.deparam` treats "/bitovi/src/app/" (the `root`) as part of the route when it shouldn't.
