### PR TITLE
Adding feature detection for sourceURL in Scanner

### DIFF
--- a/view/scanner.js
+++ b/view/scanner.js
@@ -70,14 +70,14 @@ steal('can/view', './elements', function (can, elements) {
 			return stack[stack.length - 1];
 		},
 		// characters that automatically mean a custom element
-		automaticCustomElementCharacters = /[-\:]/,		
+		automaticCustomElementCharacters = /[-\:]/,
 		Scanner;
 
 	// Detect if sourceURL can be used without errors
- 	// In IE, `@` symbols are part of its non-standard conditional compilation 
- 	// support. The `@cc_on` statement activates its support while the trailing 
- 	// `!` induces a syntax error to exlude it.
- 	// See http://msdn.microsoft.com/en-us/library/121hztk3(v=vs.94).aspx
+	// In IE, `@` symbols are part of its non-standard conditional compilation
+	// support. The `@cc_on` statement activates its support while the trailing
+	// `!` induces a syntax error to exlude it.
+	// See http://msdn.microsoft.com/en-us/library/121hztk3(v=vs.94).aspx
 	try {
 		var useSourceURL = (Function('//@cc_on!')(), true);
 	} catch(e) {}

--- a/view/view_test.js
+++ b/view/view_test.js
@@ -609,7 +609,7 @@ steal("can/view", "can/view/ejs", "can/view/mustache", "can/observe", "can/test"
 			});
 		}
 	}
-	test('should not error with IE conditional compilation turned on', function(){
+	test('should not error with IE conditional compilation turned on (#679)', function(){
 		var pass = true;
 		/*@cc_on @*/
 		var template = can.view.mustache('Hello World');
@@ -619,5 +619,5 @@ steal("can/view", "can/view/ejs", "can/view/mustache", "can/observe", "can/test"
 			pass = false;
 		}
 		ok(pass);
-	})
+	});
 });


### PR DESCRIPTION
Fix inspired by Lodash's [fix](https://github.com/lodash/lodash/commit/fadcc4c61760bcf91da288580033c5d05de8ca98) for a very similar issue.

When conditional compilation is on, `useSourceURL` will be undefined and the `@sourceURL` comment will not be added to the compiled template.

Closes #679
