### PR TITLE
stache: Custom elements in IE8 contain a colon

### DIFF
--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -3434,10 +3434,9 @@ steal("can/view/stache", "can/view","can/test","can/view/mustache/spec/specs",fu
 		var tmpl = "<my-tag></my-tag>";
 
 		var frag = can.stache(tmpl)({});
-		var qta = can.$('#qunit-test-area');
-		can.append(qta, frag);
+		can.append(can.$("#qunit-test-area"), frag);
 
-		equal(qta[0].innerHTML.toLowerCase(), "<my-tag></my-tag>", "Element created in default namespace");
+		equal(can.$("my-tag").length, 1, "Element created in default namespace");
 	});
 
 });


### PR DESCRIPTION
Using stache, custom elements are being rendered with a colon in IE8 (wrong namespace), that is when you expect: `<my-tag></my-tag>` you are getting `<:my-tag></:my-tag>`.

This problem does not occur in Mustache.

The issue is likely caused by stache using cloneNode internally. There are various issues with cloneNode that are solved by jQuery. HTML5 Shiv includes a note in their readme saying that they do not address the cloneNode problem.
