### PR TITLE
Changed use of $ to jQuery.

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -420,8 +420,9 @@ steal("can/util", "can/view/callbacks","can/control", "can/observe", "can/view/m
 
 	// If there is a `$` object and it has the `fn` object, create the `scope` plugin that returns
 	// the scope object
-	if (window.$ && $.fn) {
-		$.fn.scope = function (attr) {
+	// Issue#1288 - Changed from `$` to `jQuery` mainly when using jQuery as a CommonJS module (Browserify-shim).
+	if (window.jQuery && jQuery.fn) {
+		jQuery.fn.scope = function (attr) {
 			// If `attr` is passed to the `scope` plugin return the value of that 
 			// attribute on the `scope` object, otherwise return the whole scope
 			if (attr) {


### PR DESCRIPTION
Fixes #1288

In the referenced project, using Browserify, jQuery will not add `$` or `jQuery` if the `window` object doesn't exist.  The scope plugin looks for `$` on the window object but wouldn't find it and would therefore not attach itself.  Browserify-shim can be used to create the global jQuery, but CanJS was still looking for `$`.

Changed the check from `$` to `jQuery`.
