### PR TITLE
Updating individual test files to run on CDN and Bower components

### DIFF
--- a/component/test.html
+++ b/component/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-<link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" />
+<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css" />
 
 	<style>.active {
 		border: solid 1px red;
@@ -17,11 +17,17 @@
 <ol id="qunit-tests"></ol>
 <div id="qunit-test-area"></div>
 <script type="text/javascript" src="../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/component/component_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/compute/test.html
+++ b/compute/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">can.compute Test Suite</h1>
@@ -14,11 +14,17 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/compute/compute_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/construct/proxy/test.html
+++ b/construct/proxy/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">can.Construct.proxy Test Suite</h1>
@@ -14,11 +14,17 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/construct/proxy/proxy_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/construct/super/test.html
+++ b/construct/super/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">can.Construct.super Test Suite</h1>
@@ -14,11 +14,17 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/construct/super/super_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/construct/test.html
+++ b/construct/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">can.Construct Test Suite</h1>
@@ -14,11 +14,17 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/construct/construct_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/control/modifier/test.html
+++ b/control/modifier/test.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <title>can.Control modifier QUnit Test</title>
-    <link rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css"/>
+    <link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">route Test Suite</h1>
@@ -14,11 +14,17 @@
 <div id="qunit-test-area">
 </div>
 <script type="text/javascript" src="../../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type='text/javascript'>
-QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
     steal('can/control/modifier/modifier_test.js', function(){
-    	can.dev.logLevel = 3; QUnit.start();
+    	can.dev.logLevel = 3;
+        QUnit.start();
     })
 </script>
 </body>

--- a/control/plugin/test.html
+++ b/control/plugin/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">can.Control.plugin Test Suite</h1>
@@ -14,11 +14,17 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/control/plugin/plugin_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/control/route/test.html
+++ b/control/route/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">can.Control.plugin Test Suite</h1>
@@ -14,11 +14,17 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/control/route/route_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/control/test.html
+++ b/control/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">can.Control Test Suite</h1>
@@ -14,11 +14,17 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/control/control_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/control/view/test.html
+++ b/control/view/test.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-		<link rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css"/>
+		<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
     </head>
     <body>
 
@@ -12,11 +12,17 @@
         <ol id="qunit-tests"></ol>
 		<div id="qunit-test-area"></div>
 		<script type="text/javascript" src="../../lib/steal/steal.js"></script>
-		<script type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js"></script>
+		<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 		<script type="text/javascript">
-			QUnit.config.autostart = false;
+            if (typeof QUnit === 'undefined') {
+                document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css" /%3E'));
+                document.write(unescape('%3Cscript type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+            }
+
+            QUnit.config.autostart = false;
 			steal("can/control/view").then("can/control/view/test/view_test.js", function() {
-				can.dev.logLevel = 3; can.dev.logLevel = 3; QUnit.start();
+				can.dev.logLevel = 3;
+                QUnit.start();
 			});
 		</script>
     </body>

--- a/list/test.html
+++ b/list/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">can.List Test Suite</h1>
@@ -14,11 +14,17 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/list/list_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/map/attributes/test.html
+++ b/map/attributes/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">can.Map.attributes Test Suite</h1>
@@ -14,11 +14,17 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/map/attributes/attributes_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/map/backup/test.html
+++ b/map/backup/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">can.Map Backup Test Suite</h1>
@@ -14,11 +14,17 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/map/backup/backup_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/map/delegate/test.html
+++ b/map/delegate/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">can.Map.delegate Test Suite</h1>
@@ -14,11 +14,17 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/map/delegate/delegate_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/map/list/test.html
+++ b/map/list/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <link rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css"/>
+  <link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
   <title>can.Map.Collection Test Suite</title>
 </head>
 <body>
@@ -13,11 +13,17 @@
 <ol id="qunit-tests"></ol>
 <div id="qunit-test-area"></div>
 <script type="text/javascript" src="../../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
     QUnit.config.autostart = false;
     steal("can/map/list/list_test.js", function() {
-        can.dev.logLevel = 3; QUnit.start();
+        can.dev.logLevel = 3;
+        QUnit.start();
     });
 </script>
 </body>

--- a/map/setter/test.html
+++ b/map/setter/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">can.Map.setter Test Suite</h1>
@@ -14,11 +14,17 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/map/setter/setter_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/map/sort/test.html
+++ b/map/sort/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">can.Map sort Test Suite</h1>
@@ -14,11 +14,17 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/map/sort/sort_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/map/test.html
+++ b/map/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">can.Map Test Suite</h1>
@@ -14,11 +14,17 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/map/map_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/map/validations/test.html
+++ b/map/validations/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">can.Map.validations Test Suite</h1>
@@ -14,12 +14,19 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+
+    QUnit.config.autostart = false;
 
 	steal("can/map/validations/validations_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/model/test.html
+++ b/model/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">can.Model Test Suite</h1>
@@ -14,11 +14,17 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/model/model_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/observe/test.html
+++ b/observe/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">can.Map Test Suite</h1>
@@ -14,11 +14,17 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/observe/observe_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/route/pushstate/test.html
+++ b/route/pushstate/test.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-        <link rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css"/>
+        <link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
         <title>can.route Pushstate Test</title>
     </head>
     <body>
@@ -12,11 +12,17 @@
         <ol id="qunit-tests"></ol>
         <div id="qunit-test-area"></div>
         <script type="text/javascript" src="../../lib/steal/steal.js"></script>
-		<script type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js"></script>
+		<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 	    <script type='text/javascript'>
-	    	QUnit.config.autostart = false;
+            if (typeof QUnit === 'undefined') {
+                document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css" /%3E'));
+                document.write(unescape('%3Cscript type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+            }
+
+            QUnit.config.autostart = false;
 			steal('can/route/pushstate/pushstate_test.js', function() {
-				can.dev.logLevel = 3; QUnit.start();
+				can.dev.logLevel = 3;
+                QUnit.start();
 			});
 	    </script>
     </body>

--- a/route/test.html
+++ b/route/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">can.route Test Suite</h1>
@@ -14,11 +14,17 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/route/route_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/util/event/test.html
+++ b/util/event/test.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-        <link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css"/>
+        <link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
         <title>can.util.event Test</title>
     </head>
     <body>
@@ -12,12 +12,18 @@
         <ol id="qunit-tests"></ol>
         <div id="qunit-test-area"></div>
         <script type="text/javascript" src="../../lib/steal/steal.js"></script>
-		<script type="text/javascript" src="../bower_components/qunit/qunit/qunit.js"></script>
+		<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 	    <script type='text/javascript'>
-	    	QUnit.config.autostart = false;
+            if (typeof QUnit === 'undefined') {
+                document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css" /%3E'));
+                document.write(unescape('%3Cscript type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+            }
+
+            QUnit.config.autostart = false;
 			steal('can/util')
 				.then("can/test", 'can/util/event/event_test.js', function() {
-				can.dev.logLevel = 3; can.dev.logLevel = 3; QUnit.start();
+				can.dev.logLevel = 3;
+                QUnit.start();
 			});
 	    </script>
     </body>

--- a/view/bindings/test.html
+++ b/view/bindings/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">can.view Test Suite</h1>
@@ -14,11 +14,17 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/view/bindings/bindings_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/view/ejs/test.html
+++ b/view/ejs/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">can.EJS Test Suite</h1>
@@ -14,11 +14,17 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/view/ejs/ejs_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/view/live/test.html
+++ b/view/live/test.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 <title>can/view/mustache/live</title>
 </head>
 <body>
@@ -13,11 +13,17 @@
 <ol id="qunit-tests"></ol>
 <div id="qunit-test-area"></div>
 <script type="text/javascript" src="../../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/view/live/live_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/view/modifiers/test.html
+++ b/view/modifiers/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">can.modifiers Test Suite</h1>
@@ -14,11 +14,17 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/view/modifiers/modifiers_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/view/mustache/test.html
+++ b/view/mustache/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">can.Mustache Test Suite</h1>
@@ -14,11 +14,17 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/view/mustache/mustache_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/view/node_lists/test.html
+++ b/view/node_lists/test.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 <title>can/view/mustache/live/node_list/test</title>
 </head>
 <body>
@@ -12,12 +12,18 @@
 <h2 id="qunit-userAgent"></h2>
 <ol id="qunit-tests"></ol>
 <div id="qunit-test-area"></div>
-<script type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript" src="../../lib/steal/steal.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/view/node_lists/node_lists_test.js", function() {
-		can.dev.logLevel = 3; can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/view/scope/test.html
+++ b/view/scope/test.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 <title>can/view/mustache/scope</title>
 </head>
 <body>
@@ -13,11 +13,17 @@
 <ol id="qunit-tests"></ol>
 <div id="qunit-test-area"></div>
 <script type="text/javascript" src="../../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/view/scope/scope_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>

--- a/view/test.html
+++ b/view/test.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css"/>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
 </head>
 <body>
 <h1 id="qunit-header">can.view Test Suite</h1>
@@ -14,11 +14,17 @@
 <div id="qunit-test-area"></div>
 
 <script type="text/javascript" src="../lib/steal/steal.js"></script>
-<script type="text/javascript" src="../bower_components/qunit/qunit/qunit.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
 <script type="text/javascript">
-	QUnit.config.autostart = false;
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
 	steal("can/view/view_test.js", function() {
-		can.dev.logLevel = 3; QUnit.start();
+		can.dev.logLevel = 3;
+        QUnit.start();
 	});
 </script>
 </body>


### PR DESCRIPTION
In addition to #722 this pull request updates the individual test files that the API on canjs.com links to to use the QUnit CDN (and Bower components as the fallback).
