### PR TITLE
can-value in checkboxes in IE7

### DIFF
--- a/component/component_test.js
+++ b/component/component_test.js
@@ -872,4 +872,28 @@ test("inserted event fires twice if component inside live binding block", functi
     equal(inserted, 1)
 });
 
+test("checkboxes with can-value bind properly (#628)", function() {
+	can.Component({
+		tag: 'checkbox-value',
+		template: '<input type="checkbox" can-value="completed"/>'
+	});
+
+	var data = new can.Map({ completed: true }),
+		frag = can.view.mustache("<checkbox-value></checkbox-value>")(data);
+  can.append( can.$("#qunit-test-area") , frag );
+	
+	var input = can.$("#qunit-test-area")[0].getElementsByTagName('input')[0];
+	equal(input.checked, data.attr('completed'), 'checkbox value bound (via attr check)');
+	data.attr('completed', false);
+	equal(input.checked, data.attr('completed'), 'checkbox value bound (via attr uncheck)');
+	input.checked = true;
+	can.trigger(input, 'change');
+	equal(input.checked, true, 'checkbox value bound (via check)');
+	equal(data.attr('completed'), true, 'checkbox value bound (via check)');
+	input.checked = false;
+	can.trigger(input, 'change');
+	equal(input.checked, false, 'checkbox value bound (via uncheck)');
+	equal(data.attr('completed'), false, 'checkbox value bound (via uncheck)');
+});
+
 })()

--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -1,6 +1,9 @@
 steal("can/util","can/view/mustache", "can/control", function(can){
 	
-	
+	// IE < 8 doesn't support .hasAttribute, so feature detect it.
+	var hasAttribute = function(el, name) {
+		return el.hasAttribute ? el.hasAttribute(name) : el.getAttribute(name) !== null;
+	};
 	
 	/**
 	 * @function can.view.bindings.can-value can-value
@@ -63,12 +66,12 @@ steal("can/util","can/view/mustache", "can/control", function(can){
 		
 		if(el.nodeName.toLowerCase() === "input"){
 			if(el.type === "checkbox") {
-				if( el.hasAttribute("can-true-value") ) {
+				if( hasAttribute(el, "can-true-value") ) {
 					var trueValue = data.scope.compute( el.getAttribute("can-true-value") )
 				} else {
 					var trueValue = can.compute(true)
 				}
-				if( el.hasAttribute("can-false-value") ) {
+				if( hasAttribute(el, "can-false-value") ) {
 					var falseValue = data.scope.compute( el.getAttribute("can-false-value") )
 				} else {
 					var falseValue = can.compute(false)


### PR DESCRIPTION
throws a error in bindings.js on line 75 because IE7 doesnt support hasAttribute
