### PR TITLE
Fixed Mustache getHelper() so that it doesn't need second argument

### DIFF
--- a/view/mustache/mustache.js
+++ b/view/mustache/mustache.js
@@ -1655,7 +1655,10 @@ steal('can/util',
 		 * Returns a helper given the name.
 		 */
 		Mustache.getHelper = function (name, options) {
-			var helper = options.attr("helpers." + name);
+			var helper;
+			if (options) {
+				helper = options.attr("helpers." + name);
+			}
 			return helper ? {
 				fn: helper
 			} : this._helpers[name];


### PR DESCRIPTION
Mustache getHelper('helpername') would not work unless you supplied an empty Observe/Map as second argument.
