### PR TITLE
Fix memory leak in can.Map computed properties

### DIFF
--- a/map/map.js
+++ b/map/map.js
@@ -509,7 +509,7 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 						delete computedBinding.handler;
 					} else {
 						// Decrement number of things listening to this computed property
-						computedBinding.count++;
+						computedBinding.count--;
 					}
 
 				}

--- a/map/map_test.js
+++ b/map/map_test.js
@@ -207,5 +207,25 @@ steal("can/map", "can/compute", "can/test", function (undefined) {
 		equal(test.attr('my.newCount'), 1, 'falsey (1) value accessed correctly');
 	});
 
+	test("computed properties don't cause memory leaks", function () {
+		var computeMap = can.Map.extend({
+			'name': can.compute(function(){
+				return this.attr('first') + this.attr('last')
+			})
+		}),
+			handler = function(){},
+			map = new computeMap({
+				first: 'Mickey',
+				last: 'Mouse'
+			});
+		map.bind('name', handler);
+		map.bind('name', handler);
+		equal(map._computedBindings.name.count, 2, '2 handlers listening to computed property');
+		map.unbind('name', handler);
+		map.unbind('name', handler);
+		equal(map._computedBindings.name.count, 0, '0 handlers listening to computed property');
+		ok(!map._computedBindings.name.handler, 'computed property handler removed');
+	});
+
 
 });


### PR DESCRIPTION
The `change` event handler for a computed property should be removed if nobody is listening to it. can.Map keeps track of this by maintaining a `count` property internally. 

In `unbind` the `count` property was being incremented instead of decremented so the `count` never reached 0 and the handler would never be removed.
