### PR TITLE
Don't show a warning if a helper method is used in mustache

### DIFF
--- a/view/mustache/mustache.js
+++ b/view/mustache/mustache.js
@@ -1545,10 +1545,11 @@ steal('can/util',
 			can.compute.temporarilyBind(compute);
 
 			// computeData gives us an initial value
-			var initialValue = computeData.initialValue;
+			var initialValue = computeData.initialValue,
+				helperObj = Mustache.getHelper(key, options);
 			  
 			//!steal-remove-start
-			if (initialValue === undefined && !isHelper) {
+			if (initialValue === undefined && !isHelper && !helperObj) {
 				can.dev.warn('can/view/mustache/mustache.js: Unable to find key "' + key + '".');
 			}
 			//!steal-remove-end

--- a/view/mustache/mustache_test.js
+++ b/view/mustache/mustache_test.js
@@ -3623,6 +3623,23 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 
 			can.dev.warn = oldlog;
 		});
+
+		test("Logging: Don't show a warning on helpers (#1257)", 1, function () {
+			var oldlog = can.dev.warn;
+
+			can.dev.warn = function (text) {
+				ok(false, 'Log warning not called for helper');
+			}
+
+			can.mustache.registerHelper('myHelper', function() {
+				return 'Hi!';
+			});
+
+			var frag = can.view.mustache('<li>{{myHelper}}</li>')({});
+			equal(frag.textContent, 'Hi!');
+
+			can.dev.warn = oldlog;
+		});
 	}
 	//!steal-remove-end
 


### PR DESCRIPTION
fixes #1257

Don't show any can.dev.warn message if a Mustache helper method is accessed.

Can see this in action if you run http://localhost:8000/view/mustache/test.html and comment out can.dev.logLevel = 3. Before the change, you'll see many warnings about helper methods, but none after.
