### PR TITLE
Allow removing elements with negative indices from live lists

### DIFF
--- a/view/live/live.js
+++ b/view/live/live.js
@@ -229,7 +229,11 @@ steal('can/util', 'can/view/elements.js', 'can/view', 'can/view/node_lists', 'ca
 					if (!duringTeardown && data.teardownCheck(text.parentNode)) {
 						return;
 					}
-					var removedMappings = masterNodeList.splice(index+1, items.length),
+					if(index < 0) {
+						index = indexMap.length + index;
+					}
+
+					var removedMappings = masterNodeList.splice(index + 1, items.length),
 						itemsToRemove = [];
 					can.each(removedMappings, function (nodeList) {
 						

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -3629,4 +3629,17 @@ steal("can/view/stache", "can/view","can/test","can/view/mustache/spec/specs",fu
 
 		equal(frag.childNodes[0].outerHTML, expected, '<col> nodes added in proper position');
 	});
+
+	test('splicing negative indices works (#1038)', function() {
+		// http://jsfiddle.net/ZrWVQ/2/
+		var template = '{{#each list}}<p>{{.}}</p>{{/each}}';
+		var list = new can.List(['a', 'b', 'c', 'd']);
+		var frag = can.stache(template)({
+			list: list
+		});
+		var children = frag.childNodes.length;
+
+		list.splice(-1);
+		equal(frag.childNodes.length, children - 1, 'Child node removed');
+	});
 });


### PR DESCRIPTION
This pull request converts negative indices in live binding lists into the actual index in the map. This is needed to not break live-bound lists when calling `can.List.prototype.splice` with negative indices. Closes #1038.
