### PR TITLE
Event "Bubbling" for can.Model subclasses

### DIFF
--- a/model/model.js
+++ b/model/model.js
@@ -948,6 +948,10 @@ steal('can/util', 'can/map', 'can/list', function (can) {
 				// Add ajax converters.
 				can.Model._reqs = 0;
 				this._url = this._shortName + '/{' + this.id + '}';
+				this.__bindEvents = {};
+				if(base.__bindEvents) {
+					this.__bindEvents.__base = base.__bindEvents;
+				}
 			},
 			_ajax: ajaxMaker,
 			_makeRequest: makeRequest,

--- a/model/model_test.js
+++ b/model/model_test.js
@@ -1252,6 +1252,7 @@ steal("can/model", 'can/map/attributes', "can/test", "can/util/fixture", functio
 
 		can.trigger(Parent, 'updated');
 		can.trigger(Child1, 'updated');
+		can.trigger(Child2, 'foo'); //jslint ;_;
 		equal(parentTriggers, 2, "parent triggers");
 		equal(child1Triggers, 1, "child 1 triggers");
 		equal(child2Triggers, 0, "child 2 triggers");

--- a/model/model_test.js
+++ b/model/model_test.js
@@ -1220,4 +1220,40 @@ steal("can/model", 'can/map/attributes', "can/test", "can/util/fixture", functio
 			t.unbind('name', handler);
 		});
 	});
+	test('model event propagation only goes up the type tree', function () {
+		var parentTriggers = 0, child1Triggers = 0, child2Triggers = 0;
+		var Parent = can.Model.extend("Parent", {
+			init : function() {
+			  this.bind('updated', function () {
+					parentTriggers++;
+					ok(true, 'parent handler called');
+				});
+			}
+		}, {});
+		var Child1 = Parent.extend("Child1", {
+			init : function() {
+			  this.bind('updated', function () {
+					child1Triggers++;
+					if (child1Triggers === 1) {
+						ok(true, 'child 1 handler called');
+					} else {
+						ok(false, 'child 1 handler should only be called once');
+					}
+				});
+			}
+		}, {});
+		var Child2 = Parent.extend({
+			init : function() {
+			  this.bind('updated', function () {
+					ok(false, 'child 2 handler should not be called');
+				});
+			}
+		}, {});
+
+		can.trigger(Parent, 'updated');
+		can.trigger(Child1, 'updated');
+		equal(parentTriggers, 2, "parent triggers");
+		equal(child1Triggers, 1, "child 1 triggers");
+		equal(child2Triggers, 0, "child 2 triggers");
+	});
 });

--- a/util/event.js
+++ b/util/event.js
@@ -109,7 +109,7 @@ steal('can/util/can.js', function (can) {
 		var eventName = event.type, allHandlers, handlers, ev;
 		args = [event].concat(args || []);
 		allHandlers = this.__bindEvents;
-		do {
+		while(allHandlers) {
 			handlers = (allHandlers && allHandlers[eventName] || [])
 				.slice(0);
 			for (var i = 0, len = handlers.length; i < len; i++) {
@@ -117,7 +117,7 @@ steal('can/util/can.js', function (can) {
 				ev.handler.apply(this, args);
 			}
 			allHandlers = allHandlers.__base; // is there an inheritance chain to go up?
-		} while(allHandlers);
+		}
 	};
 	return can;
 });

--- a/util/event.js
+++ b/util/event.js
@@ -3,8 +3,8 @@ steal('can/util/can.js', function (can) {
 	// ---------
 	// _Basic event wrapper._
 	can.addEvent = function (event, fn) {
-		var allEvents = this.__bindEvents || (this.__bindEvents = {}),
-			eventList = allEvents[event] || (allEvents[event] = []);
+    var allEvents = this.__bindEvents || (this.__bindEvents = {}),
+      eventList = allEvents[event] || (allEvents[event] = []);
 		eventList.push({
 			handler: fn,
 			name: event
@@ -81,7 +81,7 @@ steal('can/util/can.js', function (can) {
 		return this;
 	};
 	can.removeEvent = function (event, fn) {
-		if (!this.__bindEvents) {
+		if (!this.hasOwnProperty("__bindEvents") || !this.__bindEvents.hasOwnProperty(event)) {
 			return this;
 		}
 		var events = this.__bindEvents[event] || [],
@@ -106,15 +106,18 @@ steal('can/util/can.js', function (can) {
 				type: event
 			};
 		}
-		var eventName = event.type,
-			handlers = (this.__bindEvents[eventName] || [])
-				.slice(0),
-			ev;
+		var eventName = event.type, allHandlers, handlers, ev;
 		args = [event].concat(args || []);
-		for (var i = 0, len = handlers.length; i < len; i++) {
-			ev = handlers[i];
-			ev.handler.apply(this, args);
-		}
+		allHandlers = this.__bindEvents;
+		do {
+			handlers = (allHandlers && allHandlers.hasOwnProperty(eventName) ? allHandlers[eventName] : [])
+				.slice(0);
+			for (var i = 0, len = handlers.length; i < len; i++) {
+				ev = handlers[i];
+				ev.handler.apply(this, args);
+			}
+			allHandlers = allHandlers.__base; // is there an inheritance chain to go up?
+		} while(allHandlers);
 	};
 	return can;
 });

--- a/util/event.js
+++ b/util/event.js
@@ -3,8 +3,8 @@ steal('can/util/can.js', function (can) {
 	// ---------
 	// _Basic event wrapper._
 	can.addEvent = function (event, fn) {
-    var allEvents = this.__bindEvents || (this.__bindEvents = {}),
-      eventList = allEvents[event] || (allEvents[event] = []);
+		var allEvents = this.__bindEvents || (this.__bindEvents = {}),
+			eventList = allEvents[event] || (allEvents[event] = []);
 		eventList.push({
 			handler: fn,
 			name: event
@@ -81,7 +81,7 @@ steal('can/util/can.js', function (can) {
 		return this;
 	};
 	can.removeEvent = function (event, fn) {
-		if (!this.hasOwnProperty("__bindEvents") || !this.__bindEvents.hasOwnProperty(event)) {
+		if (!this.__bindEvents) {
 			return this;
 		}
 		var events = this.__bindEvents[event] || [],
@@ -110,7 +110,7 @@ steal('can/util/can.js', function (can) {
 		args = [event].concat(args || []);
 		allHandlers = this.__bindEvents;
 		do {
-			handlers = (allHandlers && allHandlers.hasOwnProperty(eventName) ? allHandlers[eventName] : [])
+			handlers = (allHandlers && allHandlers[eventName] || [])
 				.slice(0);
 			for (var i = 0, len = handlers.length; i < len; i++) {
 				ev = handlers[i];


### PR DESCRIPTION
I've been perpetually annoyed at defining something like the following every time I listen on a Model class event:
```javascript
"{TodoTask} updated" : function(model, ev, instance) {
  if(instance instanceof TodoTask) {
 // ... actually get to work
 }
}
```

This is because of a peculiarity of how can.Construct creates and propagates static properties.  The __bindEvents repository for event bindings on objects gets passed along if it gets defined before the subclass is created.

That is to say, if I create ```can.Model("Todo", { init : function() { this.bind("created", ...); } }, {})``` and then extend Todo into SharedTodo, both classes share the same created/updated/destroyed event bindings.  All subclasses of Todo will share these event bindings and you have to pick apart which type you actually want to listen on, on each event firing.

This pull request is intended to resolve this problem elegantly.  Now event bindings can propagate up a class hierarchy instead of spanning the entire tree.