### PR TITLE
Warnings for map/define

### DIFF
--- a/map/define/define.js
+++ b/map/define/define.js
@@ -3,6 +3,12 @@ steal('can/util', 'can/observe', function (can) {
 
 	can.Map.helpers.define = function (Map) {
 		var define = Map.prototype.define;
+		//!steal-remove-start
+		if(Map.define){
+			can.dev.warn("The define property should be on the map's prototype properties, "+
+				"not the static properies.");
+		}
+		//!steal-remove-end
 		Map.defaultGenerators = {};
 		for (var prop in define) {
 			if ("value" in define[prop]) {

--- a/map/map.js
+++ b/map/map.js
@@ -47,7 +47,16 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 					}
 					// Builds a list of compute and non-compute properties in this Object's prototype.
 					this._computes = [];
-
+					//!steal-remove-start
+					if(this.prototype.define && !this.helpers.define) {
+						can.dev.warn("can/map/define is not included, yet there is a define property "+
+							"used. You may want to add this plugin.");
+					}
+					if(this.define && !this.helpers.define) {
+						can.dev.warn("The define property should be on the map's prototype properties, "+
+							"not the static properies. Also, can/map/define is not included.");
+					}
+					//!steal-remove-end
 					for (var prop in this.prototype) {
 						// Non-functions are regular defaults.
 						if (prop !== "define" && typeof this.prototype[prop] !== "function") {
@@ -57,7 +66,9 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 							this._computes.push(prop);
 						}
 					}
-					this.helpers.define(this);
+					if(this.helpers.define) {
+						this.helpers.define(this);
+					}
 				}
 				// If we inherit from can.Map, but not can.List, make sure any lists are the correct type.
 				if (can.List && !(this.prototype instanceof can.List)) {
@@ -87,7 +98,7 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 			helpers: {
 				// ### can.Map.helpers.define
 				// Stub function for the define plugin.
-				define: function(){},
+				define: null,
 				/**
 				 * @hide
 				 * Parses attribute name into its parts


### PR DESCRIPTION
fixes #1041 

Adds 2 warnings:
1) when someone tries to add a define property but haven't included the define plugin
2) when someone tries to add define on static props, not prototype props
