### PR TITLE
Model.create() doesn't return an instance of model

### DIFF
--- a/model/model_test.js
+++ b/model/model_test.js
@@ -247,6 +247,33 @@ steal("can/model", 'can/map/attributes', "can/test", "can/util/fixture", functio
 			equal(person.thing, 'er', 'we got updated');
 		});
 	});
+	test('create deferred', function () {
+		can.Model('Person', {
+			create: function (attrs, success, error) {
+				return can.ajax({
+					url: '/people/',
+					data: attrs,
+					type: 'post',
+					dataType: 'json',
+					fixture: function () {
+						return {
+							thing: 'er'
+						};
+					},
+					success: success
+				});
+			}
+		}, {});
+		var personD = Person.create({
+			id: 5
+		});
+		stop();
+		personD.then(function (person) {
+			start();
+			ok(person instanceof Person, 'result is instance of model');
+			equal(person.thing, 'er', 'we got created');
+		});
+	});
 	test('destroy deferred', function () {
 		can.Model('Person', {
 			destroy: function (id, success, error) {


### PR DESCRIPTION
Other Model methods such as `save()` and `findOne()` do return model instances so it is unexpected that `create()` doesn't also. I only have a failing test case, copied from the `update deferred` test.

As far as I can tell right now, it looks like an issue with `createUpdateDestroyHandler()` and `parseModel()` / `model()`.
