### PR TITLE
Live binding attribute in a truthy section does not work

### DIFF
--- a/component/component_test.js
+++ b/component/component_test.js
@@ -1,4 +1,4 @@
-steal("can/component", function(){
+steal("can/component", function () {
 	module('can/component', {
 		setup: function () {
 			can.remove(can.$('#qunit-test-area>*'));

--- a/compute/compute_test.js
+++ b/compute/compute_test.js
@@ -1,4 +1,4 @@
-steal("can/compute", "can/test", function() {
+steal("can/compute", "can/test", function () {
 	module('can/compute');
 	test('single value compute', function () {
 		var num = can.compute(1);

--- a/construct/construct_test.js
+++ b/construct/construct_test.js
@@ -1,4 +1,4 @@
-steal('can/construct', function() {
+steal('can/construct', function () {
 	/* global Foo, Car, Bar */
 	module('can/construct', {
 		setup: function () {

--- a/construct/proxy/proxy_test.js
+++ b/construct/proxy/proxy_test.js
@@ -1,4 +1,4 @@
-steal("can/construct/proxy", "can/control", function() {
+steal("can/construct/proxy", "can/control", function () {
 	/* global Car */
 	var isSteal = typeof steal !== 'undefined';
 	module('can/construct/proxy');

--- a/construct/super/super_test.js
+++ b/construct/super/super_test.js
@@ -1,4 +1,4 @@
-steal("can/construct/super", function() {
+steal("can/construct/super", function () {
 	module('can/construct/super');
 	test('prototype super', function () {
 		var A = can.Construct({

--- a/control/control_test.js
+++ b/control/control_test.js
@@ -230,8 +230,8 @@ steal("can/control", function () {
 			}
 		});
 		var item1 = bindable({
-				id: 1
-			}),
+			id: 1
+		}),
 			item2 = bindable({
 				id: 2
 			}),
@@ -278,11 +278,11 @@ steal("can/control", function () {
 	});
 	test('Multiple calls to destroy', 2, function () {
 		var Control = can.Control({
-				destroy: function () {
-					ok(true);
-					can.Control.prototype.destroy.call(this);
-				}
-			}),
+			destroy: function () {
+				ok(true);
+				can.Control.prototype.destroy.call(this);
+			}
+		}),
 			div = document.createElement('div'),
 			c = new Control(div);
 		c.destroy();

--- a/control/modifier/modifier_test.js
+++ b/control/modifier/modifier_test.js
@@ -1,5 +1,5 @@
 steal('can/util', 'can/control/modifier', function (can) {
-	if(!window.jQuery) {
+	if (!window.jQuery) {
 		return;
 	}
 

--- a/control/plugin/plugin_test.js
+++ b/control/plugin/plugin_test.js
@@ -1,5 +1,5 @@
-steal("can/control/plugin", function() {
-	if(!window.jQuery) {
+steal("can/control/plugin", function () {
+	if (!window.jQuery) {
 		return;
 	}
 

--- a/list/list_test.js
+++ b/list/list_test.js
@@ -1,4 +1,4 @@
-steal("can/util", "can/list", "can/test", function() {
+steal("can/util", "can/list", "can/test", function () {
 	module('can/list');
 	test('list attr changes length', function () {
 		var l = new can.List([
@@ -11,11 +11,11 @@ steal("can/util", "can/list", "can/test", function() {
 	});
 	test('list splice', function () {
 		var l = new can.List([
-				0,
-				1,
-				2,
-				3
-			]),
+			0,
+			1,
+			2,
+			3
+		]),
 			first = true;
 		l.bind('change', function (ev, attr, how, newVals, oldVals) {
 			equal(attr, '1');
@@ -128,10 +128,10 @@ steal("can/util", "can/list", "can/test", function() {
 	});
 	test('Array accessor methods', 11, function () {
 		var l = new can.List([
-				'a',
-				'b',
-				'c'
-			]),
+			'a',
+			'b',
+			'c'
+		]),
 			sliced = l.slice(2),
 			joined = l.join(' | '),
 			concatenated = l.concat([

--- a/map/attributes/attributes_test.js
+++ b/map/attributes/attributes_test.js
@@ -1,5 +1,5 @@
 /*jshint undef:false,unused:false*/
-steal("can/map/attributes", "can/model", "can/util/fixture", "can/test", function() {
+steal("can/map/attributes", "can/model", "can/util/fixture", "can/test", function () {
 	module('can/map/attributes');
 	test('literal converters and serializes', function () {
 		can.Map('Task1', {
@@ -307,12 +307,12 @@ steal("can/map/attributes", "can/model", "can/util/fixture", "can/test", functio
 	});
 	test('Default converters and boolean fix (#247)', function () {
 		var MyObserve = can.Map({
-				attributes: {
-					enabled: 'boolean',
-					time: 'date',
-					age: 'number'
-				}
-			}, {}),
+			attributes: {
+				enabled: 'boolean',
+				time: 'date',
+				age: 'number'
+			}
+		}, {}),
 			obs = new MyObserve({
 				enabled: 'false',
 				time: 1358980553275,

--- a/map/backup/backup_test.js
+++ b/map/backup/backup_test.js
@@ -1,5 +1,5 @@
 /*global Recipe*/
-steal("can/map/backup", "can/model", "can/test", function() {
+steal("can/map/backup", "can/model", "can/test", function () {
 	module('can/map/backup', {
 		setup: function () {
 			can.Map.extend('Recipe');

--- a/map/delegate/delegate_test.js
+++ b/map/delegate/delegate_test.js
@@ -1,4 +1,4 @@
-steal("can/map/delegate", "can/test", function() {
+steal("can/map/delegate", "can/test", function () {
 	module('can/map/delegate');
 	var matches = can.Map.prototype.delegate.matches;
 	test('matches', function () {
@@ -158,12 +158,12 @@ steal("can/map/delegate", "can/test", function() {
 		var f1 = function () {
 			state.undelegate('type', 'add', f2);
 		}, f2 = function () {
-			ok(false, 'I am removed, how am I called');
-		}, f3 = function () {
-			state.undelegate('type', 'add', f1);
-		}, f4 = function () {
-			ok(true, 'f4 called');
-		};
+				ok(false, 'I am removed, how am I called');
+			}, f3 = function () {
+				state.undelegate('type', 'add', f1);
+			}, f4 = function () {
+				ok(true, 'f4 called');
+			};
 		state.delegate('type', 'set', f1);
 		state.delegate('type', 'set', f2);
 		state.delegate('type', 'set', f3);

--- a/map/list/list_test.js
+++ b/map/list/list_test.js
@@ -1,4 +1,4 @@
-steal("can/map/list", function(){
+steal("can/map/list", function () {
 	module('can/map/list');
 	test('filter', 8, function () {
 		var original = new can.List([{

--- a/map/map_test.js
+++ b/map/map_test.js
@@ -1,5 +1,5 @@
 /* jshint asi:true*/
-steal("can/map", "can/compute", "can/test", function(undefined) {
+steal("can/map", "can/compute", "can/test", function (undefined) {
 
 	module('can/map')
 

--- a/map/setter/setter_test.js
+++ b/map/setter/setter_test.js
@@ -1,5 +1,5 @@
 /*global School*/
-steal("can/map/setter", "can/test", function() {
+steal("can/map/setter", "can/test", function () {
 	module('can/map/setter');
 	test('setter testing works', function () {
 		var Contact = can.Map({

--- a/map/sort/sort_test.js
+++ b/map/sort/sort_test.js
@@ -1,4 +1,4 @@
-steal("can/map/sort", "can/test", "can/view/mustache", function() {
+steal("can/map/sort", "can/test", "can/view/mustache", function () {
 	module('can/map/sort');
 	test('list events', 16, function () {
 		var list = new can.List([{

--- a/map/validations/validations_test.js
+++ b/map/validations/validations_test.js
@@ -1,5 +1,5 @@
 /*global Person,Task*/
-steal("can/map/validations", "can/compute", "can/test", function() {
+steal("can/map/validations", "can/compute", "can/test", function () {
 	module('can/map/validations', {
 		setup: function () {
 			can.Map.extend('Person', {}, {});
@@ -12,8 +12,8 @@ steal("can/map/validations", "can/compute", "can/test", function() {
 			return !(this.date instanceof Date);
 		});
 		var task = new Person({
-				age: 'bad'
-			}),
+			age: 'bad'
+		}),
 			errors = task.errors();
 		ok(errors, 'There are errors');
 		equal(errors.age.length, 1, 'there is one error');
@@ -31,8 +31,8 @@ steal("can/map/validations", "can/compute", "can/test", function() {
 	test('validatesFormatOf', function () {
 		Person.validateFormatOf('thing', /\d-\d/);
 		ok(!new Person({
-			thing: '1-2'
-		})
+				thing: '1-2'
+			})
 			.errors(), 'no errors');
 		var errors = new Person({
 			thing: 'foobar'
@@ -51,13 +51,13 @@ steal("can/map/validations", "can/compute", "can/test", function() {
 			.errors();
 		equal(errors2.otherThing[0], 'not a digit', 'can supply a custom message');
 		ok(!new Person({
-			thing: '1-2',
-			otherThing: null
-		})
+				thing: '1-2',
+				otherThing: null
+			})
 			.errors(), 'can handle null');
 		ok(!new Person({
-			thing: '1-2'
-		})
+				thing: '1-2'
+			})
 			.errors(), 'can handle undefiend');
 	});
 	test('validatesInclusionOf', function () {
@@ -67,8 +67,8 @@ steal("can/map/validations", "can/compute", "can/test", function() {
 			'maybe'
 		]);
 		ok(!new Person({
-			thing: 'yes'
-		})
+				thing: 'yes'
+			})
 			.errors(), 'no errors');
 		var errors = new Person({
 			thing: 'foobar'
@@ -96,9 +96,9 @@ steal("can/map/validations", "can/compute", "can/test", function() {
 		Person.validateLengthOf('nullValue', 0, 5);
 		Person.validateLengthOf('thing', 2, 5);
 		ok(!new Person({
-			thing: 'yes',
-			nullValue: null
-		})
+				thing: 'yes',
+				nullValue: null
+			})
 			.errors(), 'no errors');
 		var errors = new Person({
 			thing: 'foobar'
@@ -219,9 +219,9 @@ steal("can/map/validations", "can/compute", "can/test", function() {
 		Person.validateRangeOf('nullValue', 0, 5);
 		Person.validateRangeOf('undefinedValue', 0, 5);
 		ok(!new Person({
-			thing: 4,
-			nullValue: null
-		})
+				thing: 4,
+				nullValue: null
+			})
 			.errors(), 'no errors');
 		var errors = new Person({
 			thing: 6
@@ -331,8 +331,8 @@ steal("can/map/validations", "can/compute", "can/test", function() {
 			return !(this.date instanceof Date);
 		});
 		var task = new Person({
-				age: 20
-			}),
+			age: 20
+		}),
 			errors = can.compute(function () {
 				return task.errors();
 			});

--- a/model/model_test.js
+++ b/model/model_test.js
@@ -8,7 +8,7 @@
 /* global Product: true */
 /* global Organisation: true */
 /* global Company: true */
-steal("can/model",'can/map/attributes', "can/test", "can/util/fixture", function() {
+steal("can/model", 'can/map/attributes', "can/test", "can/util/fixture", function () {
 	module('can/model', {
 		setup: function () {}
 	});
@@ -209,8 +209,8 @@ steal("can/model",'can/map/attributes', "can/test", "can/util/fixture", function
 			}
 		}, {});
 		var person = new Person({
-				name: 'Justin'
-			}),
+			name: 'Justin'
+		}),
 			personD = person.save();
 		stop();
 		personD.then(function (person) {
@@ -236,9 +236,9 @@ steal("can/model",'can/map/attributes', "can/test", "can/util/fixture", function
 			}
 		}, {});
 		var person = new Person({
-				name: 'Justin',
-				id: 5
-			}),
+			name: 'Justin',
+			id: 5
+		}),
 			personD = person.save();
 		stop();
 		personD.then(function (person) {
@@ -263,9 +263,9 @@ steal("can/model",'can/map/attributes', "can/test", "can/util/fixture", function
 			}
 		}, {});
 		var person = new Person({
-				name: 'Justin',
-				id: 5
-			}),
+			name: 'Justin',
+			id: 5
+		}),
 			personD = person.destroy();
 		stop();
 		personD.then(function (person) {
@@ -650,8 +650,8 @@ steal("can/model",'can/map/attributes', "can/test", "can/util/fixture", function
 		});
 		stop();
 		can.when(Guy.findOne({
-				id: 1
-			}), Guy.findAll())
+			id: 1
+		}), Guy.findAll())
 			.then(function (guyRes, guysRes2) {
 				equal(guyRes.id, 1, 'got a guy id 1 back');
 				equal(guysRes2[0].id, 1, 'got guys w/ id 1 back');
@@ -907,13 +907,13 @@ steal("can/model",'can/map/attributes', "can/test", "can/util/fixture", function
 			}
 		}, {});
 		var people = new Person.List([
-				new Person({
-					id: 1
-				}),
-				new Person({
-					id: 2
-				})
-			]),
+			new Person({
+				id: 1
+			}),
+			new Person({
+				id: 2
+			})
+		]),
 			orgs = new Organisation.List([
 				new Organisation({
 					id: 1
@@ -1037,12 +1037,12 @@ steal("can/model",'can/map/attributes', "can/test", "can/util/fixture", function
 	});
 	test('.model on create and update (#301)', function () {
 		var MyModel = can.Model.extend({
-				create: 'POST /todo',
-				update: 'PUT /todo',
-				model: function (data) {
-					return can.Model.model.call(this, data.item);
-				}
-			}, {}),
+			create: 'POST /todo',
+			update: 'PUT /todo',
+			model: function (data) {
+				return can.Model.model.call(this, data.item);
+			}
+		}, {}),
 			id = 0,
 			updateTime;
 		can.fixture('POST /todo', function (original, respondWith, settings) {
@@ -1079,8 +1079,8 @@ steal("can/model",'can/map/attributes', "can/test", "can/util/fixture", function
 				}, '.model works for update');
 			});
 		var instance = new MyModel({
-				name: 'Dishes'
-			}),
+			name: 'Dishes'
+		}),
 			saveD = instance.save();
 		stop();
 		saveD.then(function () {

--- a/model/queue/queue_test.js
+++ b/model/queue/queue_test.js
@@ -1,7 +1,7 @@
 /* global Person: true */
 /* global User: true */
 /* global Hero: true */
-steal('can/util','can/model', 'can/model/queue', 'can/util/fixture','can/map/attributes', "can/test", function() {
+steal('can/util', 'can/model', 'can/model/queue', 'can/util/fixture', 'can/map/attributes', "can/test", function () {
 	module('can/model/queue', {
 		setup: function () {}
 	});
@@ -25,8 +25,8 @@ steal('can/util','can/model', 'can/model/queue', 'can/util/fixture','can/map/att
 			}
 		}, {});
 		var person = new Person({
-				name: 'Justin'
-			}),
+			name: 'Justin'
+		}),
 			personD = person.save();
 		person.attr('name', 'Brian');
 		stop();

--- a/observe/observe_test.js
+++ b/observe/observe_test.js
@@ -1,4 +1,4 @@
-steal('can/util', "can/observe", 'can/map', 'can/list', "can/test", function() {
+steal('can/util', "can/observe", 'can/map', 'can/list', "can/test", function () {
 	module('can/observe map+list');
 	test('Basic Map', 9, function () {
 		var state = new can.Map({
@@ -45,11 +45,11 @@ steal('can/util', "can/observe", 'can/map', 'can/list', "can/test", function() {
 	});
 	test('list splice', function () {
 		var l = new can.List([
-				0,
-				1,
-				2,
-				3
-			]),
+			0,
+			1,
+			2,
+			3
+		]),
 			first = true;
 		l.bind('change', function (ev, attr, how, newVals, oldVals) {
 			equal(attr, '1');
@@ -95,14 +95,14 @@ steal('can/util', "can/observe", 'can/map', 'can/list', "can/test", function() {
 	});
 	test('changing an object unbinds', function () {
 		var state = new can.Map({
-				category: 5,
-				productType: 4,
-				properties: {
-					brand: [],
-					model: [],
-					price: []
-				}
-			}),
+			category: 5,
+			productType: 4,
+			properties: {
+				brand: [],
+				model: [],
+				price: []
+			}
+		}),
 			count = 0;
 		var brand = state.attr('properties.brand');
 		state.bind('change', function (ev, attr, how, val, old) {
@@ -289,8 +289,8 @@ steal('can/util', "can/observe", 'can/map', 'can/list', "can/test", function() {
 	test('attr deep array ', function () {
 		var state = new can.Map({});
 		var arr = [{
-				foo: 'bar'
-			}],
+			foo: 'bar'
+		}],
 			thing = {
 				arr: arr
 			};
@@ -312,17 +312,17 @@ steal('can/util', "can/observe", 'can/map', 'can/list', "can/test", function() {
 				}
 			]
 		}, compare = {
-			foo: {
-				bar: 'car'
-			},
-			arr: [
-				1,
-				2,
-				3, {
-					four: '5'
-				}
-			]
-		};
+				foo: {
+					bar: 'car'
+				},
+				arr: [
+					1,
+					2,
+					3, {
+						four: '5'
+					}
+				]
+			};
 		var res = new can.Map(first)
 			.attr();
 		deepEqual(res, compare, 'test');
@@ -438,10 +438,10 @@ steal('can/util', "can/observe", 'can/map', 'can/list', "can/test", function() {
 	});
 	test('Array accessor methods', 11, function () {
 		var l = new can.List([
-				'a',
-				'b',
-				'c'
-			]),
+			'a',
+			'b',
+			'c'
+		]),
 			sliced = l.slice(2),
 			joined = l.join(' | '),
 			concatenated = l.concat([
@@ -548,11 +548,11 @@ steal('can/util', "can/observe", 'can/map', 'can/list', "can/test", function() {
 	});
 	test('startBatch and stopBatch and changed event', 5, function () {
 		var ob = new can.Map({
-				name: {
-					first: 'Brian'
-				},
-				age: 29
-			}),
+			name: {
+				first: 'Brian'
+			},
+			age: 29
+		}),
 			bothSet = false,
 			changeCallCount = 0,
 			changedCalled = false;
@@ -575,11 +575,11 @@ steal('can/util', "can/observe", 'can/map', 'can/list', "can/test", function() {
 	});
 	test('startBatch callback', 4, function () {
 		var ob = new can.Map({
-				game: {
-					name: 'Legend of Zelda'
-				},
-				hearts: 15
-			}),
+			game: {
+				name: 'Legend of Zelda'
+			},
+			hearts: 15
+		}),
 			callbackCalled = false;
 		ob.bind('change', function () {
 			equal(callbackCalled, false, 'startBatch callback not called yet');
@@ -595,10 +595,10 @@ steal('can/util', "can/observe", 'can/map', 'can/list', "can/test", function() {
 	});
 	test('nested map attr', function () {
 		var person1 = new can.Map({
-				name: {
-					first: 'Josh'
-				}
-			}),
+			name: {
+				first: 'Josh'
+			}
+		}),
 			person2 = new can.Map({
 				name: {
 					first: 'Justin',
@@ -618,19 +618,19 @@ steal('can/util', "can/observe", 'can/map', 'can/list', "can/test", function() {
 	});
 	test('Nested array conversion (#172)', 4, function () {
 		var original = [
-				[
-					1,
-					2
-				],
-				[
-					3,
-					4
-				],
-				[
-					5,
-					6
-				]
+			[
+				1,
+				2
 			],
+			[
+				3,
+				4
+			],
+			[
+				5,
+				6
+			]
+		],
 			list = new can.List(original);
 		equal(list.length, 3, 'list length is correct');
 		deepEqual(list.serialize(), original, 'Lists are the same');
@@ -655,10 +655,10 @@ steal('can/util', "can/observe", 'can/map', 'can/list', "can/test", function() {
 	});
 	test('can.List.prototype.replace (#194)', 7, function () {
 		var list = new can.List([
-				'a',
-				'b',
-				'c'
-			]),
+			'a',
+			'b',
+			'c'
+		]),
 			replaceList = [
 				'd',
 				'e',
@@ -747,10 +747,10 @@ steal('can/util', "can/observe", 'can/map', 'can/list', "can/test", function() {
 	});
 	test('IE8 error on list setup with List (#226)', function () {
 		var list = new can.List([
-				'first',
-				'second',
-				'third'
-			]),
+			'first',
+			'second',
+			'third'
+		]),
 			otherList = new can.List(list);
 		deepEqual(list.attr(), otherList.attr(), 'Lists are the same');
 	});
@@ -803,9 +803,9 @@ steal('can/util', "can/observe", 'can/map', 'can/list', "can/test", function() {
 		equal(ob.attr('other.stuff'), 'thinger', 'Set dot separated value');
 		deepEqual(ob.attr('other')
 			.serialize(), {
-			test: 'value',
-			stuff: 'thinger'
-		}, 'Object set properly');
+				test: 'value',
+				stuff: 'thinger'
+			}, 'Object set properly');
 	});
 	test('cycle binding', function () {
 		var first = new can.Map(),
@@ -980,9 +980,9 @@ steal('can/util', "can/observe", 'can/map', 'can/list', "can/test", function() {
 	});
 	test('only one update on a start and end transaction', function () {
 		var person = new can.Map({
-				first: 'Justin',
-				last: 'Meyer'
-			}),
+			first: 'Justin',
+			last: 'Meyer'
+		}),
 			age = can.compute(5);
 		var func = function (newVal, oldVal) {
 			return person.attr('first') + ' ' + person.attr('last') + age() + Math.random();
@@ -1022,8 +1022,8 @@ steal('can/util', "can/observe", 'can/map', 'can/list', "can/test", function() {
 	});
 	test('compute only updates once when a list\'s contents are replaced', function () {
 		var list = new can.List([{
-				name: 'Justin'
-			}]),
+			name: 'Justin'
+		}]),
 			computedCount = 0;
 		var compute = can.compute(function () {
 			computedCount++;

--- a/route/pushstate/pushstate_test.js
+++ b/route/pushstate/pushstate_test.js
@@ -1,5 +1,5 @@
 /* jshint asi:true*/
-steal('can/route/pushstate', "can/test", function(){
+steal('can/route/pushstate', "can/test", function () {
 
 	if (window.history && history.pushState) {
 
@@ -304,13 +304,13 @@ steal('can/route/pushstate', "can/test", function(){
 			}, "bad deparam");
 
 			equal(can.route.param({
-				search: "can.Control"
-			}),
+					search: "can.Control"
+				}),
 				"search/can.Control", "bad param");
 
 			equal(can.route.param({
-				who: "can.Control"
-			}),
+					who: "can.Control"
+				}),
 				"can.Control");
 		})
 
@@ -322,9 +322,9 @@ steal('can/route/pushstate', "can/test", function(){
 			can.route(":type/:id");
 
 			equal(can.route.param({
-				type: "foo",
-				id: "bar"
-			}),
+					type: "foo",
+					id: "bar"
+				}),
 				"foo/bar");
 		})
 
@@ -589,14 +589,14 @@ steal('can/route/pushstate', "can/test", function(){
 
 			test("routed links must descend from pushstate root (#652)", 2, function () {
 				var tests = [
-						// ["root", "link href", { route: "result" }]
-						["/app/", "/app/something/test/", {
-							section: "something",
-							sub: "test",
-							route: ":section/:sub/"
-						}],
-						["/app/", "/route/pushstate/", {}]
-					],
+					// ["root", "link href", { route: "result" }]
+					["/app/", "/app/something/test/", {
+						section: "something",
+						sub: "test",
+						route: ":section/:sub/"
+					}],
+					["/app/", "/route/pushstate/", {}]
+				],
 					iframe,
 					test;
 

--- a/route/route_test.js
+++ b/route/route_test.js
@@ -1,5 +1,5 @@
 /* jshint asi:true*/
-steal("can/route", "can/test", function() {
+steal("can/route", "can/test", function () {
 	module("can/route", {
 		setup: function () {
 			can.route._teardown();
@@ -298,13 +298,13 @@ steal("can/route", "can/test", function() {
 		}, "bad deparam");
 
 		equal(can.route.param({
-			search: "can.Control"
-		}),
+				search: "can.Control"
+			}),
 			"search/can.Control", "bad param");
 
 		equal(can.route.param({
-			who: "can.Control"
-		}),
+				who: "can.Control"
+			}),
 			"can.Control");
 	})
 
@@ -316,9 +316,9 @@ steal("can/route", "can/test", function() {
 		can.route(":type/:id");
 
 		equal(can.route.param({
-			type: "foo",
-			id: "bar"
-		}),
+				type: "foo",
+				id: "bar"
+			}),
 			"foo/bar");
 	})
 

--- a/util/fixture/fixture_test.js
+++ b/util/fixture/fixture_test.js
@@ -1,4 +1,4 @@
-steal('can/util/fixture', function() {
+steal('can/util/fixture', function () {
 	module('can/util/fixture');
 	test('static fixtures', function () {
 		stop();
@@ -161,8 +161,8 @@ steal('can/util/fixture', function() {
 		ok(num >= 0 && num < 5, 'gets a number');
 		stop();
 		var zero, three, between, next = function () {
-			start();
-		};
+				start();
+			};
 		// make sure rand can be everything we need
 		setTimeout(function timer() {
 			var res = rand([1, 2, 3]);
@@ -297,11 +297,11 @@ steal('can/util/fixture', function() {
 	 */
 	test('can.fixture.store with can.Model', function () {
 		var store = can.fixture.store(100, function (i) {
-				return {
-					id: i,
-					name: 'Object ' + i
-				};
-			}),
+			return {
+				id: i,
+				name: 'Object ' + i
+			};
+		}),
 			Model = can.Model({
 				findAll: 'GET /models',
 				findOne: 'GET /models/{id}',

--- a/util/object/object_test.js
+++ b/util/object/object_test.js
@@ -116,14 +116,14 @@ steal('can/util/object', function () {
 			id: 1,
 			name: 'thinger'
 		}, searchText = {
-			searchText: 'foo'
-		}, compare = {
-			searchText: function (items, paramsText, itemr, params) {
-				equal(item, itemr);
-				equal(searchText, params);
-				return true;
-			}
-		};
+				searchText: 'foo'
+			}, compare = {
+				searchText: function (items, paramsText, itemr, params) {
+					equal(item, itemr);
+					equal(searchText, params);
+					return true;
+				}
+			};
 		ok(can.Object.subset(item, searchText, compare), 'searchText');
 	});
 });

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -1,4 +1,4 @@
-steal("can/view/bindings", "can/map", "can/test", function(){
+steal("can/view/bindings", "can/map", "can/test", function () {
 	module('can/view/bindings', {
 		setup: function () {
 			document.getElementById('qunit-test-area')
@@ -125,8 +125,8 @@ steal("can/view/bindings", "can/map", "can/test", function(){
 	});
 	test('checkboxes with can-value bind properly (#628)', function () {
 		var data = new can.Map({
-				completed: true
-			}),
+			completed: true
+		}),
 			frag = can.view.mustache('<input type="checkbox" can-value="completed"/>')(data);
 		can.append(can.$('#qunit-test-area'), frag);
 		var input = can.$('#qunit-test-area')[0].getElementsByTagName('input')[0];

--- a/view/ejs/ejs_test.js
+++ b/view/ejs/ejs_test.js
@@ -1,4 +1,4 @@
-steal("can/model", "can/view/ejs", "can/test", function() {
+steal("can/model", "can/view/ejs", "can/test", function () {
 	module('can/view/ejs, rendering', {
 		setup: function () {
 			this.animals = [
@@ -187,9 +187,9 @@ steal("can/model", "can/view/ejs", "can/test", function() {
 	test('list helper', function () {
 		var text = '<% list(todos, function(todo){ %><div><%= todo.name %></div><% }) %>';
 		var todos = new can.List([{
-				id: 1,
-				name: 'Dishes'
-			}]),
+			id: 1,
+			name: 'Dishes'
+		}]),
 			compiled = new can.EJS({
 				text: text
 			})
@@ -951,8 +951,8 @@ steal("can/model", "can/view/ejs", "can/test", function() {
 	test('live binding textarea', function () {
 		can.view.ejs('textarea-test', '<textarea>Before<%= obs.attr(\'middle\') %>After</textarea>');
 		var obs = new can.Map({
-				middle: 'yes'
-			}),
+			middle: 'yes'
+		}),
 			div = document.createElement('div');
 		var node = can.view('textarea-test', {
 			obs: obs
@@ -1033,9 +1033,9 @@ steal("can/model", "can/view/ejs", "can/test", function() {
 	test('empty element hooks work correctly', function () {
 		var text = '<div <%= function(e){ e.innerHTML = "1 Will show"; } %>></div>' + '<div <%= function(e){ e.innerHTML = "2 Will not show"; } %>></div>' + '3 Will not show';
 		var compiled = new can.EJS({
-				text: text
-			})
-				.render(),
+			text: text
+		})
+			.render(),
 			div = document.createElement('div');
 		div.appendChild(can.view.frag(compiled));
 		equal(div.childNodes.length, 3, 'all three elements present');
@@ -1132,8 +1132,8 @@ steal("can/model", "can/view/ejs", "can/test", function() {
 			rating: 8.5
 		});
 		var res = can.view.render(can.test.path('view/ejs/test/table_test.ejs'), {
-				games: games
-			}),
+			games: games
+		}),
 			div = document.createElement('div');
 		div.appendChild(can.view.frag(res));
 		ok(!/@@!!@@/.test(div.innerHTML), 'no placeholders');
@@ -1222,16 +1222,16 @@ steal("can/model", "can/view/ejs", "can/test", function() {
 	});
 	test('HTML comment with element callback', function () {
 		var text = [
-				'<ul>',
-				'<% todos.each(function(todo) { %>',
-				'<li<%= (el) -> can.data(can.$(el),\'todo\',todo) %>>',
-				'<!-- html comment #1 -->',
-				'<%= todo.name %>',
-				'<!-- html comment #2 -->',
-				'</li>',
-				'<% }) %>',
-				'</ul>'
-			],
+			'<ul>',
+			'<% todos.each(function(todo) { %>',
+			'<li<%= (el) -> can.data(can.$(el),\'todo\',todo) %>>',
+			'<!-- html comment #1 -->',
+			'<%= todo.name %>',
+			'<!-- html comment #2 -->',
+			'</li>',
+			'<% }) %>',
+			'</ul>'
+		],
 			Todos = new can.List([{
 				id: 1,
 				name: 'Dishes'
@@ -1272,15 +1272,15 @@ steal("can/model", "can/view/ejs", "can/test", function() {
 		can.view.ejs('issue-153-no-dom', '<% can.each(todos, function(todo) { %><span><%= todo.attr("name") %></span><% }) %>');
 		can.view.ejs('issue-153-dom', '<% can.each(todos, function(todo) { %><%= todo.attr("name") %><% }) %>');
 		var todos = [
-				new can.Map({
-					id: 1,
-					name: 'Dishes'
-				}),
-				new can.Map({
-					id: 2,
-					name: 'Forks'
-				})
-			],
+			new can.Map({
+				id: 1,
+				name: 'Dishes'
+			}),
+			new can.Map({
+				id: 2,
+				name: 'Forks'
+			})
+		],
 			data = {
 				todos: new can.List(todos)
 			}, arr = {
@@ -1307,10 +1307,10 @@ steal("can/model", "can/view/ejs", "can/test", function() {
 	});
 	test('correctness of data-view-id and only in tag opening', function () {
 		var text = [
-				'<textarea><select><% can.each(this.items, function(item) { %>',
-				'<option<%= (el) -> el.data(\'item\', item) %>><%= item.title %></option>',
-				'<% }) %></select></textarea>'
-			],
+			'<textarea><select><% can.each(this.items, function(item) { %>',
+			'<option<%= (el) -> el.data(\'item\', item) %>><%= item.title %></option>',
+			'<% }) %></select></textarea>'
+		],
 			items = [{
 				id: 1,
 				title: 'One'
@@ -1329,9 +1329,9 @@ steal("can/model", "can/view/ejs", "can/test", function() {
 	});
 	test('return blocks within element tags', function () {
 		var animals = new can.List([
-				'sloth',
-				'bear'
-			]),
+			'sloth',
+			'bear'
+		]),
 			template = '<ul>' + '<%==lister(animals, function(animal){%>' + '<li><%=animal %></li>' + '<%})%>' + '</ul>';
 		var renderer = can.view.ejs(template);
 		var div = document.createElement('div');
@@ -1347,9 +1347,9 @@ steal("can/model", "can/view/ejs", "can/test", function() {
 	});
 	test('Each does not redraw items', function () {
 		var animals = new can.List([
-				'sloth',
-				'bear'
-			]),
+			'sloth',
+			'bear'
+		]),
 			template = '<div>my<b>favorite</b>animals:' + '<%==each(animals, function(animal){%>' + '<label>Animal=</label> <span><%=animal %></span>' + '<%})%>' + '!</div>';
 		var renderer = can.view.ejs(template);
 		var div = document.createElement('div');
@@ -1366,9 +1366,9 @@ steal("can/model", "can/view/ejs", "can/test", function() {
 	});
 	test('Each works with no elements', function () {
 		var animals = new can.List([
-				'sloth',
-				'bear'
-			]),
+			'sloth',
+			'bear'
+		]),
 			template = '<%==each(animals, function(animal){%>' + '<%=animal %> ' + '<%})%>';
 		var renderer = can.view.ejs(template);
 		var div = document.createElement('div');
@@ -1381,10 +1381,10 @@ steal("can/model", "can/view/ejs", "can/test", function() {
 	});
 	test('Each does not redraw items (normal array)', function () {
 		var animals = [
-				'sloth',
-				'bear',
-				'turtle'
-			],
+			'sloth',
+			'bear',
+			'turtle'
+		],
 			template = '<div>my<b>favorite</b>animals:' + '<%each(animals, function(animal){%>' + '<label>Animal=</label> <span><%=animal %></span>' + '<%})%>' + '!</div>';
 		var renderer = can.view.ejs(template);
 		var div = document.createElement('div');

--- a/view/live/live_test.js
+++ b/view/live/live_test.js
@@ -1,4 +1,4 @@
-steal("can/view/live", "can/observe", "can/test", function(){
+steal("can/view/live", "can/observe", "can/test", function () {
 	module('can/view/live');
 	test('html', function () {
 		var div = document.createElement('div'),

--- a/view/modifiers/modifiers_test.js
+++ b/view/modifiers/modifiers_test.js
@@ -1,4 +1,4 @@
-steal("can/map", "can/view/ejs", "can/view/modifiers", "can/test", function() {
+steal("can/map", "can/view/ejs", "can/view/modifiers", "can/test", function () {
 	// this only applied to jQuery libs
 	if (!window.jQuery) {
 		return;

--- a/view/mustache/mustache_test.js
+++ b/view/mustache/mustache_test.js
@@ -1,6 +1,6 @@
 /* jshint asi:true,multistr:true*/
 /*global Mustache*/
-steal("can/model", "can/view/mustache", "can/test", function() {
+steal("can/model", "can/view/mustache", "can/test", function () {
 
 	module("can/view/mustache, rendering", {
 		setup: function () {
@@ -84,8 +84,8 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 						}
 
 						deepEqual(new can.Mustache({
-							text: t.template
-						})
+								text: t.template
+							})
 							.render(t.data), expected);
 					});
 				});
@@ -256,8 +256,8 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 		var expected = t.expected.replace(/&quot;/g, '&#34;')
 			.replace(/\r\n/g, '\n');
 		deepEqual(new can.Mustache({
-			text: t.template
-		})
+				text: t.template
+			})
 			.render(t.data), expected);
 	});
 
@@ -273,8 +273,8 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 		var expected = t.expected.replace(/&quot;/g, '&#34;')
 			.replace(/\r\n/g, '\n');
 		deepEqual(new can.Mustache({
-			text: t.template
-		})
+				text: t.template
+			})
 			.render(t.data), expected);
 	});
 
@@ -303,8 +303,8 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 		var expected = t.expected.replace(/&quot;/g, '&#34;')
 			.replace(/\r\n/g, '\n');
 		deepEqual(new can.Mustache({
-			text: t.template
-		})
+				text: t.template
+			})
 			.render(t.data), expected);
 	});
 
@@ -339,12 +339,12 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 		};
 
 		deepEqual(new can.Mustache({
-			text: t.template
-		})
+				text: t.template
+			})
 			.render(t.data), t.expected);
 		deepEqual(new can.Mustache({
-			text: t.template
-		})
+				text: t.template
+			})
 			.render({}), t.expected2);
 	});
 
@@ -365,8 +365,8 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 		var expected = t.expected.replace(/&quot;/g, '&#34;')
 			.replace(/\r\n/g, '\n');
 		deepEqual(new can.Mustache({
-			text: t.template
-		})
+				text: t.template
+			})
 			.render(t.data), expected);
 	});
 
@@ -379,12 +379,12 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 		};
 
 		deepEqual(new can.Mustache({
-			text: t.template1
-		})
+				text: t.template1
+			})
 			.render({}), t.expected);
 		deepEqual(new can.Mustache({
-			text: t.template2
-		})
+				text: t.template2
+			})
 			.render({}), t.expected);
 	});
 
@@ -462,8 +462,8 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 		}
 
 		deepEqual(new can.Mustache({
-			text: t.template
-		})
+				text: t.template
+			})
 			.render(t.data), t.expected);
 	});
 
@@ -486,8 +486,8 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 		}
 
 		deepEqual(new can.Mustache({
-			text: t.template
-		})
+				text: t.template
+			})
 			.render(t.data), t.expected);
 	});
 
@@ -505,16 +505,16 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 		expected = t.expected.replace(/&quot;/g, '&#34;')
 			.replace(/\r\n/g, '\n');
 		deepEqual(new can.Mustache({
-			text: t.template
-		})
+				text: t.template
+			})
 			.render(t.data), expected);
 
 		t.data.missing = null;
 		expected = t.expected.replace(/&quot;/g, '&#34;')
 			.replace(/\r\n/g, '\n');
 		deepEqual(new can.Mustache({
-			text: t.template
-		})
+				text: t.template
+			})
 			.render(t.data), expected);
 	});
 
@@ -530,8 +530,8 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 		var expected = t.expected.replace(/&quot;/g, '&#34;')
 			.replace(/\r\n/g, '\n');
 		deepEqual(new can.Mustache({
-			text: t.template
-		})
+				text: t.template
+			})
 			.render(t.data), expected);
 	});
 
@@ -550,8 +550,8 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 		var expected = t.expected.replace(/&quot;/g, '&#34;')
 			.replace(/\r\n/g, '\n');
 		deepEqual(new can.Mustache({
-			text: t.template
-		})
+				text: t.template
+			})
 			.render(t.data), expected);
 
 		var div = document.createElement('div');
@@ -574,8 +574,8 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 		var expected = t.expected.replace(/&quot;/g, '&#34;')
 			.replace(/\r\n/g, '\n');
 		deepEqual(new can.Mustache({
-			text: t.template
-		})
+				text: t.template
+			})
 			.render(t.data), expected);
 	});
 
@@ -727,7 +727,7 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 	test('multiple function hookups in a tag', function () {
 
 		var text = "<span {{(el)-> can.data(can.$(el),'foo','bar')}}" +
-				" {{(el)-> can.data(can.$(el),'baz','qux')}}>lorem ipsum</span>",
+			" {{(el)-> can.data(can.$(el),'baz','qux')}}>lorem ipsum</span>",
 			compiled = new can.Mustache({
 				text: text
 			})
@@ -970,8 +970,8 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 	test('live binding and removeAttr', function () {
 
 		var text = '{{ #obs.show }}' +
-				'<p {{ obs.attributes }} class="{{ obs.className }}"><span>{{ obs.message }}</span></p>' +
-				'{{ /obs.show }}',
+			'<p {{ obs.attributes }} class="{{ obs.className }}"><span>{{ obs.message }}</span></p>' +
+			'{{ /obs.show }}',
 
 			obs = new can.Map({
 				show: true,
@@ -1122,8 +1122,8 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 	test("hookup and live binding", function () {
 
 		var text = "<div class='{{ task.completed }}' {{ (el)-> can.data(can.$(el),'task',task) }}>" +
-				"{{ task.name }}" +
-				"</div>",
+			"{{ task.name }}" +
+			"</div>",
 			task = new can.Map({
 				completed: false,
 				className: 'someTask',
@@ -1155,11 +1155,11 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 
 	test('multiple curly braces in a block', function () {
 		var text = '{{^obs.items}}' +
-				'<li>No items</li>' +
-				'{{/obs.items}}' +
-				'{{#obs.items}}' +
-				'<li>{{name}}</li>' +
-				'{{/obs.items}}',
+			'<li>No items</li>' +
+			'{{/obs.items}}' +
+			'{{#obs.items}}' +
+			'<li>{{name}}</li>' +
+			'{{/obs.items}}',
 
 			obs = new can.Map({
 				items: []
@@ -1527,8 +1527,8 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 		can.view.mustache("textarea-test", "<textarea>Before{{ obs.middle }}After</textarea>");
 
 		var obs = new can.Map({
-				middle: "yes"
-			}),
+			middle: "yes"
+		}),
 			div = document.createElement('div');
 
 		div.appendChild(can.view("textarea-test", {
@@ -1675,10 +1675,10 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 	//Issue 233
 	test("multiple tbodies in table hookup", function () {
 		var text = "<table>" +
-				"{{#people}}" +
-				"<tbody><tr><td>{{name}}</td></tr></tbody>" +
-				"{{/people}}" +
-				"</table>",
+			"{{#people}}" +
+			"<tbody><tr><td>{{name}}</td></tr></tbody>" +
+			"{{/people}}" +
+			"</table>",
 			people = new can.List([{
 				name: "Steve"
 			}, {
@@ -2012,15 +2012,15 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 
 	test("HTML comment with helper", function () {
 		var text = ["<ul>",
-				"{{#todos}}",
-				"<li {{data 'todo'}}>",
-				"<!-- html comment #1 -->",
-				"{{name}}",
-				"<!-- html comment #2 -->",
-				"</li>",
-				"{{/todos}}",
-				"</ul>"
-			],
+			"{{#todos}}",
+			"<li {{data 'todo'}}>",
+			"<!-- html comment #1 -->",
+			"{{name}}",
+			"<!-- html comment #2 -->",
+			"</li>",
+			"{{/todos}}",
+			"</ul>"
+		],
 			Todos = new can.List([{
 				id: 1,
 				name: "Dishes"
@@ -2063,9 +2063,9 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 
 	test("correctness of data-view-id and only in tag opening", function () {
 		var text = ["<textarea><select>{{#items}}",
-				"<option{{data 'item'}}>{{title}}</option>",
-				"{{/items}}</select></textarea>"
-			],
+			"<option{{data 'item'}}>{{title}}</option>",
+			"{{/items}}</select></textarea>"
+		],
 			items = [{
 				id: 1,
 				title: "One"
@@ -2087,8 +2087,8 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 
 	test("Empty strings in arrays within Observes that are iterated should return blank strings", function () {
 		var data = new can.Map({
-				colors: ["", 'red', 'green', 'blue']
-			}),
+			colors: ["", 'red', 'green', 'blue']
+		}),
 			compiled = new can.Mustache({
 				text: "<select>{{#colors}}<option>{{.}}</option>{{/colors}}</select>"
 			})
@@ -2198,8 +2198,8 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 		var expected = t.expected.replace(/&quot;/g, '&#34;')
 			.replace(/\r\n/g, '\n');
 		deepEqual(new can.Mustache({
-			text: t.template
-		})
+				text: t.template
+			})
 			.render(t.data), expected);
 	});
 
@@ -2343,8 +2343,8 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 
 	test("Object references can escape periods for key names containing periods", function () {
 		var template = can.view.mustache("{{#foo.bar}}" +
-				"{{some\\\\.key\\\\.name}} {{some\\\\.other\\\\.key.with\\\\.more}}" +
-				"{{/foo.bar}}"),
+			"{{some\\\\.key\\\\.name}} {{some\\\\.other\\\\.key.with\\\\.more}}" +
+			"{{/foo.bar}}"),
 			data = {
 				foo: {
 					bar: [{
@@ -2467,30 +2467,30 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 		 equal(img.src, url, 'Image should have src URL');*/
 	});
 
-	test("live binding in a truthy section", function(){
+	test("live binding in a truthy section", function () {
 		var template = can.view.mustache('<img src="http://canjs.us/scripts/static/img/canjs_logo_yellow_small.png" {{#width}}width="{{.}}"{{/width}} />'),
 			data = new can.Map({
 				width: '100'
 			});
-		
+
 		var frag = template(data),
 			img = frag.childNodes[0];
-		
+
 		equal(img.getAttribute("width"), "100", "initial width is correct");
-		
+
 		data.attr("width", "300")
 		equal(img.getAttribute('width'), "300", "updated width is correct");
-		
+
 	});
 
 	test("backtracks in mustache (#163)", function () {
 
 		var template = can.view.mustache(
 			"{{#grid.rows}}" +
-				"{{#grid.cols}}" +
-				"<div>{{columnData ../. .}}</div>" +
-				"{{/grid.cols}}" +
-				"{{/grid.rows}}");
+			"{{#grid.cols}}" +
+			"<div>{{columnData ../. .}}</div>" +
+			"{{/grid.cols}}" +
+			"{{/grid.rows}}");
 
 		var grid = new can.Map({
 			rows: [{
@@ -2959,8 +2959,8 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 
 		var tmp = can.view.mustache(
 			"<ul>{{#if showing}}" +
-				"{{#each items}}<li>item</li>{{/items}}" +
-				"{{/if}}</ul>")
+			"{{#each items}}<li>item</li>{{/items}}" +
+			"{{/if}}</ul>")
 
 		var items = new can.List([1, 2, 3]);
 		var showing = can.compute(true);
@@ -3120,12 +3120,12 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 	test("directly nested live sections unbind without needing the element to be removed", function () {
 		var template = can.view.mustache(
 			"<div>" +
-				"{{#items}}" +
-				"<p>first</p>" +
-				"{{#visible}}<label>foo</label>{{/visible}}" +
-				"<p>second</p>" +
-				"{{/items}}" +
-				"</div>");
+			"{{#items}}" +
+			"<p>first</p>" +
+			"{{#visible}}<label>foo</label>{{/visible}}" +
+			"<p>second</p>" +
+			"{{/items}}" +
+			"</div>");
 
 		var data = new can.Map({
 			items: [{
@@ -3295,7 +3295,7 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 			print_prop: function () {
 				return can.map(
 					can.makeArray(arguments)
-						.slice(0, arguments.length - 1), function (arg) {
+					.slice(0, arguments.length - 1), function (arg) {
 						while (arg && arg.isComputed) {
 							arg = arg();
 						}
@@ -3385,7 +3385,7 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 	test('can.compute should live bind when the value is changed to a Construct (#638)', function () {
 		var renderer = can.view.mustache('<p>{{#counter}} Clicked <span>{{count}}</span> times {{/counter}}</p>'),
 			div = document.createElement('div'),
-		// can.compute(null) will pass
+			// can.compute(null) will pass
 			counter = can.compute(),
 			data = {
 				counter: counter
@@ -3422,16 +3422,16 @@ steal("can/model", "can/view/mustache", "can/test", function() {
 
 		var itemsTemplate = can.view.mustache(
 			"<div>" +
-				"{{#each items}}" +
-				"{{>itempartial}}" +
-				"{{/each}}" +
-				"</div>")
+			"{{#each items}}" +
+			"{{>itempartial}}" +
+			"{{/each}}" +
+			"</div>")
 
 		var items = new can.List([{}, {}])
 
 		var frag = itemsTemplate({
-				items: items
-			}),
+			items: items
+		}),
 			div = frag.childNodes[0],
 			labels = div.getElementsByTagName("label");
 

--- a/view/render.js
+++ b/view/render.js
@@ -202,7 +202,7 @@ steal('can/view', './elements', 'can/view/live', 'can/util/string', function (ca
 				if (unbind) {
 					unbind();
 				}
-				return ( (withinTemplatedSectionWithinAnElement || escape === 2 || !escape) ?
+				return ((withinTemplatedSectionWithinAnElement || escape === 2 || !escape) ?
 					contentText :
 					contentEscape)(value, status === 0 && tag);
 			}

--- a/view/scope/scope.js
+++ b/view/scope/scope.js
@@ -177,17 +177,19 @@ steal('can/util', 'can/construct', 'can/map', 'can/list', 'can/view', 'can/compu
 			 *     curScope.attr("length") //-> 2
 			 */
 			attr: function (key) {
-                // reads for whatever called before attr.  It's possible
-                // that this.read clears them.  We want to restore them.
-                var previousReads = can.__clearReading && can.__clearReading(),
-                    res = this.read(key, {
-                        isArgument: true,
-                        returnObserveMethods: true,
-                        proxyMethods: false
-                    }).value;
-                can.__setReading && can.__setReading(previousReads);
-                
-                return res;
+				// reads for whatever called before attr.  It's possible
+				// that this.read clears them.  We want to restore them.
+				var previousReads = can.__clearReading && can.__clearReading(),
+					res = this.read(key, {
+						isArgument: true,
+						returnObserveMethods: true,
+						proxyMethods: false
+					})
+						.value;
+				if (can.__setReading) {
+					can.__setReading(previousReads);
+				}
+				return res;
 			},
 			/**
 			 * @function can.view.Scope.prototype.add

--- a/view/scope/scope_test.js
+++ b/view/scope/scope_test.js
@@ -1,4 +1,4 @@
-steal("can/view/scope", "can/route", "can/test", function(){
+steal("can/view/scope", "can/route", "can/test", function () {
 	module('can/view/scope');
 	/*	test("basics",function(){
 
@@ -101,8 +101,8 @@ steal("can/view/scope", "can/route", "can/test", function(){
 	});
 	test('backtrack path (#163)', function () {
 		var row = new can.Map({
-				first: 'Justin'
-			}),
+			first: 'Justin'
+		}),
 			col = {
 				format: 'str'
 			}, base = new can.view.Scope(row),
@@ -322,8 +322,8 @@ steal("can/view/scope", "can/route", "can/test", function(){
 			proto_prop: 'thud'
 		});
 		var data = new can.Foo({
-				own_prop: 'quux'
-			}),
+			own_prop: 'quux'
+		}),
 			scope = new can.view.Scope(data);
 		equal(scope.computeData('constructor.static_prop')
 			.compute(), 'baz', 'static prop');

--- a/view/view_test.js
+++ b/view/view_test.js
@@ -1,4 +1,4 @@
-steal("can/view", "can/view/ejs", "can/view/mustache", "can/observe", "can/test", "can/util/fixture", function() {
+steal("can/view", "can/view/ejs", "can/view/mustache", "can/observe", "can/test", "can/util/fixture", function () {
 	var Scanner = can.view.Scanner;
 	module('can/view', {
 		setup: function () {
@@ -242,18 +242,18 @@ steal("can/view", "can/view/ejs", "can/view/mustache", "can/observe", "can/test"
 	});
 	test('Select live bound options don\'t contain __!!__', function () {
 		var domainList = new can.List([{
-				id: 1,
-				name: 'example.com'
-			}, {
-				id: 2,
-				name: 'google.com'
-			}, {
-				id: 3,
-				name: 'yahoo.com'
-			}, {
-				id: 4,
-				name: 'microsoft.com'
-			}]),
+			id: 1,
+			name: 'example.com'
+		}, {
+			id: 2,
+			name: 'google.com'
+		}, {
+			id: 3,
+			name: 'yahoo.com'
+		}, {
+			id: 4,
+			name: 'microsoft.com'
+		}]),
 			frag = can.view(can.test.path('view/test/select.ejs'), {
 				domainList: domainList
 			}),
@@ -537,12 +537,12 @@ steal("can/view", "can/view/ejs", "can/view/mustache", "can/observe", "can/test"
 		var withId = can.view.mustache('test-485', template);
 		var withoutId = can.view.mustache(template);
 		ok(withoutId({
-			message: 'Without id'
-		})
+				message: 'Without id'
+			})
 			.nodeType === 11, 'View without id returned document fragment');
 		ok(withId({
-			message: 'With id'
-		})
+				message: 'With id'
+			})
 			.nodeType === 11, 'View with id returned document fragment');
 	});
 	test('create a template before the custom element works with slash and colon', function () {


### PR DESCRIPTION
If you wrap an attribute in a truthy section, updates to the attributes value will not happen via live binding.

e.g.

```
<img src="..." {{#alt}}alt="{{.}}"{{/alt}}>
```
