### PR TITLE
nested component within an #if is not live bound

### DIFF
--- a/component/component_test.js
+++ b/component/component_test.js
@@ -1246,4 +1246,30 @@ steal("can/component", "can/view/stache", function () {
 
 	});
 
+	test('nested component within an #if is not live bound(#1025)', function() {
+		can.Component.extend({
+			tag: 'parent-component',
+			template: can.stache('{{#if shown}}<child-component></child-component>{{/if}}'),
+			scope: {
+				shown: false
+			}
+		});
+
+		can.Component.extend({
+			tag: 'child-component',
+			template: can.stache('Hello world.')
+		});
+
+		var template = can.stache('<parent-component></parent-component>');
+		var frag = template({});
+
+		equal(frag.childNodes[0].innerHTML, '', 'child component is not inserted');
+		can.scope(frag.childNodes[0]).attr('shown', true);
+
+		equal(frag.childNodes[0].innerHTML, '<child-component>Hello world.</child-component>', 'child component is inserted');
+		can.scope(frag.childNodes[0]).attr('shown', false);
+
+		equal(frag.childNodes[0].innerHTML, '', 'child component is removed');
+	});
+
 });

--- a/view/callbacks/callbacks.js
+++ b/view/callbacks/callbacks.js
@@ -60,11 +60,7 @@ steal("can/util", "can/view",function(can){
 		attr: attr,
 		// handles calling back a tag callback
 		tagHandler: function(el, tagName, tagData){
-			var helperTagCallback = tagData.options.read('tags.' + tagName, {
-					isArgument: true,
-					proxyMethods: false
-				})
-					.value,
+			var helperTagCallback = tagData.options.attr('tags.' + tagName),
 				tagCallback = helperTagCallback || tags[tagName];
 	
 			// If this was an element like <foo-bar> that doesn't have a component, just render its content


### PR DESCRIPTION
# if around a child component, live binds on the initial change of a compute, however is not updated on subsequent compute updates. The parent component does receive compute change events correctly.
