### PR TITLE
Fix for incorrect ignore attributes pattern

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -1,6 +1,6 @@
 steal("can/util","can/control","can/observe","can/view/mustache","can/view/bindings",function(can){
 	
-	var ignoreAttributesRegExp = /dataViewId|class|id/i
+	var ignoreAttributesRegExp = /^(dataViewId|class|id)$/i
 	/**
 	 * @add can.Component
 	 */


### PR DESCRIPTION
``` javascirpt
var ignoreAttributesRegExp = /dataViewId|class|id/i
```

 matches all words that contain id/class letters, not the whole words

``` javascript
/^(dataViewId|class|id)$/i 
```

fixes things.
