### PR TITLE
Fixing variable format so it doesn't break Steal build

### DIFF
--- a/view/scope/scope.js
+++ b/view/scope/scope.js
@@ -19,10 +19,10 @@ steal('can/util','can/construct','can/map','can/list','can/view','can/compute',f
 		escapeDotReg = /\\\./g,
 		getNames = function(attr){
 			var names = [], last = 0;
-			attr.replace(escapeReg, function(foo, bar, index) {
-				if (!bar) {
+			attr.replace(escapeReg, function(first, second, index) {
+				if (!second) {
 					names.push(attr.slice(last, index).replace(escapeDotReg,'.'));
-					last = index + foo.length;
+					last = index + first.length;
 				}
 			});
 			names.push(attr.slice(last).replace(escapeDotReg,'.'));


### PR DESCRIPTION
I don't think env.js likes the format of the variables and it causes the build to fail.
