### PR TITLE
Fixed can/util/fixture to be compatible with new StealJS.

### DIFF
--- a/util/fixture/fixture.js
+++ b/util/fixture/fixture.js
@@ -23,9 +23,14 @@ steal('can/util', 'can/util/string', 'can/util/object', function (can) {
 
 			// Legacy steal
 			if (can.isFunction(steal.config)) {
-				return steal.config()
-					.root.mapJoin(url)
-					.toString();
+				if (steal.System) {
+					return steal.joinURIs(steal.config('baseURL'), url);
+				}
+				else {
+					return steal.config()
+						.root.mapJoin(url)
+						.toString();
+				}
 			}
 			return steal.root.join(url)
 				.toString();


### PR DESCRIPTION
With the new StealJS, `steal.config()` throws an error `TypeError: Cannot read property 'length' of undefined`.

Original PR: #1239 

A similar PR by someone else: #1321 

Will dance on a table if this can be merged
