### PR TITLE
Changing typeof check to a check for apply (#681)

### DIFF
--- a/route/route.js
+++ b/route/route.js
@@ -568,7 +568,7 @@ steal('can/util', 'can/map', 'can/list','can/util/string/deparam', function (can
 				prop = args.shift(),
 				binding = can.route.bindings[can.route.currentBinding || can.route.defaultBinding],
 				method = binding[prop];
-			if (typeof method === "function") {
+			if (method.apply) {
 				return method.apply(binding, args);
 			} else {
 				return method;


### PR DESCRIPTION
One of the methods that goes through this code path is a RegExp and in certain older browsers, RegExp is callable meaning using `typeof` on one returns`'function'`. So it passes the `typeof` check and when we try to use `apply` on the RegExp it throws an error.

You can see bugs to fix this weirdness in [all](https://bugs.webkit.org/show_bug.cgi?id=28285) [major](https://code.google.com/p/v8/issues/detail?id=617) [browsers](https://bugzilla.mozilla.org/show_bug.cgi?id=582717#c7).

The fix is to check `method` for `apply` instead of using a `typeof` check.

Closes #681
