### PR TITLE
Updating sourceURL syntax to use # instead of @

### DIFF
--- a/view/scanner.js
+++ b/view/scanner.js
@@ -73,15 +73,6 @@ steal('can/view', './elements', function (can, elements) {
 		automaticCustomElementCharacters = /[-\:]/,
 		Scanner;
 
-	// Detect if sourceURL can be used without errors
-	// In IE, `@` symbols are part of its non-standard conditional compilation
-	// support. The `@cc_on` statement activates its support while the trailing
-	// `!` induces a syntax error to exlude it.
-	// See http://msdn.microsoft.com/en-us/library/121hztk3(v=vs.94).aspx
-	try {
-		var useSourceURL = (Function('//@cc_on!')(), true);
-	} catch(e) {}
-
 	/**
 	 * @constructor can.view.Scanner
 	 *
@@ -694,13 +685,9 @@ steal('can/view', './elements', function (can, elements) {
 			var template = buff.join(''),
 				out = {
 					out: (this.text.outStart || '') + template + ' ' + finishTxt + (this.text.outEnd || '')
-				},
-				toEval = 'this.fn = (function(' + this.text.argNames + '){' + out.out + '});';
-			if(useSourceURL) {
-				toEval += '\r\n//@ sourceURL=' + name + '.js';
-			}
+				};
 			// Use `eval` instead of creating a function, because it is easier to debug.
-			myEval.call(out, toEval);
+			myEval.call(out, 'this.fn = (function(' + this.text.argNames + '){' + out.out + '});\r\n//# sourceURL=' + name + '.js');
 			return out;
 		}
 	};


### PR DESCRIPTION
This removes the fixes I made in #679 to support the deprecated `#` syntax and changes Scanner to use the recommended `#` syntax.

Closes #772 
