### PR TITLE
Fix @typedef name to be dot-separated.

### DIFF
--- a/util/bind/bind.js
+++ b/util/bind/bind.js
@@ -1,6 +1,6 @@
 steal('can/util', function (can) {
 	/**
-	 * @typedef {{bind:function():*,unbind:function():*}} can/util/bind
+	 * @typedef {{bind:function():*,unbind:function():*}} can.util.bind
 	 *
 	 * Provides mixin-able bind and unbind methods. `bind()` calls `this._bindsetup`
 	 * when the first bind happens and.  `unbind()` calls `this._bindteardown` when there


### PR DESCRIPTION
After reviewing other @ typedef definitions in other files, updated this one to use `.` instead of `/` for separators in the name. 

This also fixes a warning in the dash docset generation script, which issues a warning when it encounters an invalid typedef name. 
