### PR TITLE
Fixes a memory leak with live binding.

### DIFF
--- a/view/live/live.js
+++ b/view/live/live.js
@@ -382,15 +382,10 @@ steal('can/util', 'can/view/elements.js','can/view','can/view/node_lists',
 				node = document.createTextNode( compute() );
 			
 			// Replace the placeholder with the live node and do the nodeLists thing.
-			live.replace([el], node,  data.teardownCheck  );
+			// Add that node to nodeList so we can remove it when the parent element is removed from the page
+			data.nodeList = live.replace([el], node,  data.teardownCheck  );
 		},
-		/**
-		 * @function can.view.live.text
-		 * @parent can.view.live
-		 * 
-		 * Replaces one element with some content while keeping [can.view.live.nodeLists nodeLists] data
-		 * correct.
-		 */
+
 		attributes: function(el, compute, currentValue){
 			var setAttrs = function(newVal){
 				var parts = getAttributeParts(newVal),

--- a/view/live/live_test.js
+++ b/view/live/live_test.js
@@ -218,7 +218,38 @@
 		
 		var spans = div.getElementsByTagName('span')
 		equal(spans.length, 3, "there are 3 spans");
+	});
+	
+	test("text binding is memory safe (#666)", function(){
+		
+		// clear nodeMap because other tests setup live binding but never
+		// insert their elements the binding is never torn down
+		
+		can.view.nodeLists.nodeMap = {};
+		
+		var div = document.createElement('div'),
+			span = document.createElement('span'),
+			el = can.$(div),
+			text = can.compute(function(){
+				return "foo"
+			})
+
+		div.appendChild(span)
+		
+		can.$("#qunit-test-area")[0].appendChild(div);
+		
+		can.view.live.text(span,text, div)
+		
+		can.remove(el)
+		stop()
+		setTimeout(function(){
+			ok(can.isEmptyObject( can.view.nodeLists.nodeMap), "nothing in nodeMap");
+			start();
+		},100)
+		
 	})
+	
+	
 	
 
 })();


### PR DESCRIPTION
fixes #666 by registering the nodeList to be removed when the parent element is torn down
