### PR TITLE
RE #1302 : Fix fix up can.Component docs' spelling/syntax issues & make ...

### DIFF
--- a/component/component.md
+++ b/component/component.md
@@ -68,7 +68,7 @@ set on the component's scope.
 
 ## Use
 
-To create a `can.Component`, you must first [can.Component.extend extend] `can.Component` 
+To create a [can.Component], you must first [can.Component.extend extend] `can.Component`
 with the methods and properties of how your component behaves:
 
     can.Component.extend({
@@ -114,7 +114,7 @@ you'll render a template with many custom tags like:
 
 ### Extending can.Component
 
-Use [can.Component.extend] to create a can.Component constructor function
+Use [can.Component.extend] to create a [can.Component] constructor function
 that will automatically get initialized whenever the component's tag is 
 found.
 
@@ -298,11 +298,11 @@ If the key was not wrapped, the template would render:
 
     frag //-> <my-tag greeting='message'><h1>message</h1></my-tag>
  
-Because the attribute value would be passed as the value of `gretting`.
+Because the attribute value would be passed as the value of `greeting`.
 
 ## Examples
 
-Check out the following examples built with can.Component.
+Check out the following examples built with [can.Component].
 
 ### Tabs
 
@@ -320,7 +320,7 @@ elements like:
       {{/each}}
     </tabs>
 
-To add another panel, all we have to do is add data to foodTypes like:
+To add another panel, all we have to do is add data to `foodTypes` like:
 
     foodTypes.push({
       title: "Vegetables",
@@ -424,7 +424,7 @@ its sub-components:
 ## IE 8 Support
 
 While CanJS does support Internet Explorer 8 out of the box, if you decide
-to use can.Component then you will need to include [HTML5 Shiv](https://github.com/aFarkas/html5shiv)
+to use [can.Component] then you will need to include [HTML5 Shiv](https://github.com/aFarkas/html5shiv)
 in order for your custom tags to work properly.
 
 For namespaced tag names (e.g. `<can:example>`) and hyphenated tag names (e.g. `<can-example>`) to work properly, you will need to use version 3.7.2 or later.

--- a/component/events.md
+++ b/component/events.md
@@ -28,11 +28,11 @@ element. The component's scope is available within event handlers as `this.scope
 
 ## Use
 
-[can.Component]'s events object allows you to provide low-level [can.Control]-like abilities to a can.Component
-while still accessing can.Component's objects and methods like [can.Component::scope scope].  The following 
+[can.Component]'s events object allows you to provide low-level [can.Control]-like abilities to a `can.Component`
+while still accessing `can.Component`'s objects and methods like [can.Component::scope scope].  The following
 example listens to clicks on elements with `className="next"` and calls `.next()` on the component's scope.
 
-@demo can/component/examples/paginate_events_next.html  
+@demo can/component/examples/paginate_events_next.html
 
 The events object can also listen to objects or properties on the component's [can.Component::scope scope]. For instance, instead 
 of using live-binding, we could listen to when offset changes and update the page manually:

--- a/component/helpers.md
+++ b/component/helpers.md
@@ -13,7 +13,7 @@ are always called back with `this` as the [can.Component::scope scope].
 
 ## Use
 
-can.Component's helper object lets you provide helper functions that are localized to
+[can.Component]'s helper object lets you provide helper functions that are localized to
 the component's [can.Component::template template].  The following example
 uses an `isSelected` helper to render content for selected items. Click
 one of the following libraries to toggle them within the `selected` array. 

--- a/component/scope.md
+++ b/component/scope.md
@@ -1,7 +1,7 @@
 @property {Object|can.Map|function} can.Component.prototype.scope
 @parent can.Component.prototype
 
-Provides or describes a [can.Map] constructor function or can.Map instance that will be 
+Provides or describes a [can.Map] constructor function or `can.Map` instance that will be
 used to retrieve values found in the component's [can.Component::template template]. The map 
 instance is initialized with values specified by the component element's attributes.
 
@@ -10,8 +10,8 @@ scope differently. To pass data from the scope, you must wrap your attribute
 value with `{}`. In 3.0, [can.mustache]
 will use [can.stache]'s syntax.
 
-@option {Object} A plain JavaScript object that is used to define the prototype methods and properties of 
-[can.Construct constructor function] that extends can.Map. For example:
+@option {Object} A plain JavaScript object that is used to define the prototype methods and properties of
+[can.Construct constructor function] that extends [can.Map]. For example:
 
     can.Component.extend({
       tag: "my-paginate",
@@ -24,7 +24,7 @@ will use [can.stache]'s syntax.
       }
     })
 
-Prototype properties that have values of `"@"` are not looked up in the current scope, instead
+Prototype properties that have values of `@` are not looked up in the current scope, instead
 the literal string value of the relevant attribute is used (like pass by value instead of pass by reference).  For example:
 
     can.Component.extend({
@@ -43,8 +43,8 @@ Results in:
 
     <my-tag><h1>hello</h1></my-tag>
 
-@option {can.Map} A can.Map constructor function will be used to create an instance of the observable
-can.Map placed at the head of the template's scope.  For example:
+@option {can.Map} A `can.Map` constructor function will be used to create an instance of the observable
+`can.Map` placed at the head of the template's scope.  For example:
 
     var Paginate = can.Map.extend({
       offset: 0,
@@ -96,7 +96,7 @@ the user to provide an attribute, you can set this up here.  For example:
 
 Notice how the attribute's value is looked up in `my-element`'s parent scope.
 
-@param {HTMLElement} element The element the can.Component is going to be placed on. If you want 
+@param {HTMLElement} element The element the [can.Component] is going to be placed on. If you want
 to add custom attribute handling, you can do that here.  For example:
 
     can.Component.extend({
@@ -157,7 +157,7 @@ This is because the provided scope object is used to extend a can.Map like:
       }
     })
 
-Any primitives found on a can.Map's prototype (ex: `offset: 0`) are used as 
+Any primitives found on a `can.Map`'s prototype (ex: `offset: 0`) are used as
 default values.
 
 Next, a new instance of CustomMap is created with the attribute data within `<my-paginate>`
@@ -175,22 +175,22 @@ render the component's template, and inserted into the element:
 ## Values passed from attributes
 
 Values can be "passed" into the scope of a component, similar to passing arguments into a function. By default, 
-custom tag attributes (other than "class" and "id") are looked up
+custom tag attributes (other than `class` and `id`) are looked up
 in the parent scope and set as observable values on the [can.Map] instance. 
 
 Values passed in this way are passed similar to function arguments that are "pass by reference" because they are crossbound to 
 the property in the parent scope. Changes in the parent scope property that is passed in trigger changes in this component's scope 
 property, and likewise, changes in the component's scope property trigger a change in the parent scope property.
 
-As mentioned in the deprecation warning above, using can.stache, values are passed into components like this:
+As mentioned in the deprecation warning above, using [can.stache], values are passed into components like this:
 
     <my-paginate offset='{index}' limit='{size}'></my-paginate>
 
-But using can.mustache, values are passed like this:
+But using [can.mustache], values are passed like this:
 
-    my-paginate offset='index' limit='size'></my-paginate>
+    <my-paginate offset='index' limit='size'></my-paginate>
 
-The rest of the examples in this section show can.mustache syntax (which will change to match can.stach in 3.0). 
+The rest of the examples in this section show `can.mustache` syntax (which will change to match can.stache in 3.0).
 
 Note that using double brackets would instead render the string version of the value, and pass by value rather than by reference:
 
@@ -199,8 +199,7 @@ Note that using double brackets would instead render the string version of the v
 The above would create an offset and limit property on the component that are initialized to whatever index and size are, NOT cross-bind 
 the offset and limit properties to the index and size.
 
-The following component requires an offset and 
-limit:
+The following component requires an `offset` and `limit`:
 
     can.Component.extend({
       tag: "my-paginate",
@@ -229,8 +228,7 @@ index like:
 
     pageInfo.attr("index",20)
 
-... the component's offset value will change and it's template
-will update to:
+... the component's offset value will change and its template will update to:
 
     <my-paginate>Page 1</my-paginate>
 
@@ -239,16 +237,16 @@ will update to:
 You can also pass a literal string value of the attribute instead of the attribute's value looked up in
 the parent scope (similar to pass by value). 
 
-To do this in can.stache, simply pass any value not wrapped in single brackets, and the scope property will 
+To do this in [can.stache], simply pass any value not wrapped in single brackets, and the scope property will
 be initialized to this string value:
 
     <my-tag title="hello"></my-tag>
 
-The above will create a title property in the component's scope, which has a string "hello".  If instead hello was wrapped with 
-brackets like "{hello}", a hello property would be looked up in the parent's scope.
+The above will create a title property in the component's scope, which has a string `hello`.  If instead hello was wrapped with
+brackets like `{hello}`, a hello property would be looked up in the parent's scope.
 
-To do this in can.mustache, pass a value like in can.stache, and set the corresponding scope property in the component 
-to a value of "@".  For example:
+To do this in [can.mustache], pass a value like in `can.stache`, and set the corresponding scope property in the component
+to `@`.  For example:
 
     can.Component.extend({
       tag: "my-tag",
@@ -266,17 +264,16 @@ Results in:
 
     <my-tag><h1>hello</h1></my-tag>
 
-can.mustache syntax (requiring the "@") will change to can.stache in 3.0 (not requiring the "@").
+In 3.0, `can.mustache` syntax (requiring `@`) will change to `can.stache`'s' (not requiring `@`).
 
 If the tag's `title` attribute is changed, it updates the scope property 
 automatically.  This can be seen in the following example:
 
 @demo can/component/examples/accordion.html
 
-Clicking the __Change title__
-button sets a `<panel>` element's "title" attribute like:
+Clicking the __Change title__ button sets a `<panel>` element's "title" attribute like:
 
-    $("#out").on("click","button", function(){
+    $("#out").on("click", "button", function(){
       $("panel:first").attr("title", "Users")
       $(this).remove();
     });
@@ -284,7 +281,7 @@ button sets a `<panel>` element's "title" attribute like:
 
 ## Calling methods on scope from events within the template
 
-Using html attributes like `can-EVENT=METHOD`, you can directly call a scope method 
+Using html attributes like `can-EVENT-METHOD`, you can directly call a scope method
 from a template. For example, we can make `<my-paginate>` elements include a next
 button that calls the scope's `next` method like:
 

--- a/component/tag.md
+++ b/component/tag.md
@@ -1,11 +1,11 @@
 @property {String} can.Component.prototype.tag
 @parent can.Component.prototype
 
-Specifies the HTML tag (or node-name) the can.Component will be created on.
+Specifies the HTML tag (or node-name) the [can.Component] will be created on.
 
-@option {String} The tag name the can.Component 
+@option {String} The tag name the [can.Component]
 will be created on.  Tag names are typically lower cased and
-hypenated like: "foo-bar".  Component's register their
+hypenated like: `foo-bar`.  Component's register their
 tag with [can.view.tag].
 
 

--- a/component/template.md
+++ b/component/template.md
@@ -30,7 +30,7 @@ the [http://www.w3.org/TR/shadow-dom/ W3C Shadow DOM proposal]. It represents th
 of a custom element, while being able to reposition the user provided __source__ elements
 with the `<content>` tag.
 
-There are three things to understand about a `can.Component`'s template:
+There are three things to understand about a [can.Component]'s template:
 
  - It is inserted into the component's tag.
  - It is rendered with access to the component instance's scope.
@@ -40,7 +40,7 @@ The following example demonstrates all three features:
 
 @demo can/component/examples/my_greeting_full.html
 
-The following explains how each part works.
+The following explains how each part works:
 
 __can.Component:__
 
@@ -67,7 +67,7 @@ __Source template:__
 
 The source template is the template that 
 uses `<my-greeting>`.  In the demo, this is defined within a `<script>` 
-tag.  
+tag.
 
 Notice:
 
@@ -101,7 +101,7 @@ The following sections break this down more.
 
 ## Template insertion
 
-The mustache template specified by template is rendered directly withing the custom tag.  
+The [can.mustache] template specified by template is rendered directly withing the custom tag.
 
 For example the following component:
 


### PR DESCRIPTION
...more consistent use of CanJS component hyperlink references in the doc.s

More notes in and closes #1302 
