### PR TITLE
Fix for calling removeAttr with number type (on lists)

### DIFF
--- a/list/list_test.js
+++ b/list/list_test.js
@@ -9,6 +9,11 @@ steal("can/util", "can/list", "can/test", function () {
 		l.attr(3, 3);
 		equal(l.length, 4);
 	});
+	test('removeAttr on list', function() {
+		var l = new can.List([0, 1, 2]);
+		l.removeAttr(0);
+		equal(l.attr('length'), 2);
+	});
 	test('list splice', function () {
 		var l = new can.List([
 			0,

--- a/map/map.js
+++ b/map/map.js
@@ -641,7 +641,7 @@ steal('can/util', 'can/util/bind', 'can/construct', 'can/util/batch', function (
 				if (parts.length && current) {
 					return current.removeAttr(parts);
 				} else {
-					if (!!~attr.indexOf('.')) {
+					if (typeof attr === 'string' && !!~attr.indexOf('.')) {
 						prop = attr;
 					}
 					if (isList) {


### PR DESCRIPTION
Made sure attr is string when calling indexOf
Added test for can.list removeAttr method with number argument.
