### PR TITLE
Emit events for can.List.prototype.reverse

### DIFF
--- a/list/list.js
+++ b/list/list.js
@@ -871,7 +871,10 @@ steal("can/util", "can/map", function (can, Map) {
 		 * list === reversedList; // true
 		 * @codeend
 		 */
-		reverse: [].reverse,
+		reverse: function() {
+			var list = can.makeArray([].reverse.call(this));
+			this.replace(list);
+		},
 
 		/**
 		 * @function can.List.prototype.slice slice

--- a/list/list_test.js
+++ b/list/list_test.js
@@ -166,4 +166,17 @@ steal("can/util", "can/list", "can/test", function () {
 		l.splice(0, 1);
 		ok(!l.attr(0), 'all props are removed');
 	});
+
+	test('reverse triggers add/remove events (#851)', function() {
+		expect(6);
+		var l = new can.List([1,2,3]);
+
+		l.bind('change', function() { ok(true, 'change should be called'); });
+		l.bind('set', function() { ok(false, 'set should not be called'); });
+		l.bind('add', function() { ok(true, 'add called'); });
+		l.bind('remove', function() { ok(true, 'remove called'); });
+		l.bind('length', function() { ok(true, 'length should be called'); });
+
+		l.reverse();
+	});
 });


### PR DESCRIPTION
Implemented can.List.prototype.reverse to modify the list in place and trigger corresponding events. Closes #851 
