### PR TITLE
Use QUnit CDN by default. Fall back to bower components if not found.

### DIFF
--- a/test/dojo.html
+++ b/test/dojo.html
@@ -4,8 +4,8 @@
     
     <head>
         <title>Dojo Test Suite</title>
-        <link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" />
         <script type="text/javascript" src="../lib/html5shiv.js"></script>
+        <link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css" />
     </head>
     
     <body>
@@ -19,8 +19,15 @@
         <ol id="qunit-tests"></ol>
         <div id="qunit-test-area"></div>
         <script type="text/javascript" src="../lib/steal/steal.js"></script>
-        <script type="text/javascript" src="../bower_components/qunit/qunit/qunit.js"></script>
+        <script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
         <script type="text/javascript">
+            if (typeof QUnit === 'undefined') {
+                document.write(unescape(
+                        '%3Clink rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" /%3E'));
+                document.write(unescape(
+                        '%3Cscript type="text/javascript" src="../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+            }
+
             QUnit.config.autostart = false;
 
             steal(function() {

--- a/test/jquery-2.html
+++ b/test/jquery-2.html
@@ -4,8 +4,8 @@
     
     <head>
         <title>jQuery (2.x) Test Suite</title>
-        <link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" />
         <script type="text/javascript" src="../lib/html5shiv.js"></script>
+        <link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css" />
     </head>
     
     <body>
@@ -19,8 +19,15 @@
         <ol id="qunit-tests"></ol>
         <div id="qunit-test-area"></div>
         <script type="text/javascript" src="../lib/steal/steal.js"></script>
-        <script type="text/javascript" src="../bower_components/qunit/qunit/qunit.js"></script>
+        <script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
         <script type="text/javascript">
+            if (typeof QUnit === 'undefined') {
+                document.write(unescape(
+                        '%3Clink rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" /%3E'));
+                document.write(unescape(
+                        '%3Cscript type="text/javascript" src="../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+            }
+
             QUnit.config.autostart = false;
 
             steal(function() {

--- a/test/jquery.html
+++ b/test/jquery.html
@@ -4,8 +4,8 @@
     
     <head>
         <title>jQuery Test Suite</title>
-        <link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" />
         <script type="text/javascript" src="../lib/html5shiv.js"></script>
+        <link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css" />
     </head>
     
     <body>
@@ -19,8 +19,15 @@
         <ol id="qunit-tests"></ol>
         <div id="qunit-test-area"></div>
         <script type="text/javascript" src="../lib/steal/steal.js"></script>
-        <script type="text/javascript" src="../bower_components/qunit/qunit/qunit.js"></script>
+        <script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
         <script type="text/javascript">
+            if (typeof QUnit === 'undefined') {
+                document.write(unescape(
+                        '%3Clink rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" /%3E'));
+                document.write(unescape(
+                        '%3Cscript type="text/javascript" src="../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+            }
+
             QUnit.config.autostart = false;
 
             steal(function() {

--- a/test/mootools.html
+++ b/test/mootools.html
@@ -4,8 +4,8 @@
     
     <head>
         <title>Mootools Test Suite</title>
-        <link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" />
         <script type="text/javascript" src="../lib/html5shiv.js"></script>
+        <link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css" />
     </head>
     
     <body>
@@ -19,8 +19,15 @@
         <ol id="qunit-tests"></ol>
         <div id="qunit-test-area"></div>
         <script type="text/javascript" src="../lib/steal/steal.js"></script>
-        <script type="text/javascript" src="../bower_components/qunit/qunit/qunit.js"></script>
+        <script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
         <script type="text/javascript">
+            if (typeof QUnit === 'undefined') {
+                document.write(unescape(
+                        '%3Clink rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" /%3E'));
+                document.write(unescape(
+                        '%3Cscript type="text/javascript" src="../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+            }
+
             QUnit.config.autostart = false;
 
             steal(function() {

--- a/test/templates/__configuration__.html.ejs
+++ b/test/templates/__configuration__.html.ejs
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title><%= configuration.description %> Test Suite</title>
-		<link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css"/>
         <script type="text/javascript" src="../lib/html5shiv.js"></script>
+        <link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 	</head>
 <body>
 	<h1 id="qunit-header"><%= configuration.description %> Test Suite</h1>
@@ -14,8 +14,13 @@
 	<div id="qunit-test-area"></div>
 
 	<script type="text/javascript" src="../lib/steal/steal.js"></script>
-	<script type="text/javascript" src="../bower_components/qunit/qunit/qunit.js"></script>
+	<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 	<script type="text/javascript">
+        if (typeof QUnit === 'undefined') {
+            document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" /%3E'));
+            document.write(unescape('%3Cscript type="text/javascript" src="../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+        }
+
 		QUnit.config.autostart = false;
 
         steal(function() {

--- a/test/yui.html
+++ b/test/yui.html
@@ -4,8 +4,8 @@
     
     <head>
         <title>YUI Test Suite</title>
-        <link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" />
         <script type="text/javascript" src="../lib/html5shiv.js"></script>
+        <link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css" />
     </head>
     
     <body>
@@ -19,8 +19,15 @@
         <ol id="qunit-tests"></ol>
         <div id="qunit-test-area"></div>
         <script type="text/javascript" src="../lib/steal/steal.js"></script>
-        <script type="text/javascript" src="../bower_components/qunit/qunit/qunit.js"></script>
+        <script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
         <script type="text/javascript">
+            if (typeof QUnit === 'undefined') {
+                document.write(unescape(
+                        '%3Clink rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" /%3E'));
+                document.write(unescape(
+                        '%3Cscript type="text/javascript" src="../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+            }
+
             QUnit.config.autostart = false;
 
             steal(function() {

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -4,8 +4,8 @@
     
     <head>
         <title>Zepto Test Suite</title>
-        <link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" />
         <script type="text/javascript" src="../lib/html5shiv.js"></script>
+        <link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css" />
     </head>
     
     <body>
@@ -19,8 +19,15 @@
         <ol id="qunit-tests"></ol>
         <div id="qunit-test-area"></div>
         <script type="text/javascript" src="../lib/steal/steal.js"></script>
-        <script type="text/javascript" src="../bower_components/qunit/qunit/qunit.js"></script>
+        <script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
         <script type="text/javascript">
+            if (typeof QUnit === 'undefined') {
+                document.write(unescape(
+                        '%3Clink rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" /%3E'));
+                document.write(unescape(
+                        '%3Cscript type="text/javascript" src="../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+            }
+
             QUnit.config.autostart = false;
 
             steal(function() {


### PR DESCRIPTION
This pull request uses the QUnit CDN by default and falls back to the Bower components if not found (e.g. when developing offline).
