### PR TITLE
Fix rendering of <col> inside <table> in templates.

### DIFF
--- a/view/elements.js
+++ b/view/elements.js
@@ -54,6 +54,7 @@ steal('can/util', "can/view",function (can) {
 		 */
 		tagMap: {
 			'': 'span',
+			colgroup: 'col',
 			table: 'tbody',
 			tr: 'td',
 			ol: 'li',
@@ -66,6 +67,7 @@ steal('can/util', "can/view",function (can) {
 		},
 		// a tag's parent element
 		reverseTagMap: {
+			col: 'colgroup',
 			tr: 'tbody',
 			option: 'select',
 			td: 'tr',


### PR DESCRIPTION
Please refer to this [fiddle](http://jsfiddle.net/sMUFZ/) which demonstrates that `<col>` tags end up being rendered outside `<table>`. The clue was that live-binding triggers the messed up rendering. The attached patch fixes this behavior.

See HTML5 spec regarding the [`<colgroup>` element](http://www.w3.org/TR/html5/tabular-data.html#the-colgroup-element) and the [`<col>` element](http://www.w3.org/TR/html5/tabular-data.html#the-col-element), the main take-away being that `<col>` should be within `<colgroup>` which should be within `<table>`.
