### PR TITLE
Subclassed Model.List should inherit from their parent Model.List

### DIFF
--- a/model/model.js
+++ b/model/model.js
@@ -1083,9 +1083,16 @@ steal('can/util', 'can/map', 'can/list', function (can) {
 				 *     Task.List.Map //-> Task
 				 *
 				 */
-				this.List = ML({
-					Map: this
-				}, {});
+				if(staticProps && staticProps.List) {
+					this.List = staticProps.List;
+					this.List.Map = this;
+				}
+				else {
+					this.List = base.List.extend({
+						Map: this
+					}, {});
+				}
+
 				var self = this,
 					clean = can.proxy(this._clean, self);
 

--- a/model/model_test.js
+++ b/model/model_test.js
@@ -1448,4 +1448,16 @@ steal("can/model", 'can/map/attributes', "can/test", "can/util/fixture", functio
 
 	});
 
+	test('extending a model also inherits model list', function() {
+		var BaseModel = can.Model.extend({});
+		BaseModel.List = can.Model.List.extend({
+			someFunc: function() {}
+		});
+
+
+		var SomeModel = BaseModel.extend({});
+		var list = new SomeModel.List([]);
+		ok(list instanceof BaseModel.List);
+	});
+
 });


### PR DESCRIPTION
Changed model.js to setup the correct model.list in cases of inheritance. Closes #736 
