### PR TITLE
Fix IE7 character access

### DIFF
--- a/view/stache/mustache_core.js
+++ b/view/stache/mustache_core.js
@@ -541,7 +541,7 @@ steal("can/util",
 		 */
 		splitModeFromExpression: function(expression, state){
 			expression = can.trim(expression);
-			var mode = expression[0];
+			var mode = expression.charAt(0);
 	
 			if( "#/{&^>!".indexOf(mode) >= 0 ) {
 				expression = can.trim( expression.substr(1) );


### PR DESCRIPTION
This fixes an array-like string-access.

Updated explanations:
It was not possible to use block-scope (mode==# etc) in stache on ie7 and other non-es5-browsers.
