### PR TITLE
Adding grunt test:compatibility

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -79,6 +79,33 @@ module.exports = function (grunt) {
 				builder: builderJSON,
 				root: '../..',
 				out: 'test/amd/'
+			},
+			compatibility: {
+				template: 'test/templates/__configuration__-compat.html.ejs',
+				builder: builderJSON,
+				root: '../../',
+				out: 'test/compatibility/',
+				transform: {
+					module: function (definition) {
+						if (!definition.isDefault) {
+							return definition.name.toLowerCase();
+						}
+						return null;
+					},
+
+					test: function (definition, key) {
+						var name = key.substr(key.lastIndexOf('/') + 1);
+						var path = key.replace('can/', '') + '/';
+						return path + name + '_test.js';
+					},
+
+					options: function (config) {
+						return {
+							pluginified: ['2.0.5'],
+							dist: 'can.' + config
+						};
+					}
+				}
 			}
 		},
 		builder: {
@@ -194,6 +221,18 @@ module.exports = function (grunt) {
 						//'http://localhost:8000/can/test/zepto.html',
 						'http://localhost:8000/test/dist/mootools.html',
 						'http://localhost:8000/test/dist/yui.html'
+					]
+				}
+			},
+			compatibility: {
+				options: {
+					urls: [
+						'http://localhost:8000/test/compatibility/jquery.html',
+						'http://localhost:8000/test/compatibility/jquery-2.html',
+						'http://localhost:8000/test/compatibility/dojo.html',
+						//'http://localhost:8000/can/test/zepto.html',
+						'http://localhost:8000/test/compatibility/mootools.html',
+						'http://localhost:8000/test/compatibility/yui.html'
 					]
 				}
 			},
@@ -320,7 +359,7 @@ module.exports = function (grunt) {
 					exclude : /bower_components\|dist\|docs\|guides\|lib\|node_modules\|src\|examples\|dojo\-\|demos/
 				},
 				files: {
-					'plato/src': '<%= docco.dev.src %>',
+					'plato/src': '<%= docco.dev.src %>'
 				}
 			},
 			tests : {
@@ -330,7 +369,7 @@ module.exports = function (grunt) {
 					exclude : /node_modules/
 				},
 				files: {
-					'plato/tests': '**/*_test.js',
+					'plato/tests': '**/*_test.js'
 				}
 			}
 
@@ -362,8 +401,7 @@ module.exports = function (grunt) {
 			legacy: {
 				options: { to: 'test/pluginified/<%= pkg.version %>.test.js' }
 			}
-		},
-		publish: {}
+		}
 	});
 
 	grunt.loadNpmTasks('grunt-contrib-connect');
