### PR TITLE
shorten npm install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "test": "grunt test",
-    "install": "node node_modules/bower/bin/bower install"
+    "install": "bower install"
   },
   "demos": [
     "http://canjs.us/#examples",


### PR DESCRIPTION
Node automatically discovers package.json "bin" attributes within node_modules/
