### PR TITLE
Upgrading html5shiv to 3.7.2

### DIFF
--- a/lib/html5shiv.js
+++ b/lib/html5shiv.js
@@ -1,10 +1,10 @@
 /**
-* @preserve HTML5 Shiv v3.6.2 | @afarkas @jdalton @jon_neal @rem | MIT/GPL2 Licensed
+* @preserve HTML5 Shiv 3.7.2 | @afarkas @jdalton @jon_neal @rem | MIT/GPL2 Licensed
 */
 ;(function(window, document) {
 /*jshint evil:true */
   /** version */
-  var version = '3.6.2 - CanJS Mod';
+  var version = '3.7.2';
 
   /** Preset options */
   var options = window.html5 || {};
@@ -82,7 +82,25 @@
     return typeof elements == 'string' ? elements.split(' ') : elements;
   }
 
-    /**
+  /**
+   * Extends the built-in list of html5 elements
+   * @memberOf html5
+   * @param {String|Array} newElements whitespace separated list or array of new element names to shiv
+   * @param {Document} ownerDocument The context document.
+   */
+  function addElements(newElements, ownerDocument) {
+    var elements = html5.elements;
+    if(typeof elements != 'string'){
+      elements = elements.join(' ');
+    }
+    if(typeof newElements != 'string'){
+      newElements = newElements.join(' ');
+    }
+    html5.elements = elements +' '+ newElements;
+    shivDocument(ownerDocument);
+  }
+
+   /**
    * Returns the data associated to the given document
    * @private
    * @param {Document} ownerDocument The document.
@@ -133,7 +151,7 @@
     //   a 403 response, will cause the tab/window to crash
     // * Script elements appended to fragments will execute when their `src`
     //   or `text` property is set
-    return node.canHaveChildren && !reSkip.test(nodeName) ? data.frag.appendChild(node) : node;
+    return node.canHaveChildren && !reSkip.test(nodeName) && !node.tagUrn ? data.frag.appendChild(node) : node;
   }
 
   /**
@@ -187,7 +205,7 @@
       'var n=f.cloneNode(),c=n.createElement;' +
       'h.shivMethods&&(' +
         // unroll the `createElement` calls
-        getElements().join().replace(/([\w\-]|[\w\:])+/g, function(nodeName) {
+        getElements().join().replace(/[\w\-:]+/g, function(nodeName) {
           data.createElem(nodeName);
           data.frag.createElement(nodeName);
           return 'c("' + nodeName + '")';
@@ -244,7 +262,7 @@
      * @memberOf html5
      * @type Array|String
      */
-    'elements': options.elements || 'abbr article aside audio bdi canvas data datalist details dialog figcaption figure footer header hgroup main mark meter nav output progress section summary template time video',
+    'elements': options.elements || 'abbr article aside audio bdi canvas data datalist details dialog figcaption figure footer header hgroup main mark meter nav output picture progress section summary template time video',
 
     /**
      * current version of html5shiv
@@ -287,7 +305,10 @@
     createElement: createElement,
 
     //creates a shived documentFragment
-    createDocumentFragment: createDocumentFragment
+    createDocumentFragment: createDocumentFragment,
+
+    //extends list of elements
+    addElements: addElements
   };
 
   /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
Updating HTML5 Shiv to 3.7.2 which has fixes for [namespaced tag names](https://github.com/aFarkas/html5shiv/pull/135) (e.g. `<can:example>`) and [hyphenated tag names](https://github.com/aFarkas/html5shiv/pull/124) (e.g. `<can-example>`)
