### PR TITLE
can.Object.same should check date values when comparing

### DIFF
--- a/util/object/object.js
+++ b/util/object/object.js
@@ -97,7 +97,7 @@ steal('can/util', function (can) {
 			return a === b;
 		}
 		if (a instanceof Date || b instanceof Date) {
-			return a === b;
+			return a.getTime() === b.getTime();
 		}
 		if (deep === -1) {
 			return aType === 'object' || a === b;

--- a/util/object/object_test.js
+++ b/util/object/object_test.js
@@ -27,6 +27,11 @@ steal('can/util/object', function () {
 			{foo: null},
 			{foo: {}}
 		), 'nulls and empty objects are not considered the same. (#773)');
+
+		ok(can.Object.same(
+			{foo: new Date()},
+			{foo: new Date()}
+		), 'nulls and Dates are not considered the same. (#773)');
 	});
 	test('subsets', function () {
 		var res1 = can.Object.subsets({

--- a/util/object/object_test.js
+++ b/util/object/object_test.js
@@ -31,7 +31,7 @@ steal('can/util/object', function () {
 		ok(can.Object.same(
 			{foo: new Date()},
 			{foo: new Date()}
-		), 'nulls and Dates are not considered the same. (#773)');
+		), 'Date values are compared');
 	});
 	test('subsets', function () {
 		var res1 = can.Object.subsets({


### PR DESCRIPTION
This is related to #773 
When values in an Object are dates, their time values should be compared since `new Date() === new Date() //-> false`

http://jsfiddle.net/D9kEv/

This involves a breaking API change.