### PR TITLE
can.List.Map documentation

### DIFF
--- a/list/list.js
+++ b/list/list.js
@@ -44,7 +44,7 @@ steal("can/util","can/map", function(can, Map){
 		 * 
 		 *     User.List = can.List.extend({
 		 *       Map: User
-		 *     });
+		 *     }, {});
 		 * 
 		 *     var list = new User.List();
 		 *     list.push({first: "Justin", last: "Meyer"});


### PR DESCRIPTION
The can.List.Map example do not work.

The Map type is passed in the instanceProperties instead of the  staticProperties.

User.List = can.List.extend({
  Map: User
});

It should be :
User.List = can.List.extend({
  Map: User
}, {});
