### PR TITLE
less noisy dev warnings

### DIFF
--- a/construct/construct.js
+++ b/construct/construct.js
@@ -7,7 +7,9 @@ steal('can/util/string', function (can) {
 	// It provides class level inheritance and callbacks._
 	// A private flag used to initialize a new class instance without
 	// initializing it's bindings.
-	var initializing = 0;
+	var initializing = 0,
+	// only show the warning once per page load
+		noExtendWarning = false;
 	/**
 	 * @add can.Construct
 	 */
@@ -296,8 +298,9 @@ steal('can/util/string', function (can) {
 					//!steal-remove-start
 					if(this.constructor !== Constructor &&
 					// We are being called without `new` or we are extending.
-					arguments.length && Constructor.constructorExtends) {
+					arguments.length && Constructor.constructorExtends && !noExtendWarning) {
 						can.dev.warn('can/construct/construct.js: extending a can.Construct without calling extend');
+						noExtendWarning = true;
 					}
 					//!steal-remove-end
 					

--- a/construct/construct_test.js
+++ b/construct/construct_test.js
@@ -2,7 +2,7 @@ steal('can/construct', function () {
 	/* global Foo, Car, Bar */
 	module('can/construct', {
 		setup: function () {
-			var Animal = this.Animal = can.Construct({
+			var Animal = this.Animal = can.Construct.extend({
 				count: 0,
 				test: function () {
 					return this.match ? true : false;
@@ -13,7 +13,7 @@ steal('can/construct', function () {
 					this.eyes = false;
 				}
 			});
-			var Dog = this.Dog = this.Animal({
+			var Dog = this.Dog = this.Animal.extend({
 				match: /abc/
 			}, {
 				init: function () {
@@ -23,7 +23,7 @@ steal('can/construct', function () {
 					return 'Woof';
 				}
 			});
-			this.Ajax = this.Dog({
+			this.Ajax = this.Dog.extend({
 				count: 0
 			}, {
 				init: function (hairs) {
@@ -37,6 +37,21 @@ steal('can/construct', function () {
 			});
 		}
 	});
+	
+	//!steal-remove-start
+	if (can.dev) {
+		test('console warning if extend is not used without new (#932)', function () {
+			
+			var oldlog = can.dev.warn;
+			can.dev.warn = function (text) {
+				ok(text, "got a message");
+				can.dev.warn = oldlog;
+			};
+			var K1 = can.Construct({});
+			K1({});
+		});
+	}
+	//!steal-remove-end
 	test('inherit', function () {
 		var Base = can.Construct({});
 		ok(new Base() instanceof can.Construct);
@@ -128,21 +143,6 @@ steal('can/construct', function () {
 		new Foo()
 			.dude(true);
 	});
-	
-	//!steal-remove-start
-	if (can.dev) {
-		test('console warning if extend is not used without new (#932)', function () {
-			
-			var oldlog = can.dev.warn;
-			can.dev.warn = function (text) {
-				ok(text, "got a message");
-				can.dev.warn = oldlog;
-			};
-			var K1 = can.Construct({});
-			K1({});
-		});
-	}
-	//!steal-remove-end
 	
 	
 });

--- a/map/setter/setter.js
+++ b/map/setter/setter.js
@@ -1,5 +1,6 @@
 steal('can/util', 'can/map', function (can) {
 
+	var warned = false;
 	can.classize = function (s, join) {
 		// this can be moved out ..
 		// used for getter setter
@@ -16,8 +17,11 @@ steal('can/util', 'can/map', function (can) {
 	proto.__set = function (prop, value, current, success, error) {
 		//!steal-remove-start
 		var asyncTimer;
-		can.dev.warn("can/map/setter is a deprecated plugin and will be removed in a future release. "+
-			"can/map/define provides the same functionality in a more complete API.");
+		if(!warned){
+			warned = true;
+			can.dev.warn("can/map/setter is a deprecated plugin and will be removed in a future release. "+
+				"can/map/define provides the same functionality in a more complete API.");
+		}
 		//!steal-remove-end
 		
 		// check if there's a setter

--- a/test/jquery.html
+++ b/test/jquery.html
@@ -74,7 +74,7 @@
             "can/view/scope/scope_test.js",
             "can/util/string/string_test.js",
             "can/util/attr/attr_test.js", function() {
-                can.dev.logLevel = 3;
+                // can.dev.logLevel = 3;
                 QUnit.start();
             });
         </script>

--- a/view/mustache/mustache.js
+++ b/view/mustache/mustache.js
@@ -47,6 +47,9 @@ steal('can/util',
 			isLookup = function (obj) {
 				return obj && typeof obj.get === "string";
 			},
+			// object to keep track of keys we already showed warnings about
+			// only show a warning once per key
+			missingKeys = {},
 
 			/*
 			 * Checks whether an object is like a can.Map. This takes into
@@ -1332,6 +1335,7 @@ steal('can/util',
 
 			// here we are going to cache the lookup values so future calls are much faster
 			var scope = scopeAndOptions.scope,
+				propName = name.get,
 				options = scopeAndOptions.options,
 				args = [],
 				helperOptions = {
@@ -1354,11 +1358,11 @@ steal('can/util',
 					// get values on hash
 					for (var prop in hash) {
 						if (isLookup(hash[prop])) {
-							hash[prop] = Mustache.get(hash[prop].get, scopeAndOptions, false, true);
+							hash[prop] = Mustache.get(hash[prop].get, scopeAndOptions, false, true, false);
 						}
 					}
 				} else if (arg && isLookup(arg)) {
-					args.push(Mustache.get(arg.get, scopeAndOptions, false, true));
+					args.push(Mustache.get(arg.get, scopeAndOptions, false, true, false));
 				} else {
 					args.push(arg);
 				}
@@ -1366,7 +1370,7 @@ steal('can/util',
 
 			if (isLookup(name)) {
 				var get = name.get;
-				name = Mustache.get(name.get, scopeAndOptions, args.length, false);
+				name = Mustache.get(name.get, scopeAndOptions, args.length, false, true);
 
 				// Base whether or not we will get a helper on whether or not the original
 				// name.get and Mustache.get resolve to the same thing. Saves us from running
@@ -1511,11 +1515,12 @@ steal('can/util',
 		 * @param {Object} context The context to use for checking for a reference if it doesn't exist in the object.
 		 * @param {Boolean} [isHelper] Whether the reference is seen as a helper.
 		 */
-		Mustache.get = function (key, scopeAndOptions, isHelper, isArgument) {
+		Mustache.get = function (key, scopeAndOptions, isHelper, isArgument, showWarning) {
 
 			// Cache a reference to the current context and options, we will use them a bunch.
 			var context = scopeAndOptions.scope.attr('.'),
-				options = scopeAndOptions.options || {};
+				options = scopeAndOptions.options || {},
+				showWarning = showWarning || false;
 
 			// If key is called as a helper,
 			if (isHelper) {
@@ -1530,7 +1535,10 @@ steal('can/util',
 				}
 
 				//!steal-remove-start
-				can.dev.warn('can/view/mustache/mustache.js: Unable to find helper "' + key + '".');
+				if(showWarning && !missingKeys[key]){
+					can.dev.warn('can/view/mustache/mustache.js: Unable to find helper "' + key + '".');
+					missingKeys[key] = true;
+				}
 				//!steal-remove-end
 			}
 
@@ -1545,16 +1553,18 @@ steal('can/util',
 			can.compute.temporarilyBind(compute);
 
 			// computeData gives us an initial value
-			var initialValue = computeData.initialValue;
+			var initialValue = computeData.initialValue,
+				helperObj = Mustache.getHelper(key, options);
 			  
 			//!steal-remove-start
-			if (initialValue === undefined && !isHelper) {
+			if (showWarning && initialValue === undefined && !isHelper && !helperObj && !missingKeys[key]) {
 				can.dev.warn('can/view/mustache/mustache.js: Unable to find key "' + key + '".');
+				missingKeys[key] = true;
 			}
 			//!steal-remove-end
 
 			// Use helper over the found value if the found value isn't in the current context
-			if ((initialValue === undefined || computeData.scope !== scopeAndOptions.scope) && Mustache.getHelper(key, options)) {
+			if ((initialValue === undefined || computeData.scope !== scopeAndOptions.scope) && helperObj) {
 				return key;
 			}
 

--- a/view/mustache/mustache.js
+++ b/view/mustache/mustache.js
@@ -1335,7 +1335,6 @@ steal('can/util',
 
 			// here we are going to cache the lookup values so future calls are much faster
 			var scope = scopeAndOptions.scope,
-				propName = name.get,
 				options = scopeAndOptions.options,
 				args = [],
 				helperOptions = {
@@ -1520,7 +1519,7 @@ steal('can/util',
 			// Cache a reference to the current context and options, we will use them a bunch.
 			var context = scopeAndOptions.scope.attr('.'),
 				options = scopeAndOptions.options || {},
-				showWarning = showWarning || false;
+				showWarningFlag = showWarning || false;
 
 			// If key is called as a helper,
 			if (isHelper) {
@@ -1535,7 +1534,7 @@ steal('can/util',
 				}
 
 				//!steal-remove-start
-				if(showWarning && !missingKeys[key]){
+				if(showWarningFlag && !missingKeys[key]){
 					can.dev.warn('can/view/mustache/mustache.js: Unable to find helper "' + key + '".');
 					missingKeys[key] = true;
 				}
@@ -1557,7 +1556,7 @@ steal('can/util',
 				helperObj = Mustache.getHelper(key, options);
 			  
 			//!steal-remove-start
-			if (showWarning && initialValue === undefined && !isHelper && !helperObj && !missingKeys[key]) {
+			if (showWarningFlag && initialValue === undefined && !isHelper && !helperObj && !missingKeys[key]) {
 				can.dev.warn('can/view/mustache/mustache.js: Unable to find key "' + key + '".');
 				missingKeys[key] = true;
 			}

--- a/view/mustache/test.html
+++ b/view/mustache/test.html
@@ -24,7 +24,7 @@
 
     QUnit.config.autostart = false;
 	steal("can/view/mustache/mustache_test.js", function() {
-		// can.dev.logLevel = 3;
+		can.dev.logLevel = 3;
         QUnit.start();
 	});
 </script>

--- a/view/mustache/test.html
+++ b/view/mustache/test.html
@@ -24,7 +24,7 @@
 
     QUnit.config.autostart = false;
 	steal("can/view/mustache/mustache_test.js", function() {
-		can.dev.logLevel = 3;
+		// can.dev.logLevel = 3;
         QUnit.start();
 	});
 </script>


### PR DESCRIPTION
1) only show the construct.extend warning once per page
2) only show each mustache key missing warning once per key (if this is in a loop it gets very noisy)
3) only show mustache key warnings for rendering properties, not for arguments to a helper
4) mustache key warnings were broken and showing up for all helper access also
