### PR TITLE
Remove outer setTimeout

### DIFF
--- a/map/define/test.html
+++ b/map/define/test.html
@@ -20,7 +20,6 @@
         document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../../bower_components/qunit/qunit/qunit.css" /%3E'));
         document.write(unescape('%3Cscript type="text/javascript" src="../../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
     }
-	setTimeout(function(){
 		QUnit.config.autostart = false;
 		setTimeout(function(){
 			steal("can/map/define/define_test.js", function() {
@@ -28,8 +27,6 @@
 		        QUnit.start();
 			});
 		},100);
-		
-	},10);
     
 	
 </script>


### PR DESCRIPTION
The define plugin's test page was throwing errors: 

![screenshot 2014-10-23 15 42 03](https://cloud.githubusercontent.com/assets/82166/4760071/ae3856c2-5aec-11e4-9864-fec1ce8b40ab.png)

@daffl Pointed out that the outer `setTimeout` shouldn't be there. Removing it got rid of the error. 
