### PR TITLE
Fix for issues when building with steal-tools

### DIFF
--- a/util/attr/attr.js
+++ b/util/attr/attr.js
@@ -7,14 +7,14 @@ steal("can/util/can.js", function (can) {
 
 	// Acts as a polyfill for setImmediate which only works in IE 10+. Needed to make
 	// the triggering of `attributes` event async.
-	var setImmediate = window.setImmediate || function (cb) {
+	var setImmediate = (typeof window !== "undefined" && window.setImmediate) || function (cb) {
 			return setTimeout(cb, 0);
 		},
 		attr = {
 			// This property lets us know if the browser supports mutation observers.
 			// If they are supported then that will be setup in can/util/jquery and those native events will be used to inform observers of attribute changes.
 			// Otherwise this module handles triggering an `attributes` event on the element.
-			MutationObserver: window.MutationObserver || window.WebKitMutationObserver || window.MozMutationObserver,
+			MutationObserver: typeof window !== "undefined" && (window.MutationObserver || window.WebKitMutationObserver || window.MozMutationObserver),
 
 			/**
 			 * @property {Object.<String,(String|Boolean|function)>} can.view.attr.map
@@ -161,15 +161,19 @@ steal("can/util/can.js", function (can) {
 			// Checks if an element contains an attribute.
 			// For browsers that support `hasAttribute`, creates a function that calls hasAttribute, otherwise creates a function that uses `getAttribute` to check that the attribute is not null.
 			has: (function () {
-				var el = document.createElement('div');
-				if (el.hasAttribute) {
-					return function (el, name) {
-						return el.hasAttribute(name);
-					};
+				if(typeof document !== "undefined") {
+					var el = document.createElement('div');
+					if (el.hasAttribute) {
+						return function (el, name) {
+							return el.hasAttribute(name);
+						};
+					} else {
+						return function (el, name) {
+							return el.getAttribute(name) !== null;
+						};
+					}
 				} else {
-					return function (el, name) {
-						return el.getAttribute(name) !== null;
-					};
+					return function() {};
 				}
 			})()
 		};

--- a/util/can.js
+++ b/util/can.js
@@ -1,8 +1,13 @@
 steal(function () {
 	/* global GLOBALCAN */
-	var can = window.can || {};
-	if (typeof GLOBALCAN === 'undefined' || GLOBALCAN !== false) {
-		window.can = can;
+	var can;
+	if (typeof window !== 'undefined') {
+		can = window.can || {};
+		if(typeof GLOBALCAN === 'undefined' || GLOBALCAN !== false) {
+			window.can = can;
+		}
+	} else {
+		can = {};
 	}
 
 	// An empty function useful for where you need a dummy callback.

--- a/view/target/target.js
+++ b/view/target/target.js
@@ -23,6 +23,10 @@ steal("can/util", "can/view/elements.js",function(can, elements){
 			return cloned.childNodes[0].childNodes.length === 2;
 		})(),
 		clonesWork = (function(){
+			if(typeof document === "undefined") {
+				return false;
+			}
+
 			// Since html5shiv is required to support custom elements, assume cloning
 			// works in any browser that doesn't have html5shiv
 

--- a/view/view.js
+++ b/view/view.js
@@ -96,7 +96,7 @@ steal('can/util', function (can) {
 		// You should only be using `//` if you are using an AMD loader like `steal` or `require` (not almond).
 		if (url.match(/^\/\//)) {
 			url = url.substr(2);
-			url = !window.steal ?
+			url = ( typeof window === "undefined" || ! window.steal ) ?
 				url :
 				steal.config()
 					.root.mapJoin("" + steal.id(url));


### PR DESCRIPTION
Some of the previous domless checks were removed somehow which was breaking the builds with steal-tools. This just adds those checks back in.

We should create a test that checks that builds will work.
