### PR TITLE
Adding deprecation warnings to outdated plugins

### DIFF
--- a/control/modifier/key/key.js
+++ b/control/modifier/key/key.js
@@ -4,6 +4,11 @@
  * @documentjs-ignore
  */
 steal('can/control/modifier', function (Control) {
+
+	//!steal-remove-start
+	can.dev.warn("can/control/modifier/key is an undocumented and untested plugin and will be removed in a future release.");
+	//!steal-remove-end
+
 	/*
 	 * jwerty - Awesome handling of keyboard events
 	 *

--- a/control/view/view.js
+++ b/control/view/view.js
@@ -1,4 +1,9 @@
 steal('can/util', 'can/control', 'can/view', function (can) {
+
+	//!steal-remove-start
+	can.dev.warn("can/control/view is a deprecated plugin and will be removed in a future release.");
+	//!steal-remove-end
+
 	var URI = steal.URI || steal.File;
 	can.Control.getFolder = function () {
 		return can.underscore(this.fullName.replace(/\./g, '/'))

--- a/model/cached/cached.js
+++ b/model/cached/cached.js
@@ -1,4 +1,9 @@
 steal('can/model', 'can/util/object', 'can/util/json.js', function () {
+
+	//!steal-remove-start
+	can.dev.warn("can/model/cached is a deprecated plugin and will be removed in a future release.");
+	//!steal-remove-end
+
 	// Base model to handle reading / writing to local storage
 	can.Model('can.Model.Cached', {
 		setup: function () {

--- a/model/list/list.js
+++ b/model/list/list.js
@@ -1,4 +1,9 @@
 steal('can/util', 'can/model', 'can/map/elements', function (can) {
+
+	//!steal-remove-start
+	can.dev.warn("can/model/list is a deprecated plugin and will be removed in a future release.");
+	//!steal-remove-end
+
 	var getArgs = function (args) {
 		if (args[0] && can.isArray(args[0])) {
 			return args[0];

--- a/model/local/local.js
+++ b/model/local/local.js
@@ -1,4 +1,9 @@
 steal('can/model', 'jquery/lang/object', function () {
+
+	//!steal-remove-start
+	can.dev.warn("can/model/local is a deprecated plugin and will be removed in a future release.");
+	//!steal-remove-end
+
 	can.Model('can.Model.Local', {
 		compare: {},
 		identifier: function () {

--- a/model/store/store.js
+++ b/model/store/store.js
@@ -1,5 +1,10 @@
 /* jshint maxdepth:5 */
 steal('can/model/list', 'can/util/object', function () {
+
+	//!steal-remove-start
+	can.dev.warn("can/model/store is a deprecated plugin and will be removed in a future release.");
+	//!steal-remove-end
+
 	var same = can.Object.same;
 	can.Construct('can.Model.Store', {
 		init: function () {


### PR DESCRIPTION
Adding deprecation to the following plugins. These plugins either do not work, lack documentation or lack tests. They will be removed in a future version of CanJS.

can/control/modifier/key
can/control/view
can/model/cached
can/model/list
can/model/local
can/model/store
#423
