### PR TITLE
Android - document.contains

### DIFF
--- a/util/inserted/inserted.js
+++ b/util/inserted/inserted.js
@@ -6,11 +6,13 @@ steal('can/util/can.js',function (can) {
 		elems = can.makeArray(elems);
 		var inDocument = false,
 			checked = false,
+			// Not all browsers implement document.contains (Android)
+			doc = can.$(document.contains ? document : document.body),
 			children;
 		for ( var i = 0, elem; (elem = elems[i]) !== undefined; i++ ) {
 			if( !inDocument ) {
 				if( elem.getElementsByTagName ){
-					if( can.has( can.$(document.body) , elem ).length ) {
+					if( can.has( doc , elem ).length ) {
 						inDocument = true;
 					} else {
 						return;


### PR DESCRIPTION
util/inserted/inserted.js provide can.inserted which checks if the given elements belong to the document DOM tree.

This rely on can.has which itself rely on the DOM library (zepto, jquery....) which rely on browser contains native method (at least for zepto).

document.contains isn't provided by android stock browser and so, can.inserted fails and so can.view can't render.

I assume it would be better to check on document.body instead of document.
It's possible to use contains from document.childNodes, so this contains check will also works over HTML (document.childNodes[1]), even if I don't see much interest to check in full HTML fragment.
