### PR TITLE
Fixes compute.read with a Map wrapped in a compute

### DIFF
--- a/compute/compute.js
+++ b/compute/compute.js
@@ -643,7 +643,7 @@ steal('can/util', 'can/util/bind', 'can/util/batch', function (can, bind) {
 				if (options.foundObservable) {
 					options.foundObservable(prev, i);
 				}
-				prev = prev();
+				prev = cur = prev();
 			}
 			// Look to read a property from something.
 			if (isObserve(prev)) {

--- a/compute/compute_test.js
+++ b/compute/compute_test.js
@@ -316,5 +316,13 @@ steal("can/compute", "can/test", "can/map", function () {
 		
 		async([]);
 	});
+
+	test("compute.read works with a Map wrapped in a compute", function() {
+		var parent = can.compute(new can.Map({map: {first: "Justin" }}));
+		var reads = ["map", "first"];
+
+		var result = can.compute.read(parent, reads);
+		equal(result.value, "Justin", "The correct value is found.");
+	});
 	
 });


### PR DESCRIPTION
Previously if compute.read received a can.Map wrapped in a can.compute
it would attempt to call `.attr` against the compute itself. This is
because we were checking for `prev` to be a compute and if so getting
the value, but not setting the value on `cur` as well.
