### PR TITLE
Model destroyed bug

### DIFF
--- a/list/list.js
+++ b/list/list.js
@@ -271,16 +271,26 @@ steal("can/util", "can/map", "can/map/bubble.js",function (can, Map, bubble) {
 			 */
 			splice: function (index, howMany) {
 				var args = can.makeArray(arguments),
-					i;
-
+					added =[],
+					i, j;
 				for (i = 2; i < args.length; i++) {
 					args[i] = bubble.set(this, i, this.__type(args[i], i) );
-					
+					added.push(args[i]);
 				}
 				if (howMany === undefined) {
 					howMany = args[1] = this.length - index;
 				}
-				var removed = splice.apply(this, args);
+				var removed = splice.apply(this, args),
+					cleanRemoved = removed;
+
+				// remove any items that were just added from the removed array
+				if(added.length && removed.length){
+					for (j = 0; j < removed.length; j++) {
+						if(added.indexOf(removed[j]) !== -1) {
+							cleanRemoved.splice(j, 1);
+						}
+					}
+				}
 
 				if (!spliceRemovesProps) {
 					for (i = this.length; i < removed.length + this.length; i++) {

--- a/model/model_test.js
+++ b/model/model_test.js
@@ -1516,4 +1516,17 @@ steal("can/model", 'can/map/attributes', "can/test", "can/util/fixture", functio
 			start();
 		});
 	});
+
+	test("model list destroy after calling replace", function(){
+		expect(2);
+		var map = new can.Model({name: "map1"});
+		var map2 = new can.Model({name: "map2"});
+		var list = new can.Model.List([map, map2]);
+		list.bind('destroyed', function(ev){
+			ok(true, 'trigger destroyed');
+		});
+		can.trigger(map, 'destroyed');
+		list.replace([map2]);
+		can.trigger(map2, 'destroyed');
+	});
 });


### PR DESCRIPTION
#1040 adding a test and a fix for an issue where .splice is called to remove and re-add the same object (i.e. for .reverse), which was causing it to unbind incorrectly
