### PR TITLE
Added breaking test of string attributes not working with scope retured ...

### DIFF
--- a/component/component_test.js
+++ b/component/component_test.js
@@ -1190,4 +1190,31 @@ steal("can/component", "can/view/stache", function () {
 		
 	});
 
+    test("Respect string attributes with scope function (mustache)", function(){
+
+        var scope
+
+        can.Component.extend({
+            tag: "comp-scope",
+
+            scope: function(){
+                return {
+
+                    string: '@',
+                    init: function(){
+                        scope = this
+                    }
+                }
+            }
+        });
+
+        var view = can.mustache('<comp-scope string="string"></comp-scope>');
+
+        view()
+
+        equal(scope.string, "string");
+
+    });
+
+
 });


### PR DESCRIPTION
...as function (for mustache engine)

in scope "string" attribute defined as '@' and should be equal to passed value in template which is "string".

But it equals "@".

It seems to work with stache though.