### PR TITLE
Properly use parseModel(s) and allow extension

### DIFF
--- a/model/model_test.js
+++ b/model/model_test.js
@@ -1050,6 +1050,7 @@ steal("can/model", 'can/map/attributes', "can/test", "can/util/fixture", functio
 			};
 		});
 		stop();
+
 		MyModel.bind('created', function (ev, created) {
 			start();
 			deepEqual(created.attr(), {
@@ -1662,4 +1663,55 @@ steal("can/model", 'can/map/attributes', "can/test", "can/util/fixture", functio
 		});
 	});
 
+	test("parseModels does not get overwritten if already implemented in base class (#1246, #1272)", 5, function() {
+		var Base = can.Model.extend({
+			findOne: function() {
+				var dfd = can.Deferred();
+				dfd.resolve({
+					text: 'Base findOne'
+				});
+				return dfd;
+			},
+			parseModel: function(attributes) {
+				deepEqual(attributes, {
+					text: 'Base findOne'
+				}, 'parseModel called');
+				attributes.parsed = true;
+				return attributes;
+			}
+		}, {});
+		var Extended = Base.extend({}, {});
+
+		stop();
+
+		Extended.findOne({}).then(function(model) {
+			ok(model instanceof Base);
+			ok(model instanceof Extended);
+			deepEqual(model.attr(), {
+				text: 'Base findOne',
+				parsed: true
+			});
+			start();
+		}, function() {
+			ok(false, 'Failed handler should not be called.');
+		});
+
+		var Third = Extended.extend({
+			findOne: function() {
+				var dfd = can.Deferred();
+				dfd.resolve({
+					nested: {
+						text: 'Third findOne'
+					}
+				});
+				return dfd;
+			},
+
+			parseModel: 'nested'
+		}, {});
+
+		Third.findOne({}).then(function(model) {
+			equal(model.attr('text'), 'Third findOne', 'correct findOne used');
+		});
+	});
 });


### PR DESCRIPTION
Closes #1246, closes #1272.

This pull request changes `.model` and `.models` to use `parseModel(s)` while staying backwards compatible with previous versions. Adds undocumented additional parameters to `.model(data, oldModel, xhr)` and `.models(data, oldList, xhr)` to be able to pass the xhr (and makes `.model` signature consistent with `.models`).
