### PR TITLE
#686 - Fix document.contains issue on Android

### DIFF
--- a/util/inserted/inserted.js
+++ b/util/inserted/inserted.js
@@ -10,7 +10,7 @@ steal('can/util/can.js',function (can) {
 		for ( var i = 0, elem; (elem = elems[i]) !== undefined; i++ ) {
 			if( !inDocument ) {
 				if( elem.getElementsByTagName ){
-					if( can.has( can.$(document) , elem ).length ) {
+					if( can.has( can.$(document.body) , elem ).length ) {
 						inDocument = true;
 					} else {
 						return;


### PR DESCRIPTION
Here is the fix for the issue #686 which prevent can.js to be usable on Android (at least with Zepto)
