### PR TITLE
Map define warn

### DIFF
--- a/map/map_test.js
+++ b/map/map_test.js
@@ -238,18 +238,5 @@ steal("can/map", "can/compute", "can/test", "can/list", function(){
 		equal(res.name, "map1");
 		equal(res.map2.name, "map2");
 	});
-
-	test("using define without adding the plugin", function(){
-		var oldlog = can.dev.warn;
-		can.dev.warn = function (text) {
-			ok(text, "got a message");
-			can.dev.warn = oldlog;
-		};
-		/* jshint ignore:start */
-		var MapClass = can.Map.extend({
-			define: {}
-		});
-		/* jshint ignore:end */
-	})
 	
 });


### PR DESCRIPTION
related to https://forum.javascriptmvc.com/topic/can-route-map-working-with-arrays

I've seen a few times that people forget to add the define plugin and it fails silently.  This is an attempt to add a warning so its obvious right away.
