### PR TITLE
Update compute.read to also return constructor functions

### DIFF
--- a/component/component_test.js
+++ b/component/component_test.js
@@ -1311,4 +1311,31 @@ steal("can/component", "can/view/stache" ,"can/route", function () {
 		
 	});
 
+	test('scope objects with Constructor functions as properties do not get converted (#1261)', 1, function(){
+		stop();
+
+		var Test = can.Map.extend({
+			test: 'Yeah'
+		});
+
+		can.Component.extend({
+			tag:'my-app',
+			scope: {
+				MyConstruct: Test
+			},
+			events: {
+				'{MyConstruct} something': function() {
+					ok(true, 'Event got triggered');
+					start();
+				}
+			}
+		});
+
+		var frag = can.stache('<my-app></my-app>')();
+
+		// element must be inserted, otherwise attributes event will not be fired
+		can.append(can.$("#qunit-test-area"),frag);
+
+		can.trigger(Test, 'something');
+	});
 });

--- a/compute/compute.js
+++ b/compute/compute.js
@@ -658,7 +658,8 @@ steal('can/util', 'can/util/bind', 'can/util/batch', function (can, bind) {
 					// call that method
 					if (options.returnObserveMethods) {
 						cur = cur[reads[i]];
-					} else if (reads[i] === 'constructor' && prev instanceof can.Construct) {
+					} else if ( (reads[i] === 'constructor' && prev instanceof can.Construct) ||
+						(prev[reads[i]].prototype instanceof can.Construct)) {
 						cur = prev[reads[i]];
 					} else {
 						cur = prev[reads[i]].apply(prev, options.args || []);

--- a/compute/compute_test.js
+++ b/compute/compute_test.js
@@ -324,5 +324,13 @@ steal("can/compute", "can/test", "can/map", function () {
 		var result = can.compute.read(parent, reads);
 		equal(result.value, "Justin", "The correct value is found.");
 	});
-	
+
+	test("compute.read returns constructor functions instead of executing them (#1332)", function() {
+		var Todo = can.Map.extend({});
+		var parent = can.compute(new can.Map({map: { Test: Todo }}));
+		var reads = ["map", "Test"];
+
+		var result = can.compute.read(parent, reads);
+		equal(result.value, Todo, 'Got the same Todo');
+	});
 });


### PR DESCRIPTION
This is a follow up on #1261 and #1319 and also adds the ability to return constructor functions when using `can.compute.read` (constructor functions should never be just executed).
