### PR TITLE
Re-adding inline documentation for can.Map

### DIFF
--- a/map/map.js
+++ b/map/map.js
@@ -1,12 +1,17 @@
-// 1.69
+// # can/map/map.js
+// `can.Map` provides the observable pattern for JavaScript Objects.
+
+
+
+
+
+
 steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batch', function (can, bind, bubble) {
-	// ## map.js  
-	// `can.Map`  
-	// _Provides the observable pattern for JavaScript Objects._  
-	
-	// A map that temporarily houses a reference
-	// to maps that have already been made for a plain ole JS object
+	// ## Helpers
+
+	// A temporary map of Maps that have been made from plain JS objects.
 	var madeMap = null;
+	// Clears out map of converted objects.
 	var teardownMap = function () {
 		for (var cid in madeMap) {
 			if (madeMap[cid].added) {
@@ -15,6 +20,7 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 		}
 		madeMap = null;
 	};
+	// Retrieves a Map instance from an Object.
 	var getMapFromObject = function (obj) {
 		return madeMap && madeMap[obj._cid] && madeMap[obj._cid].instance;
 	};
@@ -31,23 +37,26 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 
 				can.Construct.setup.apply(this, arguments);
 
+				// Do not run if we are defining can.Map.
 				if (can.Map) {
 					if (!this.defaults) {
 						this.defaults = {};
 					}
-					// a list of the compute properties
+					// Builds a list of compute and non-compute properties in this Object's prototype.
 					this._computes = [];
-					
+
 					for (var prop in this.prototype) {
+						// Non-functions are regular defaults.
 						if (prop !== "define" && typeof this.prototype[prop] !== "function") {
 							this.defaults[prop] = this.prototype[prop];
+						// Functions with an `isComputed` property are computes.
 						} else if (this.prototype[prop].isComputed) {
 							this._computes.push(prop);
 						}
 					}
 					this.helpers.define(this);
 				}
-				// if we inerit from can.Map, but not can.List
+				// If we inherit from can.Map, but not can.List, make sure any lists are the correct type.
 				if (can.List && !(this.prototype instanceof can.List)) {
 					this.List = Map.List({
 						Map: this
@@ -55,38 +64,66 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 				}
 
 			},
+			// Reference to bubbling helpers.
 			_bubble: bubble,
+			// Given an eventName, determine if bubbling should be setup.
 			_bubbleRule: function(eventName) {
 				return (eventName === "change" || eventName.indexOf(".") >= 0 ) && "change";
 			},
+			// List of computes on the Map's prototype.
 			_computes: [],
-			// keep so it can be overwritten
+			// Adds an event to this Map.
 			bind: can.bindAndSetup,
 			on: can.bindAndSetup,
+			// Removes an event from this Map.
 			unbind: can.unbindAndTeardown,
 			off: can.unbindAndTeardown,
+			// Name of the id field. Used in can.Model.
 			id: "id",
+			// ## Internal helpers
 			helpers: {
+				// ### can.Map.helpers.define
+				// Stub function for the define plugin.
 				define: function(){},
+				/**
+				 * @hide
+				 * Parses attribute name into its parts
+				 * @param {String|Array} attr attribute name
+				 * @param {Boolean} keepKey whether to keep the key intact
+				 * @return {Array} attribute parts
+				 */
+				// ### can.Map.helpers.attrParts
+				// Parses attribute name into its parts.
 				attrParts: function (attr, keepKey) {
+					//Keep key intact
 					if (keepKey) {
 						return [attr];
 					}
+					// Split key on '.'
 					return can.isArray(attr) ? attr : ("" + attr)
 						.split(".");
 				},
-
+				/**
+				 * @hide
+				 * Tracks Map instances created from JS Objects
+				 * @param {Object} obj original Object
+				 * @param {can.Map} instance the can.Map instance
+				 * @return {Function} function to clear out object mapping
+				 */
+				// ### can.Map.helpers.addToMap
+				// Tracks Map instances created from JS Objects
 				addToMap: function (obj, instance) {
 					var teardown;
+					// Setup a fresh mapping if `madeMap` is missing.
 					if (!madeMap) {
 						teardown = teardownMap;
 						madeMap = {};
 					}
-					// record if it has a Cid before we add one
+					// Record if Object has a `_cid` before adding one.
 					var hasCid = obj._cid;
 					var cid = can.cid(obj);
 
-					// only update if there already isn't one
+					// Only update if there already isn't one already.
 					if (!madeMap[cid]) {
 
 						madeMap[cid] = {
@@ -97,17 +134,38 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 					}
 					return teardown;
 				},
+				/**
+				 * @hide
+				 * Determines if `obj` is observable
+				 * @param {Object} obj Object to check
+				 * @return {Boolean} whether `obj` is an observable
+				 */
+				// ### can.Map.helpers.isObservable
+				// Determines if `obj` is observable.
 				isObservable: function(obj){
 					return obj instanceof can.Map || (obj && obj === can.route);
 				},
+				/**
+				 * @hide
+				 * Determines if `obj` can be made into an observable
+				 * @param {Object} obj Object to check
+				 * @return {Boolean} whether `obj` can be made into an observable
+				 */
+				// ### can.Map.helpers.canMakeObserve
+				// Determines if an object can be made into an observable.
 				canMakeObserve: function (obj) {
 					return obj && !can.isDeferred(obj) && (can.isArray(obj) || can.isPlainObject(obj) );
 				},
-				// A helper used to serialize an `Map` or `Map.List`.
-				// `map` - The observable.
-				// `how` - To serialize with `attr` or `serialize`.
-
-				// `where` - To put properties, in an `{}` or `[]`.
+				/**
+				 * @hide
+				 * Serializes a Map or Map.List
+				 * @param {can.Map|can.List} map The observable.
+				 * @param {String} how To serialize using `attr` or `serialize`.
+				 * @param {String} where Object or Array to put properties in.
+				 * @return {Object|Array} serialized Map or List data.
+				 */
+				// ### can.Map.helpers.serialize
+				// Serializes a Map or Map.List
 				serialize: function (map, how, where) {
 					// Go through each property.
 					map.each(function (val, name) {
@@ -126,30 +184,11 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 					return where;
 				}
 			},
-
-			// starts collecting events
-			// takes a callback for after they are updated
-			// how could you hook into after ejs
 			/**
-			 * @function can.Map.keys keys
-			 * @parent can.Map.static
-			 * @description Iterate over the keys of an Map.
-			 * @signature `can.Map.keys(map)`
-			 * @param {can.Map} map the `can.Map` to get the keys from
-			 * @return {Array} array An array containing the keys from _map_.
-			 *
-			 * @body
-			 * `keys` iterates over an map to get an array of its keys.
-			 *
-			 * @codestart
-			 * var people = new can.Map({
-			 *     a: 'Alice',
-			 *     b: 'Bob',
-			 *     e: 'Eve'
-			 * });
-			 *
-			 * can.Map.keys(people); // ['a', 'b', 'e']
-			 * @codeend
+			 * @hide
+			 * Returns list of keys in a Map
+			 * @param {can.Map} map
+			 * @returns {Array}
 			 */
 			keys: function (map) {
 				var keys = [];
@@ -177,40 +216,11 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 				can.cid(this, ".map");
 				// Sets all `attrs`.
 				this._init = 1;
+				// Setup computed attributes.
 				this._setupComputes();
 				var teardownMapping = obj && can.Map.helpers.addToMap(obj, this);
-				/**
-				 * @property {*} can.Map.prototype.DEFAULT-ATTR
-				 *
-				 * @description Specify a default property and value.
-				 *
-				 * @option {*} A value of any type other than a function that will
-				 * be set as the `DEFAULT-ATTR` attribute's value.
-				 *
-				 * @body
-				 *
-				 * ## Use
-				 *
-				 * When extending [can.Map], if a prototype property is not a function,
-				 * it is used as a default value on instances of the extended Map.  For example:
-				 *
-				 *     var Paginate = can.Map.extend({
-				 *       limit: 20,
-				 *       offset: 0,
-				 *       next: function(){
-				 *         this.attr("offset", this.attr("offset")+this.attr("limit"))
-				 *       }
-				 *     });
-				 *
-				 *     var paginate = new Paginate({limit: 30});
-				 *
-				 *     paginate.attr("offset") //-> 0
-				 *     paginate.attr("limit")  //-> 30
-				 *
-				 *     paginate.next();
-				 *
-				 *     paginate.attr("offset") //-> 30
-				 */
+
+				// Setup default attribute values.
 				var data = can.extend(can.extend(true, {}, this._setupDefaults()), obj);
 				this.attr(data);
 
@@ -218,104 +228,21 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 					teardownMapping();
 				}
 
+				// `batchTrigger` change events.
 				this.bind('change', can.proxy(this._changes, this));
 
 				delete this._init;
 			},
-			/**
-			 * @property {can.compute} can.Map.prototype.COMPUTE-ATTR
-			 *
-			 * @description Specify an attribute that is computed from other attributes.
-			 *
-			 * @option {can.compute} A compute that reads values on instances of the
-			 * map and returns a derived value.  The compute may also be a getter-setter
-			 * compute and able to be passed a value.
-			 *
-			 * @body
-			 *
-			 * ## Use
-			 *
-			 * When extending [can.Map], if a prototype property is a [can.compute]
-			 * it will setup that compute to behave like a normal attribute. This means
-			 * that it can be read and written to with [can.Map::attr attr] and bound to
-			 * with [can.Map::bind bind].
-			 *
-			 * The following example makes a `fullName` attribute on `Person` maps:
-			 *
-			 *     var Person = can.Map.extend({
-			 *       fullName: can.compute(function(){
-			 *         return this.attr("first")+" "+this.attr("last")
-			 *       })
-			 *     })
-			 *
-			 *     var me = new Person({first: "Justin", last: "Meyer"})
-			 *
-			 *     me.attr("fullName") //-> "Justin Meyer"
-			 *
-			 *     me.bind("fullName", function(ev, newValue, oldValue){
-			 *       newValue //-> Brian Moschel
-			 *       oldValue //-> Justin Meyer
-			 *     })
-			 *
-			 *     me.attr({first: "Brian", last: "Moschel"})
-			 *
-			 * ## Getter / Setter computes
-			 *
-			 * A compute's setter will be called if [can.Map::attr attr] is
-			 * used to set the compute-property's value.
-			 *
-			 * The following makes `fullName` able to set `first` and `last`:
-			 *
-			 *     var Person = can.Map.extend({
-			 *       fullName: can.compute(function(newValue){
-			 *         if( arguments.length ) {
-			 *           var parts = newValue.split(" ");
-			 *           this.attr({
-			 *             first: parts[0],
-			 *             last:  parts[1]
-			 *           });
-			 *
-			 *         } else {
-			 *           return this.attr("first")+" "+this.attr("last");
-			 *         }
-			 *       })
-			 *     })
-			 *
-			 *     var me = new Person({first: "Justin", last: "Meyer"})
-			 *
-			 *     me.attr("fullName", "Brian Moschel")
-			 *     me.attr("first") //-> "Brian"
-			 *     me.attr("last")  //-> "Moschel"
-			 *
-			 *
-			 * ## Alternatives
-			 *
-			 * [can.Mustache] and [can.EJS] will automatically convert any function
-			 * read in the template to a can.compute. So, simply having a fullName
-			 * function like:
-			 *
-			 *     var Person = can.Map.extend({
-			 *       fullName: function(){
-			 *         return this.attr("first")+" "+this.attr("last")
-			 *       }
-			 *     })
-			 *     var me = new Person({first: "Justin", last: "Meyer"})
-			 *
-			 * Will already be live-bound if read in a template like:
-			 *
-			 *     {{me.fullName}}
-			 *     <%= me.attr("fullName") %>
-			 *
-			 * The [can.Map.setter setter] plugin can also provide similar functionality as
-			 * Getter/Setter computes.
-			 */
+			// Sets up computed properties on a Map.
 			_setupComputes: function () {
 				var computes = this.constructor._computes;
 				this._computedBindings = {};
 
 				for (var i = 0, len = computes.length, prop; i < len; i++) {
 					prop = computes[i];
+					// Make the context of the compute the current Map
 					this[prop] = this[prop].clone(this);
+					// Keep track of computed properties
 					this._computedBindings[prop] = {
 						count: 0
 					};
@@ -324,15 +251,18 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 			_setupDefaults: function(){
 				return this.constructor.defaults || {};
 			},
+			// Setup child bindings.
 			_bindsetup: function(){},
+			// Teardown child bindings.
 			_bindteardown: function(){},
+			// `change`event handler.
 			_changes: function (ev, attr, how, newVal, oldVal) {
 				// when a change happens, create the named event.
 				can.batch.trigger(this, {
 					type: attr,
 					batchNum: ev.batchNum
 				}, [newVal, oldVal]);
-				
+
 				if(how === "remove" || how === "add") {
 					can.batch.trigger(this, {
 						type: "__keys",
@@ -340,10 +270,11 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 					});
 				}
 			},
+			// Trigger a change event.
 			_triggerChange: function (attr, how, newVal, oldVal) {
 				can.batch.trigger(this, "change", can.makeArray(arguments));
 			},
-			// no live binding iterator
+			// Iterator that does not trigger live binding.
 			_each: function (callback) {
 				var data = this.__get();
 				for (var prop in data) {
@@ -352,144 +283,15 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 					}
 				}
 			},
-			/**
-			 * @function can.Map.prototype.attr attr
-			 * @description Get or set properties on an Map.
-			 * @signature `map.attr()`
-			 *
-			 * Gets a collection of all the properties in this `can.Map`.
-			 *
-			 * @return {Object<String, *>} an object with all the properties in this `can.Map`.
-			 *
-			 * @signature `map.attr(key)`
-			 *
-			 * Reads a property from this `can.Map`.
-			 *
-			 * @param {String} key the property to read
-			 * @return {*} the value assigned to _key_.
-			 *
-			 * @signature `map.attr(key, value)`
-			 *
-			 * Assigns _value_ to a property on this `can.Map` called _key_.
-			 *
-			 * @param {String} key the property to set
-			 * @param {*} the value to assign to _key_.
-			 * @return {can.Map} this Map, for chaining
-			 *
-			 * @signature `map.attr(obj[, removeOthers])`
-			 *
-			 * Assigns each value in _obj_ to a property on this `can.Map` named after the
-			 * corresponding key in _obj_, effectively merging _obj_ into the Map.
-			 *
-			 * @param {Object<String, *>} obj a collection of key-value pairs to set.
-			 * If any properties already exist on the `can.Map`, they will be overwritten.
-			 *
-			 * @param {bool} [removeOthers=false] whether to remove keys not present in _obj_.
-			 * To remove keys without setting other keys, use `[can.Map::removeAttr removeAttr]`.
-			 *
-			 * @return {can.Map} this Map, for chaining
-			 *
-			 * @body
-			 * `attr` gets or sets properties on the `can.Map` it's called on. Here's a tour through
-			 * how all of its forms work:
-			 *
-			 * @codestart
-			 * var people = new can.Map({});
-			 *
-			 * // set a property:
-			 * people.attr('a', 'Alex');
-			 *
-			 * // get a property:
-			 * people.attr('a'); // 'Alex'
-			 *
-			 * // set and merge multiple properties:
-			 * people.attr({
-			 *     a: 'Alice',
-			 *     b: 'Bob'
-			 * });
-			 *
-			 * // get all properties:
-			 * people.attr(); // {a: 'Alice', b: 'Bob'}
-			 *
-			 * // set properties while removing others:
-			 * people.attr({
-			 *     b: 'Bill',
-			 *     e: 'Eve'
-			 * }, true);
-			 *
-			 * people.attr(); // {b: 'Bill', e: 'Eve'}
-			 * @codeend
-			 *
-			 * ## Deep properties
-			 *
-			 * `attr` can also set and read deep properties. All you have to do is specify
-			 * the property name as you normally would if you weren't using `attr`.
-			 *
-			 * @codestart
-			 * var people = new can.Map({names: {}});
-			 *
-			 * // set a property:
-			 * people.attr('names.a', 'Alice');
-			 *
-			 * // get a property:
-			 * people.attr('names.a'); // 'Alice'
-			 * people.names.attr('a'); // 'Alice'
-			 *
-			 * // get all properties:
-			 * people.attr(); // {names: {a: 'Alice'}}
-			 * @codeend
-			 *
-			 * Objects that are added to Observes become Observes themselves behind the scenes,
-			 * so changes to deep properties fire events at each level, and you can bind at any
-			 * level. As this example shows, all the same events are fired no matter what level
-			 * you call `attr` at:
-			 *
-			 * @codestart
-			 * var people = new can.Map({names: {}});
-			 *
-			 * people.bind('change', function(ev, attr, how, newVal, oldVal) {
-			 *   console.log('people change: ' + attr + ', ' + how + ', ' + newVal + ', ' + oldVal);
-			 * });
-			 *
-			 * people.names.bind('change', function(ev, attr, how, newVal, oldVal) {
-			 *    console.log('people.names change' + attr + ', ' + how + ', ' + newVal + ', ' + oldVal);
-			 * });
-			 *
-			 * people.bind('names', function(ev, newVal, oldVal) {
-			 *     console.log('people names: ' + newVal + ', ' + oldVal);
-			 * });
-			 *
-			 * people.names.bind('a', function(ev, newVal, oldVal) {
-			 *     console.log('people.names a: ' + newVal + ', ' + oldVal);
-			 * });
-			 *
-			 * people.bind('names.a', function(ev, newVal, oldVal) {
-			 *     console.log('people names.a: ' + newVal + ', ' + oldVal);
-			 * });
-			 *
-			 * people.attr('names.a', 'Alice'); // people change: names.a, add, Alice, undefined
-			 *                                  // people.names change: a, add, Alice, undefined
-			 *                                  // people.names a: Alice, undefined
-			 *                                  // people names.a: Alice, undefined
-			 *
-			 * people.names.attr('b', 'Bob');   // people change: names.b, add, Bob, undefined
-			 *                                  // people.names change: b, add, Bob, undefined
-			 *                                  // people.names b: Bob, undefined
-			 *                                  // people names.b: Bob, undefined
-			 * @codeend
-			 *
-			 * ## See also
-			 *
-			 * For information on the events that are fired on property changes and how
-			 * to listen for those events, see [can.Map.prototype.bind bind].
-			 */
+
 			attr: function (attr, val) {
 				// This is super obfuscated for space -- basically, we're checking
 				// if the type of the attribute is not a `number` or a `string`.
 				var type = typeof attr;
 				if (type !== "string" && type !== "number") {
 					return this._attrs(attr, val);
-				} else if (arguments.length === 1) { // If we are getting a value.
+				// If we are getting a value.
+				} else if (arguments.length === 1) {
 					// Let people know we are reading.
 					can.__reading(this, attr);
 					return this._get(attr);
@@ -499,70 +301,13 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 					return this;
 				}
 			},
-			/**
-			 * @function can.Map.prototype.each each
-			 * @description Call a function on each property of an Map.
-			 * @signature `map.each( callback(item, propName ) )`
-			 *
-			 * `each` iterates through the Map, calling a function
-			 * for each property value and key.
-			 *
-			 * @param {function(*,String)} callback(item,propName) the function to call for each property
-			 * The value and key of each property will be passed as the first and second
-			 * arguments, respectively, to the callback. If the callback returns false,
-			 * the loop will stop.
-			 *
-			 * @return {can.Map} this Map, for chaining
-			 *
-			 * @body
-			 * @codestart
-			 * var names = [];
-			 * new can.Map({a: 'Alice', b: 'Bob', e: 'Eve'}).each(function(value, key) {
-			 *     names.push(value);
-			 * });
-			 *
-			 * names; // ['Alice', 'Bob', 'Eve']
-			 *
-			 * names = [];
-			 * new can.Map({a: 'Alice', b: 'Bob', e: 'Eve'}).each(function(value, key) {
-			 *     names.push(value);
-			 *     if(key === 'b') {
-			 *         return false;
-			 *     }
-			 * });
-			 *
-			 * names; // ['Alice', 'Bob']
-			 *
-			 * @codeend
-			 */
+
 			each: function () {
 				return can.each.apply(undefined, [this].concat(can.makeArray(arguments)));
 			},
-			/**
-			 * @function can.Map.prototype.removeAttr removeAttr
-			 * @description Remove a property from an Map.
-			 * @signature `map.removeAttr(attrName)`
-			 * @param {String} attrName the name of the property to remove
-			 * @return {*} the value of the property that was removed
-			 *
-			 * @body
-			 * `removeAttr` removes a property by name from an Map.
-			 *
-			 * @codestart
-			 * var people = new can.Map({a: 'Alice', b: 'Bob', e: 'Eve'});
-			 *
-			 * people.removeAttr('b'); // 'Bob'
-			 * people.attr();          // {a: 'Alice', e: 'Eve'}
-			 * @codeend
-			 *
-			 * Removing an attribute will cause a _change_ event to fire with `'remove'`
-			 * passed as the _how_ parameter and `undefined` passed as the _newVal_ to
-			 * handlers. It will also cause a _property name_ event to fire with `undefined`
-			 * passed as _newVal_. An in-depth description at these events can be found
-			 * under `[can.Map.prototype.attr attr]`.
-			 */
+
 			removeAttr: function (attr) {
-				// Info if this is List or not
+				// If this is List.
 				var isList = can.List && this instanceof can.List,
 					// Convert the `attr` into parts (if nested).
 					parts = can.Map.helpers.attrParts(attr),
@@ -576,6 +321,7 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 					return current.removeAttr(parts);
 				} else {
 
+					// If attr does not have a `.`
 					if (!!~attr.indexOf('.')) {
 						prop = attr;
 					}
@@ -584,15 +330,16 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 					return current;
 				}
 			},
+			// Remove a property.
 			_remove: function(prop, current){
 				if (prop in this._data) {
-					// Otherwise, `delete`.
+					// Delete the property from `_data` and the Map
+					// as long as it isn't part of the Map's prototype.
 					delete this._data[prop];
-					// Create the event.
 					if (!(prop in this.constructor.prototype)) {
 						delete this[prop];
 					}
-					// Let others know the number of keys have changed
+					// Let others now this property has been removed.
 					this._triggerChange(prop, "remove", undefined, current);
 
 				}
@@ -600,37 +347,43 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 			// Reads a property from the `object`.
 			_get: function (attr) {
 				var value;
+				// Handles the case of a key having a `.` in its name
 				if (typeof attr === 'string' && !! ~attr.indexOf('.')) {
+					// Attempt to get the value
 					value = this.__get(attr);
+					// For keys with a `.` in them, value will be defined
 					if (value !== undefined) {
 						return value;
 					}
 				}
 
-				// break up the attr (`"foo.bar"`) into `["foo","bar"]`
+				// Otherwise we have to dig deeper into the Map to get the value.
+				// First, break up the attr (`"foo.bar"`) into parts like `["foo","bar"]`.
 				var parts = can.Map.helpers.attrParts(attr),
-					// get the value of the first attr name (`"foo"`)
+					// Then get the value of the first attr name (`"foo"`).
 					current = this.__get(parts.shift());
-				// if there are other attributes to read
+				// If there are other attributes to read...
 				return parts.length ?
-				// and current has a value
+				// and current has a value...
 				current ?
-				// lookup the remaining attrs on current
+				// then lookup the remaining attrs on current
 				current._get(parts) :
-				// or if there's no current, return undefined
+				// or if there's no current, return undefined.
 				undefined :
-				// if there are no more parts, return current
+				// If there are no more parts, return current.
 				current;
 			},
 			// Reads a property directly if an `attr` is provided, otherwise
 			// returns the "real" data object itself.
 			__get: function (attr) {
 				if (attr) {
+					// If property is a compute return the result, otherwise get the value directly
 					if (this._computedBindings[attr]) {
 						return this[attr]();
 					} else {
 						return this._data[attr];
 					}
+				// If not property is provided, return entire `_data` object
 				} else {
 					return this._data;
 				}
@@ -639,7 +392,7 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 			__type: function(value, prop){
 				// If we are getting an object.
 				if (!( value instanceof can.Map) && can.Map.helpers.canMakeObserve(value)  ) {
-					
+
 					var cached = getMapFromObject(value);
 					if(cached) {
 						return cached;
@@ -665,39 +418,35 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 					// The current value.
 					current = this.__get(prop);
 
-				// If we have an `object` and remaining parts.
 				if ( parts.length && Map.helpers.isObservable(current) ) {
-					// That `object` should set it (this might need to call attr).
+					// If we have an `object` and remaining parts that `object` should set it.
 					current._set(parts, value);
 				} else if (!parts.length) {
 					// We're in "real" set territory.
 					if (this.__convert) {
+						//Convert if there is a converter
 						value = this.__convert(prop, value);
 					}
-					
 					this.__set(prop, this.__type(value, prop), current);
 				} else {
 					throw "can.Map: Object does not exist";
 				}
 			},
 			__set: function (prop, value, current) {
-
-				// Otherwise, we are setting it on this `object`.
-				// TODO: Check if value is object and transform
-				// are we changing the value.
+				// TODO: Check if value is object and transform.
+				// Don't do anything if the value isn't changing.
 				if (value !== current) {
 					// Check if we are adding this for the first time --
 					// if we are, we need to create an `add` event.
 					var changeType = this.__get()
 						.hasOwnProperty(prop) ? "set" : "add";
 
-					// Set the value on data.
+					// Set the value on `_data` and hook it up to send event.
 					this.___set(prop, this.constructor._bubble.set(this, prop, value, current) );
 
 					// `batchTrigger` the change event.
 					this._triggerChange(prop, changeType, value, current);
 
-					//can.batch.trigger(this, prop, [value, current]);
 					// If we can stop listening to our old value, do it.
 					if (current) {
 						this.constructor._bubble.teardownFromParent(this, current);
@@ -708,6 +457,7 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 			// Directly sets a property on this `object`.
 			___set: function (prop, val) {
 
+				// Handle computed properties
 				if (this[prop] && this[prop].isComputed && can.isFunction(this.constructor.prototype[prop])) {
 					this[prop](val);
 				}
@@ -720,107 +470,11 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 				}
 			},
 
-			/**
-			 * @function can.Map.prototype.bind bind
-			 * @description Bind event handlers to an Map.
-			 *
-			 * @signature `map.bind(eventType, handler)`
-			 *
-			 * @param {String} eventType the type of event to bind this handler to
-			 * @param {Function} handler the handler to be called when this type of event fires
-			 * The signature of the handler depends on the type of event being bound. See below
-			 * for details.
-			 * @return {can.Map} this Map, for chaining
-			 *
-			 * @body
-			 * `bind` binds event handlers to property changes on `can.Map`s. When you change
-			 * a property using `attr`, two events are fired on the Map, allowing other parts
-			 * of your application to map the changes to the object.
-			 *
-			 * ## The _change_ event
-			 *
-			 * The first event that is fired is the _change_ event. The _change_ event is useful
-			 * if you want to react to all changes on an Map.
-			 *
-			 * @codestart
-			 * var o = new can.Map({});
-			 * o.bind('change', function(ev, attr, how, newVal, oldVal) {
-			 *     console.log('Something changed.');
-			 * });
-			 * @codeend
-			 *
-			 * The parameters of the event handler for the _change_ event are:
-			 *
-			 * - _ev_ The event object.
-			 * - _attr_ Which property changed.
-			 * - _how_ Whether the property was added, removed, or set. Possible values are `'add'`, `'remove'`, or `'set'`.
-			 * - _newVal_ The value of the property after the change. `newVal` will be `undefined` if the property was removed.
-			 * - _oldVal_ Thishe value of the property before the change. `oldVal` will be `undefined` if the property was added.
-			 *
-			 * Here is a concrete tour through the _change_ event handler's arguments:
-			 *
-			 * @codestart
-			 * var o = new can.Map({});
-			 * o.bind('change', function(ev, attr, how, newVal, oldVal) {
-			 *     console.log(ev + ', ' + attr + ', ' + how + ', ' + newVal + ', ' + oldVal);
-			 * });
-			 *
-			 * o.attr('a', 'Alexis'); // [object Object], a, add, Alexis, undefined
-			 * o.attr('a', 'Adam');   // [object Object], a, set, Adam, Alexis
-			 * o.attr({
-			 *     'a': 'Alice',      // [object Object], a, set, Alice, Adam
-			 *     'b': 'Bob'         // [object Object], b, add, Bob, undefined
-			 * });
-			 * o.removeAttr('a');     // [object Object], a, remove, undefined, Alice
-			 * @codeend
-			 *
-			 * (See also `[can.Map::removeAttr removeAttr]`, which removes properties).
-			 *
-			 * ## The _property name_ event
-			 *
-			 * The second event that is fired is an event whose type is the same as the changed
-			 * property's name. This event is useful for noticing changes to a specific property.
-			 *
-			 * @codestart
-			 * var o = new can.Map({});
-			 * o.bind('a', function(ev, newVal, oldVal) {
-			 *     console.log('The value of a changed.');
-			 * });
-			 * @codeend
-			 *
-			 * The parameters of the event handler for the _property name_ event are:
-			 *
-			 * - _ev_ The event object.
-			 * - _newVal_ The value of the property after the change. `newVal` will be `undefined` if the property was removed.
-			 * - _oldVal_ The value of the property before the change. `oldVal` will be `undefined` if the property was added.
-			 *
-			 * Here is a concrete tour through the _property name_ event handler's arguments:
-			 *
-			 * @codestart
-			 * var o = new can.Map({});
-			 * o.bind('a', function(ev, newVal, oldVal) {
-			 *     console.log(ev + ', ' + newVal + ', ' + oldVal);
-			 * });
-			 *
-			 * o.attr('a', 'Alexis'); // [object Object], Alexis, undefined
-			 * o.attr('a', 'Adam');   // [object Object], Adam, Alexis
-			 * o.attr({
-			 *     'a': 'Alice',      // [object Object], Alice, Adam
-			 *     'b': 'Bob'
-			 * });
-			 * o.removeAttr('a');     // [object Object], undefined, Alice
-			 * @codeend
-			 *
-			 * ## See also
-			 *
-			 * More information about changing properties on Observes can be found under
-			 * [can.Map.prototype.attr attr].
-			 *
-			 * For a more specific way to changes on Observes, see the [can.Map.delegate] plugin.
-			 */
 			bind: function (eventName, handler) {
 				var computedBinding = this._computedBindings && this._computedBindings[eventName];
 				if (computedBinding) {
+					// The first time we bind to this computed property we
+					// initialize `count` and `batchTrigger` the change event.
 					if (!computedBinding.count) {
 						computedBinding.count = 1;
 						var self = this;
@@ -832,87 +486,38 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 						};
 						this[eventName].bind("change", computedBinding.handler);
 					} else {
+						// Increment number of things listening to this computed property.
 						computedBinding.count++;
 					}
 
 				}
+				// The first time we bind to this Map, `_bindsetup` will
+				// be called to setup child event bubbling.
 				this.constructor._bubble.bind(this, eventName);
 				return can.bindAndSetup.apply(this, arguments);
 
 			},
-			/**
-			 * @function can.Map.prototype.unbind unbind
-			 * @description Unbind event handlers from an Map.
-			 * @signature `map.unbind(eventType[, handler])`
-			 * @param {String} eventType the type of event to unbind, exactly as passed to `bind`
-			 * @param {Function} [handler] the handler to unbind
-			 *
-			 * @body
-			 * `unbind` unbinds event handlers previously bound with [can.Map.prototype.bind|`bind`].
-			 * If no _handler_ is passed, all handlers for the given event type will be unbound.
-			 *
-			 * @codestart
-			 * var i = 0,
-			 *     increaseBy2 = function() { i += 2; },
-			 *     increaseBy3 = function() { i += 3; },
-			 *     o = new can.Map();
-			 *
-			 * o.bind('change', increaseBy2);
-			 * o.bind('change', increaseBy3);
-			 * o.attr('a', 'Alice');
-			 * i; // 5
-			 *
-			 * o.unbind('change', increaseBy2);
-			 * o.attr('b', 'Bob');
-			 * i; // 8
-			 *
-			 * o.unbind('change');
-			 * o.attr('e', 'Eve');
-			 * i; // 8
-			 * @codeend
-			 */
+
 			unbind: function (eventName, handler) {
 				var computedBinding = this._computedBindings && this._computedBindings[eventName];
 				if (computedBinding) {
+					// If there is only one listener, we unbind the change event handler
+					// and clean it up since no one is listening to this property any more.
 					if (computedBinding.count === 1) {
 						computedBinding.count = 0;
 						this[eventName].unbind("change", computedBinding.handler);
 						delete computedBinding.handler;
 					} else {
+						// Decrement number of things listening to this computed property
 						computedBinding.count++;
 					}
 
 				}
 				this.constructor._bubble.unbind(this, eventName);
-
-				
 				return can.unbindAndTeardown.apply(this, arguments);
 
 			},
-			/**
-			 * @function can.Map.prototype.serialize serialize
-			 * @description Serialize this object to something that
-			 * can be passed to `JSON.stringify`.
-			 * @signature `map.serialize()`
-			 *
-			 *
-			 * Get the serialized Object form of the map.  Serialized
-			 * data is typically used to send back to a server.
-			 *
-			 *     o.serialize() //-> { name: 'Justin' }
-			 *
-			 * Serialize currently returns the same data
-			 * as [can.Map.prototype.attrs].  However, in future
-			 * versions, serialize will be able to return serialized
-			 * data similar to [can.Model].  The following will work:
-			 *
-			 *     new Map({time: new Date()})
-			 *       .serialize() //-> { time: 1319666613663 }
-			 *
-			 * @return {Object} a JavaScript Object that can be
-			 * serialized with `JSON.stringify` or other methods.
-			 *
-			 */
+
 			serialize: function () {
 				return can.Map.helpers.serialize(this, 'serialize', {});
 			},
@@ -931,15 +536,18 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 				var prop,
 					self = this,
 					newVal;
+
+				// Batch all of the change events until we are done.
 				can.batch.start();
+				// Merge current properties with the new ones.
 				this.each(function (curVal, prop) {
-					// you can not have a _cid property!
+					// You can not have a _cid property; abort.
 					if (prop === "_cid") {
 						return;
 					}
 					newVal = props[prop];
 
-					// If we are merging...
+					// If we are merging, remove the property if it has no value.
 					if (newVal === undefined) {
 						if (remove) {
 							self.removeAttr(prop);
@@ -947,17 +555,18 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 						return;
 					}
 
+					// Run converter if there is one
 					if (self.__convert) {
 						newVal = self.__convert(prop, newVal);
 					}
 
-					// if we're dealing with models, want to call _set to let converter run
+					// If we're dealing with models, we want to call _set to let converters run.
 					if ( Map.helpers.isObservable( newVal ) ) {
 						self.__set(prop, newVal, curVal);
-						// if its an object, let attr merge
+						// If its an object, let attr merge.
 					} else if (Map.helpers.isObservable(curVal) && Map.helpers.canMakeObserve(newVal) ) {
 						curVal.attr(newVal, remove);
-						// otherwise just set
+						// Otherwise just set.
 					} else if (curVal !== newVal) {
 						self.__set(prop, newVal, curVal);
 					}
@@ -966,6 +575,7 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 				});
 				// Add remaining props.
 				for (prop in props) {
+					// Ignore _cid.
 					if (prop !== "_cid") {
 						newVal = props[prop];
 						this._set(prop, newVal, true);
@@ -976,33 +586,9 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 				return this;
 			},
 
-			/**
-			 * @function can.Map.prototype.compute compute
-			 * @description Make a can.compute from an observable property.
-			 * @signature `map.compute(attrName)`
-			 * @param {String} attrName the property to bind to
-			 * @return {can.compute} a [can.compute] bound to _attrName_
-			 *
-			 * @body
-			 * `compute` is a convenience method for making computes from properties
-			 * of Observes. More information about computes can be found under [can.compute].
-			 *
-			 * @codestart
-			 * var map = new can.Map({a: 'Alexis'});
-			 * var name = map.compute('a');
-			 * name.bind('change', function(ev, nevVal, oldVal) {
-			 *     console.log('a changed from ' + oldVal + 'to' + newName + '.');
-			 * });
-			 *
-			 * name(); // 'Alexis'
-			 *
-			 * map.attr('a', 'Adam'); // 'a changed from Alexis to Adam.'
-			 * name(); // 'Adam'
-			 *
-			 * name('Alice'); // 'a changed from Adam to Alice.'
-			 * name(); // 'Alice'
-			 */
 			compute: function (prop) {
+				// If the property is a function, use it as the getter/setter
+				// otherwise, create a new compute that returns the value of a property on `this`
 				if (can.isFunction(this.constructor.prototype[prop])) {
 					return can.compute(this[prop], this);
 				} else {
@@ -1025,6 +611,7 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 			}
 		});
 
+	// Setup on/off aliases
 	Map.prototype.on = Map.prototype.bind;
 	Map.prototype.off = Map.prototype.unbind;
 


### PR DESCRIPTION
Some of the inline documentation for can.Map was wiped out in merging. This adds that back in.
