### PR TITLE
property for which no validations are defined throws an exception

### DIFF
--- a/map/validations/validations.js
+++ b/map/validations/validations.js
@@ -160,11 +160,11 @@ steal('can/util', 'can/map', function (can) {
 							errors[attr].push(res);
 						}
 					});
-				}, validations = this.constructor.validations,
+				}, validations = this.constructor.validations || {},
 				isTest = attrs && attrs.length === 1 && arguments.length === 2;
 			// go through each attribute or validation and
 			// add any errors
-			can.each(attrs || validations || {}, function (funcs, attr) {
+			can.each(attrs || validations, function (funcs, attr) {
 				// if we are iterating through an array, use funcs
 				// as the attr name
 				if (typeof attr === 'number') {

--- a/map/validations/validations_test.js
+++ b/map/validations/validations_test.js
@@ -343,4 +343,8 @@ steal("can/map/validations", "can/compute", "can/test", function () {
 		task.attr('age', 'bad');
 		task.attr('age', 'still bad');
 	});
+	test('Validate undefined property', function () {
+		new can.Map().errors( "foo" );
+		ok(true, "does not throw" );
+	});
 });


### PR DESCRIPTION
I created a small fix for the edge case when you explicitly test a property for errors when there are no validations defined in the can.Map.

attrs would be filled with your one property that is checked, but validations would be undefined, causing an issue.
