### PR TITLE
Auto-install bower dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "steal-tools": "git://github.com/bitovi/steal-tools.git#master"
   },
   "scripts": {
+    "install": "bower install",
     "test": "grunt test"
   },
   "demos": [


### PR DESCRIPTION
I'd git cloned, ran `npm test` and it failed. Tried opening test *.html files in the browser and they had no CSS and did not run anything. I then realized that `bower install` had not been ran. This should prevent that and speed up PRs.
