### PR TITLE
Fix templates not being picked up by `can.view()` when using `steal('som...

### DIFF
--- a/view/ejs/system.js
+++ b/view/ejs/system.js
@@ -2,7 +2,7 @@ steal("can/view/ejs", function(can){
 
 	function translate(load) {
 		return "define(['can/view/ejs/ejs'],function(can){" +
-			"return can.view.preloadStringRenderer('" + load.metadata.pluginArgument + "'," +
+			"return can.view.preloadStringRenderer('" + can.view.toId(load.metadata.pluginArgument) + "'," +
 			'can.EJS(function(_CONTEXT,_VIEW) { ' + new can.EJS({
 				text: load.source,
 				name: load.name

--- a/view/mustache/system.js
+++ b/view/mustache/system.js
@@ -2,7 +2,7 @@ steal("can/view/mustache", function(can){
 
 	function translate(load) {
 		return "define(['can/view/mustache/mustache'],function(can){" +
-			"return can.view.preloadStringRenderer('" + load.metadata.pluginArgument + "'," +
+			"return can.view.preloadStringRenderer('" + can.view.toId(load.metadata.pluginArgument) + "'," +
 			'can.Mustache(function(scope,options) { ' + new can.Mustache({
 				text: load.source,
 				name: load.name


### PR DESCRIPTION
When using the SystemJS ext plugins, `can.view(url)` isn't finding the templates.

In `stealconfig.js`, I have:

```
...
ext: {
    css: "$css",
    less: "$less",
    ejs: "can/view/ejs/system",
    mustache: "can/view/mustache/system",
    stache: "can/view/stache/system"
},
...
```

I load the template with steal:

```
steal('example/template.mustache!', ...)
```

I can see it has been added to `can.view.cached["example/template.mustache"]`.

But then when I call `can.view('example/template.mustache')`, it doesn't see the cached template and tries to fetch it (which fails for another reason). 

It looks like `can/view/view.js` doesn't lookup the cache with `url`, instead uses `id` where `id = toId(url)`. 

I haven't checked stache templates.
