### PR TITLE
Corrected pushstate tests and update can.test.route

### DIFF
--- a/route/pushstate/pushstate_test.js
+++ b/route/pushstate/pushstate_test.js
@@ -631,7 +631,7 @@ steal('can/route/pushstate', "can/test", function () {
 				// Allows bindings.pushstate.root to handle the full domain instead of just the pathname
 				stop();
 				makeTestingIframe(function(info, done){
-					info.route.bindings.pushstate.root = can.test.path("route/pushstate/testing.html").replace("route/pushstate/testing.html", "");
+					info.route.bindings.pushstate.root = can.test.path("route/pushstate/testing.html", true).replace("route/pushstate/testing.html", "");
 					info.route(":module/:plugin/:page\\.html");
 					info.route.ready();
 
@@ -647,7 +647,7 @@ steal('can/route/pushstate', "can/test", function () {
 			test("URL's don't greedily match", function () {
 				stop();
 				makeTestingIframe(function(info, done){
-					info.route.bindings.pushstate.root = can.test.path("route/pushstate/testing.html").replace("route/pushstate/testing.html", "");
+					info.route.bindings.pushstate.root = can.test.path("route/pushstate/testing.html", true).replace("route/pushstate/testing.html", "");
 					info.route(":module\\.html");
 					info.route.ready();
 

--- a/test/test.js
+++ b/test/test.js
@@ -12,12 +12,13 @@ steal('can/util', function() {
 			}
 			return path;
 		},
-		path: function (path) {
+		path: function (path, absolute) {
+			//absolute prevents require.toURL from returning a relative path
 			if (typeof steal !== 'undefined') {
 				return ""+steal.idToUri(steal.id("can/"+path).toString())  ;
 			}
 
-			if (window.require && require.toUrl && !viewCheck.test(path)) {
+			if (!absolute && window.require && require.toUrl && !viewCheck.test(path)) {
 				return require.toUrl(path);
 			}
 


### PR DESCRIPTION
Fixes pushstate domain tests to run properly. `can.test.path` will adjust the root path depending on whether tests have access to steal.
