### PR TITLE
Correct bower install dir

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "bower_components"
+}


### PR DESCRIPTION
Bower recently changed the default install dir to `app/bower_components/`. All test files currently point to `bower_components/`, so this patches that.
