### PR TITLE
fixes issue #771

### DIFF
--- a/model/model.js
+++ b/model/model.js
@@ -1758,8 +1758,8 @@ steal('can/util', 'can/map', 'can/list', function (can) {
 		_changes: function (ev, attr) {
 			can.List.prototype._changes.apply(this, arguments);
 			if (/\w+\.destroyed/.test(attr)) {
-				var index = this.indexOf(ev.target);
-				if (index !== -1) {
+				var index;
+				while((index = this.indexOf(ev.target)) > -1) {
 					this.splice(index, 1);
 				}
 			}

--- a/model/model_test.js
+++ b/model/model_test.js
@@ -1448,4 +1448,24 @@ steal("can/model", 'can/map/attributes', "can/test", "can/util/fixture", functio
 
 	});
 
+	test('destroy called on multiple model references in a list (#771)', function() {
+		expect(2);
+
+		var list = new can.Model.List(),
+		Thing = can.Model.extend({
+			destroy: function() {
+				return new $.Deferred().resolve();
+			}
+		}, {});
+
+		var a = new Thing({ name: 'a' });
+		list.push(a, a);
+
+		list.bind('remove', function(ev, items, i) {
+			ok('remove event triggered');
+		});
+
+		a.destroy();
+	});
+
 });


### PR DESCRIPTION
For issue #771, iterate through all model references in a list(as opposed to removing just the first) upon destroy.
