### PR TITLE
Evaluate and cache text sections properly

### DIFF
--- a/view/stache/mustache_core.js
+++ b/view/stache/mustache_core.js
@@ -406,20 +406,21 @@ steal("can/util",
 		 * @return {function(can.view.Scope,can.view.Options, can.view.renderer, can.view.renderer)} 
 		 */
 		makeStringBranchRenderer: function(mode, expression){
-			
 			var exprData = expressionData(expression),
 				// Use the full mustache expression as the cache key.
 				fullExpression = mode+expression;
-			
+
 			// A branching renderer takes truthy and falsey renderer.
 			return function branchRenderer(scope, options, truthyRenderer, falseyRenderer){
-				// TODO: What happens if same mode/expresion, but different sub-sections?
 				// Check the scope's cache if the evaluator already exists for performance.
-				//console.log("here!");
 				var evaluator = scope.__cache[fullExpression];
-				if(!evaluator) {
-					evaluator = scope.__cache[fullExpression] = makeEvaluator( scope, options, null, mode, exprData, truthyRenderer, falseyRenderer, true);
+				if(mode || !evaluator) {
+					evaluator = makeEvaluator( scope, options, null, mode, exprData, truthyRenderer, falseyRenderer, true);
+					if(!mode) {
+						scope.__cache[fullExpression] = evaluator;
+					}
 				}
+
 				// Run the evaluator and return the result.
 				var res = evaluator();
 				return res == null ? "" : ""+res;

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -3501,4 +3501,16 @@ steal("can/view/stache", "can/view","can/test","can/view/mustache/spec/specs",fu
 		data.attr('color', false);
 		equal(frag.childNodes[0].getAttribute('class'), 'red', 'else branch');
 	});
+
+	test("returns correct value for DOM attributes (#1065)", 3, function() {
+		var template = '<h2 class="{{#if shown}}foo{{/if}} test1 {{#shown}}muh{{/shown}}"></h2>' +
+			'<h3 class="{{#if shown}}bar{{/if}} test2 {{#shown}}kuh{{/shown}}"></h3>' +
+			'<h4 class="{{#if shown}}baz{{/if}} test3 {{#shown}}boom{{/shown}}"></h4>';
+
+		var frag = can.stache(template)({ shown: true });
+
+		equal(frag.childNodes[0].className, 'foo test1 muh');
+		equal(frag.childNodes[1].className, 'bar test2 kuh');
+		equal(frag.childNodes[2].className, 'baz test3 boom');
+	});
 });


### PR DESCRIPTION
This pull request fixes #1065. Caching was done under the assumption that in a text sub section all expressions contain the same content making a simple template like the following fail:

``` html
<h2 class="{{#shown}}foo{{/if}} test {{#shown}}bar{{/shown}}"></h2>
```

The solution is to cache the evaluators for normal property lookups (like `{{style}}`) to improve performance but always create the evaluator when the mode is set (which means that there potentially is a different subsection).