@@ -381,6 +419,7 @@ module.exports = function (grunt) {
 
 	grunt.registerTask('quality', [ 'jsbeautifier', 'jshint']);
 	grunt.registerTask('build', ['clean:build', 'builder', 'amdify', 'stealify', 'uglify', 'string-replace:version']);
+	grunt.registerTask('test:compatibility', ['connect', 'connect', 'build', 'testify', 'pluginifyTests:latest', 'qunit:compatibility']);
 	grunt.registerTask('test', ['jshint', 'connect', 'build', 'testify', 'pluginifyTests:latest', 'qunit']);
 	grunt.registerTask('default', ['build']);
 

--- a/test/compatibility/dojo.html
+++ b/test/compatibility/dojo.html
@@ -1,0 +1,64 @@
+<!-- AUTO GENERATED - DO NOT MODIFY -->
+<!DOCTYPE HTML>
+<html>
+    
+    <head>
+        <title>Dojo Compatibility Test Suite</title>
+        <base href="../../" />
+        <!--[if IE]>
+            <script type="text/javascript">
+                // Fix for IE ignoring relative base tags.
+                (function() {
+                    var baseTag = document.getElementsByTagName(
+                        'base')[0];
+                    var loc = window.location.toString();
+                    var location = loc.substring(0, loc.lastIndexOf(
+                            '/') + 1);
+                    baseTag.href = location + baseTag.href;
+                })();
+            </script>
+        <![endif]-->
+        <link rel="stylesheet" type="text/css" href="bower_components/qunit/qunit/qunit.css" />
+        <script type="text/javascript" src="lib/html5shiv.js"></script>
+    </head>
+    
+    <body>
+        
+<h1 id="qunit-header">Dojo Compatibility Test Suite</h1>
+
+        
+<h2 id="qunit-banner"></h2>
+
+        <div id="qunit-testrunner-toolbar"></div>
+        
+<h2 id="qunit-userAgent"></h2>
+
+        <ol id="qunit-tests"></ol>
+        <div id="qunit-test-area"></div>
+        <script type="text/javascript" src="bower_components/qunit/qunit/qunit.js"></script>
+        <script type="text/javascript">
+            QUnit.config.autostart = false;
+        </script>
+        <script type="text/javascript" src="util/dojo/dojo-1.8.1.js"></script>
+        <script type="text/javascript" src="dist/can.dojo.min.js"></script>
+        <script type="text/javascript" src="dist/can.ejs.js"></script>
+        <script type="text/javascript" src="dist/can.route.pushstate.js"></script>
+        <script type="text/javascript" src="dist/can.model.queue.js"></script>
+        <script type="text/javascript" src="dist/can.construct.super.js"></script>
+        <script type="text/javascript" src="dist/can.construct.proxy.js"></script>
+        <script type="text/javascript" src="dist/can.map.delegate.js"></script>
+        <script type="text/javascript" src="dist/can.map.setter.js"></script>
+        <script type="text/javascript" src="dist/can.map.attributes.js"></script>
+        <script type="text/javascript" src="dist/can.map.validations.js"></script>
+        <script type="text/javascript" src="dist/can.map.backup.js"></script>
+        <script type="text/javascript" src="dist/can.map.list.js"></script>
+        <script type="text/javascript" src="dist/can.list.sort.js"></script>
+        <script type="text/javascript" src="dist/can.object.js"></script>
+        <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="test/pluginified/2.0.5.test.js"></script>
+        <script type="text/javascript">
+            QUnit.start();
+        </script>
+    </body>
+
+</html>

--- a/test/compatibility/jquery-2.html
+++ b/test/compatibility/jquery-2.html
@@ -1,0 +1,66 @@
+<!-- AUTO GENERATED - DO NOT MODIFY -->
+<!DOCTYPE HTML>
+<html>
+    
+    <head>
+        <title>jQuery (2.x) Compatibility Test Suite</title>
+        <base href="../../" />
+        <!--[if IE]>
+            <script type="text/javascript">
+                // Fix for IE ignoring relative base tags.
+                (function() {
+                    var baseTag = document.getElementsByTagName(
+                        'base')[0];
+                    var loc = window.location.toString();
+                    var location = loc.substring(0, loc.lastIndexOf(
+                            '/') + 1);
+                    baseTag.href = location + baseTag.href;
+                })();
+            </script>
+        <![endif]-->
+        <link rel="stylesheet" type="text/css" href="bower_components/qunit/qunit/qunit.css" />
+        <script type="text/javascript" src="lib/html5shiv.js"></script>
+    </head>
+    
+    <body>
+        
+<h1 id="qunit-header">jQuery (2.x) Compatibility Test Suite</h1>
+
+        
+<h2 id="qunit-banner"></h2>
+
+        <div id="qunit-testrunner-toolbar"></div>
+        
+<h2 id="qunit-userAgent"></h2>
+
+        <ol id="qunit-tests"></ol>
+        <div id="qunit-test-area"></div>
+        <script type="text/javascript" src="bower_components/qunit/qunit/qunit.js"></script>
+        <script type="text/javascript">
+            QUnit.config.autostart = false;
+        </script>
+        <script type="text/javascript" src="lib/jquery.2.0.3.js"></script>
+        <script type="text/javascript" src="dist/can.jquery.min.js"></script>
+        <script type="text/javascript" src="dist/can.ejs.js"></script>
+        <script type="text/javascript" src="dist/can.route.pushstate.js"></script>
+        <script type="text/javascript" src="dist/can.model.queue.js"></script>
+        <script type="text/javascript" src="dist/can.construct.super.js"></script>
+        <script type="text/javascript" src="dist/can.construct.proxy.js"></script>
+        <script type="text/javascript" src="dist/can.map.delegate.js"></script>
+        <script type="text/javascript" src="dist/can.map.setter.js"></script>
+        <script type="text/javascript" src="dist/can.map.attributes.js"></script>
+        <script type="text/javascript" src="dist/can.map.validations.js"></script>
+        <script type="text/javascript" src="dist/can.map.backup.js"></script>
+        <script type="text/javascript" src="dist/can.map.list.js"></script>
+        <script type="text/javascript" src="dist/can.list.sort.js"></script>
+        <script type="text/javascript" src="dist/can.control.plugin.js"></script>
+        <script type="text/javascript" src="dist/can.view.modifiers.js"></script>
+        <script type="text/javascript" src="dist/can.object.js"></script>
+        <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="test/pluginified/2.0.5.test.js"></script>
+        <script type="text/javascript">
+            QUnit.start();
+        </script>
+    </body>
+
+</html>

--- a/test/compatibility/jquery.html
+++ b/test/compatibility/jquery.html
@@ -1,0 +1,66 @@
+<!-- AUTO GENERATED - DO NOT MODIFY -->
+<!DOCTYPE HTML>
+<html>
+    
+    <head>
+        <title>jQuery Compatibility Test Suite</title>
+        <base href="../../" />
+        <!--[if IE]>
+            <script type="text/javascript">
+                // Fix for IE ignoring relative base tags.
+                (function() {
+                    var baseTag = document.getElementsByTagName(
+                        'base')[0];
+                    var loc = window.location.toString();
+                    var location = loc.substring(0, loc.lastIndexOf(
+                            '/') + 1);
+                    baseTag.href = location + baseTag.href;
+                })();
+            </script>
+        <![endif]-->
+        <link rel="stylesheet" type="text/css" href="bower_components/qunit/qunit/qunit.css" />
+        <script type="text/javascript" src="lib/html5shiv.js"></script>
+    </head>
+    
+    <body>
+        
+<h1 id="qunit-header">jQuery Compatibility Test Suite</h1>
+
+        
+<h2 id="qunit-banner"></h2>
+
+        <div id="qunit-testrunner-toolbar"></div>
+        
+<h2 id="qunit-userAgent"></h2>
+
+        <ol id="qunit-tests"></ol>
+        <div id="qunit-test-area"></div>
+        <script type="text/javascript" src="bower_components/qunit/qunit/qunit.js"></script>
+        <script type="text/javascript">
+            QUnit.config.autostart = false;
+        </script>
+        <script type="text/javascript" src="lib/jquery.1.10.2.js"></script>
+        <script type="text/javascript" src="dist/can.jquery.min.js"></script>
+        <script type="text/javascript" src="dist/can.ejs.js"></script>
+        <script type="text/javascript" src="dist/can.route.pushstate.js"></script>
+        <script type="text/javascript" src="dist/can.model.queue.js"></script>
+        <script type="text/javascript" src="dist/can.construct.super.js"></script>
+        <script type="text/javascript" src="dist/can.construct.proxy.js"></script>
+        <script type="text/javascript" src="dist/can.map.delegate.js"></script>
+        <script type="text/javascript" src="dist/can.map.setter.js"></script>
+        <script type="text/javascript" src="dist/can.map.attributes.js"></script>
+        <script type="text/javascript" src="dist/can.map.validations.js"></script>
+        <script type="text/javascript" src="dist/can.map.backup.js"></script>
+        <script type="text/javascript" src="dist/can.map.list.js"></script>
+        <script type="text/javascript" src="dist/can.list.sort.js"></script>
+        <script type="text/javascript" src="dist/can.control.plugin.js"></script>
+        <script type="text/javascript" src="dist/can.view.modifiers.js"></script>
+        <script type="text/javascript" src="dist/can.object.js"></script>
+        <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="test/pluginified/2.0.5.test.js"></script>
+        <script type="text/javascript">
+            QUnit.start();
+        </script>
+    </body>
+
+</html>

--- a/test/compatibility/mootools.html
+++ b/test/compatibility/mootools.html
@@ -1,0 +1,64 @@
+<!-- AUTO GENERATED - DO NOT MODIFY -->
+<!DOCTYPE HTML>
+<html>
+    
+    <head>
+        <title>Mootools Compatibility Test Suite</title>
+        <base href="../../" />
+        <!--[if IE]>
+            <script type="text/javascript">
+                // Fix for IE ignoring relative base tags.
+                (function() {
+                    var baseTag = document.getElementsByTagName(
+                        'base')[0];
+                    var loc = window.location.toString();
+                    var location = loc.substring(0, loc.lastIndexOf(
+                            '/') + 1);
+                    baseTag.href = location + baseTag.href;
+                })();
+            </script>
+        <![endif]-->
+        <link rel="stylesheet" type="text/css" href="bower_components/qunit/qunit/qunit.css" />
+        <script type="text/javascript" src="lib/html5shiv.js"></script>
+    </head>
+    
+    <body>
+        
+<h1 id="qunit-header">Mootools Compatibility Test Suite</h1>
+
+        
+<h2 id="qunit-banner"></h2>
+
+        <div id="qunit-testrunner-toolbar"></div>
+        
+<h2 id="qunit-userAgent"></h2>
+
+        <ol id="qunit-tests"></ol>
+        <div id="qunit-test-area"></div>
+        <script type="text/javascript" src="bower_components/qunit/qunit/qunit.js"></script>
+        <script type="text/javascript">
+            QUnit.config.autostart = false;
+        </script>
+        <script type="text/javascript" src="lib/mootools-core-1.4.5.js"></script>
+        <script type="text/javascript" src="dist/can.mootools.min.js"></script>
+        <script type="text/javascript" src="dist/can.ejs.js"></script>
+        <script type="text/javascript" src="dist/can.route.pushstate.js"></script>
+        <script type="text/javascript" src="dist/can.model.queue.js"></script>
+        <script type="text/javascript" src="dist/can.construct.super.js"></script>
+        <script type="text/javascript" src="dist/can.construct.proxy.js"></script>
+        <script type="text/javascript" src="dist/can.map.delegate.js"></script>
+        <script type="text/javascript" src="dist/can.map.setter.js"></script>
+        <script type="text/javascript" src="dist/can.map.attributes.js"></script>
+        <script type="text/javascript" src="dist/can.map.validations.js"></script>
+        <script type="text/javascript" src="dist/can.map.backup.js"></script>
+        <script type="text/javascript" src="dist/can.map.list.js"></script>
+        <script type="text/javascript" src="dist/can.list.sort.js"></script>
+        <script type="text/javascript" src="dist/can.object.js"></script>
+        <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="test/pluginified/2.0.5.test.js"></script>
+        <script type="text/javascript">
+            QUnit.start();
+        </script>
+    </body>
+
+</html>

--- a/test/compatibility/yui.html
+++ b/test/compatibility/yui.html
@@ -1,0 +1,64 @@
+<!-- AUTO GENERATED - DO NOT MODIFY -->
+<!DOCTYPE HTML>
+<html>
+    
+    <head>
+        <title>YUI Compatibility Test Suite</title>
+        <base href="../../" />
+        <!--[if IE]>
+            <script type="text/javascript">
+                // Fix for IE ignoring relative base tags.
+                (function() {
+                    var baseTag = document.getElementsByTagName(
+                        'base')[0];
+                    var loc = window.location.toString();
+                    var location = loc.substring(0, loc.lastIndexOf(
+                            '/') + 1);
+                    baseTag.href = location + baseTag.href;
+                })();
+            </script>
+        <![endif]-->
+        <link rel="stylesheet" type="text/css" href="bower_components/qunit/qunit/qunit.css" />
+        <script type="text/javascript" src="lib/html5shiv.js"></script>
+    </head>
+    
+    <body>
+        
+<h1 id="qunit-header">YUI Compatibility Test Suite</h1>
+
+        
+<h2 id="qunit-banner"></h2>
+
+        <div id="qunit-testrunner-toolbar"></div>
+        
+<h2 id="qunit-userAgent"></h2>
+
+        <ol id="qunit-tests"></ol>
+        <div id="qunit-test-area"></div>
+        <script type="text/javascript" src="bower_components/qunit/qunit/qunit.js"></script>
+        <script type="text/javascript">
+            QUnit.config.autostart = false;
+        </script>
+        <script type="text/javascript" src="lib/yui-3.7.3.js"></script>
+        <script type="text/javascript" src="dist/can.yui.min.js"></script>
+        <script type="text/javascript" src="dist/can.ejs.js"></script>
+        <script type="text/javascript" src="dist/can.route.pushstate.js"></script>
+        <script type="text/javascript" src="dist/can.model.queue.js"></script>
+        <script type="text/javascript" src="dist/can.construct.super.js"></script>
+        <script type="text/javascript" src="dist/can.construct.proxy.js"></script>
+        <script type="text/javascript" src="dist/can.map.delegate.js"></script>
+        <script type="text/javascript" src="dist/can.map.setter.js"></script>
+        <script type="text/javascript" src="dist/can.map.attributes.js"></script>
+        <script type="text/javascript" src="dist/can.map.validations.js"></script>
+        <script type="text/javascript" src="dist/can.map.backup.js"></script>
+        <script type="text/javascript" src="dist/can.map.list.js"></script>
+        <script type="text/javascript" src="dist/can.list.sort.js"></script>
+        <script type="text/javascript" src="dist/can.object.js"></script>
+        <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="test/pluginified/2.0.5.test.js"></script>
+        <script type="text/javascript">
+            QUnit.start();
+        </script>
+    </body>
+
+</html>

--- a/test/compatibility/zepto.html
+++ b/test/compatibility/zepto.html
@@ -1,0 +1,64 @@
+<!-- AUTO GENERATED - DO NOT MODIFY -->
+<!DOCTYPE HTML>
+<html>
+    
+    <head>
+        <title>Zepto Compatibility Test Suite</title>
+        <base href="../../" />
+        <!--[if IE]>
+            <script type="text/javascript">
+                // Fix for IE ignoring relative base tags.
+                (function() {
+                    var baseTag = document.getElementsByTagName(
+                        'base')[0];
+                    var loc = window.location.toString();
+                    var location = loc.substring(0, loc.lastIndexOf(
+                            '/') + 1);
+                    baseTag.href = location + baseTag.href;
+                })();
+            </script>
+        <![endif]-->
+        <link rel="stylesheet" type="text/css" href="bower_components/qunit/qunit/qunit.css" />
+        <script type="text/javascript" src="lib/html5shiv.js"></script>
+    </head>
+    
+    <body>
+        
+<h1 id="qunit-header">Zepto Compatibility Test Suite</h1>
+
+        
+<h2 id="qunit-banner"></h2>
+
+        <div id="qunit-testrunner-toolbar"></div>
+        
+<h2 id="qunit-userAgent"></h2>
+
+        <ol id="qunit-tests"></ol>
+        <div id="qunit-test-area"></div>
+        <script type="text/javascript" src="bower_components/qunit/qunit/qunit.js"></script>
+        <script type="text/javascript">
+            QUnit.config.autostart = false;
+        </script>
+        <script type="text/javascript" src="bower_components/zepto/zepto.js"></script>
+        <script type="text/javascript" src="dist/can.zepto.min.js"></script>
+        <script type="text/javascript" src="dist/can.ejs.js"></script>
+        <script type="text/javascript" src="dist/can.route.pushstate.js"></script>
+        <script type="text/javascript" src="dist/can.model.queue.js"></script>
+        <script type="text/javascript" src="dist/can.construct.super.js"></script>
+        <script type="text/javascript" src="dist/can.construct.proxy.js"></script>
+        <script type="text/javascript" src="dist/can.map.delegate.js"></script>
+        <script type="text/javascript" src="dist/can.map.setter.js"></script>
+        <script type="text/javascript" src="dist/can.map.attributes.js"></script>
+        <script type="text/javascript" src="dist/can.map.validations.js"></script>
+        <script type="text/javascript" src="dist/can.map.backup.js"></script>
+        <script type="text/javascript" src="dist/can.map.list.js"></script>
+        <script type="text/javascript" src="dist/can.list.sort.js"></script>
+        <script type="text/javascript" src="dist/can.object.js"></script>
+        <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="test/pluginified/2.0.5.test.js"></script>
+        <script type="text/javascript">
+            QUnit.start();
+        </script>
+    </body>
+
+</html>

--- a/test/templates/__configuration__-compat.html.ejs
+++ b/test/templates/__configuration__-compat.html.ejs
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <title><%= configuration.description %> Compatibility Test Suite</title>
+    <base href="<%= root %>" />
+    <!--[if IE]><script type="text/javascript">
+        // Fix for IE ignoring relative base tags.
+        (function() {
+            var baseTag = document.getElementsByTagName('base')[0];
+            var loc = window.location.toString();
+            var location = loc.substring(0, loc.lastIndexOf('/') + 1);
+            baseTag.href = location + baseTag.href;
+        })();
+    </script><![endif]-->
+    <link rel="stylesheet" type="text/css" href="bower_components/qunit/qunit/qunit.css"/>
+    <script type="text/javascript" src="lib/html5shiv.js"></script>
+</head>
+<body>
+<h1 id="qunit-header"><%= configuration.description %> Compatibility Test Suite</h1>
+
+<h2 id="qunit-banner"></h2>
+
+<div id="qunit-testrunner-toolbar"></div>
+<h2 id="qunit-userAgent"></h2>
+<ol id="qunit-tests"></ol>
+<div id="qunit-test-area"></div>
+
+<script type="text/javascript" src="bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript">
+    QUnit.config.autostart = false;
+</script>
+
+<script type="text/javascript" src="<%= configuration.library %>"></script>
+<script type="text/javascript" src="dist/<%= dist.replace('-2', '') %>.min.js"></script>
+<% modules.forEach(function(module) { %>
+<% if(!module.isDefault) { %>
+<script type="text/javascript" src="dist/<%= module %>.js"></script>
+<% } %>
+<% }); %>
+<% pluginified.forEach(function(version) { %>
+<script type="text/javascript" src="test/pluginified/<%= version %>.test.js"></script>
+<% }); %>
+
+<script type="text/javascript">
+    QUnit.start();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
This pull request adds support to test backwards compatibility by running the current dist build against a list of pluginified tests from previous versions (currently just 2.0.5).
