### PR TITLE
Fixing truncation of special attribute (src and style) values containing '='

### DIFF
--- a/view/elements.js
+++ b/view/elements.js
@@ -48,7 +48,7 @@ steal('can/util', function (can) {
 				}
 			}
 		},
-		attrReg: /([^\s]+)[\s]*=[\s]*/,
+		attrReg: /([^\s=]+)[\s]*=[\s]*/,
 		// elements whos default value we should set
 		defaultValue: ["input", "textarea"],
 		// a map of parent element to child elements

--- a/view/view_test.js
+++ b/view/view_test.js
@@ -327,16 +327,19 @@ steal("can/view", "can/view/ejs", "can/view/mustache", "can/observe", "can/test"
 		bar.resolve('Bar done');
 	});
 	test('Using \'=\' in attribute does not truncate the value', function () {
-		var template = can.view.ejs('<div id=\'equalTest\' <%= this.attr(\'class\') %>></div>'),
+		var template = can.view.ejs('<img id=\'equalTest\' <%= this.attr(\'class\') %> src="<%= this.attr(\'src\') %>">'),
 			obs = new can.Map({
-				'class': 'class="someClass"'
+				'class': 'class="someClass"',
+				'src': 'http://canjs.us/scripts/static/img/canjs_logo_yellow_small.png'
 			}),
 			frag = template(obs),
-			div;
+			img;
 		can.append(can.$('#qunit-test-area'), frag);
-		div = document.getElementById('equalTest');
+		img = document.getElementById('equalTest');
 		obs.attr('class', 'class="do=not=truncate=me"');
-		equal(div.className, 'do=not=truncate=me', 'class is right');
+		obs.attr('src', 'http://canjs.us/scripts/static/img/canjs_logo_yellow_small.png?wid=100&wid=200');
+		equal(img.className, 'do=not=truncate=me', 'class is right');
+		equal(img.src, 'http://canjs.us/scripts/static/img/canjs_logo_yellow_small.png?wid=100&wid=200', 'attribute is right');
 	});
 	test('basic scanner custom tags', function () {
 		can.view.Scanner.tag('panel', function (el, options) {


### PR DESCRIPTION
Exact same issue as #342 except with `src` and `style` which are considered _special_ attributes. Values for special attributes are passed to [getValue](https://github.com/bitovi/canjs/blob/master/view/live/live.js#L355) where they are run through a few regex.

The value passed to getValue has the attribute name in it followed by an `=`, so  if your `src` value has a '=' in it like `myImage.png?wid=900&hei=450`, getValue would be operating on `src="myImage.png?wid=900&hei=450"` and you would end up with `450`.

Fix is to change the attribute regex to take the string after the first `=` instead of taking the string after the last `=`
