### PR TITLE
can.Construct and can.Construct.super support ES5 getters and setters

### DIFF
--- a/construct/construct.js
+++ b/construct/construct.js
@@ -31,7 +31,7 @@ steal('can/util/string', function (can) {
 			addTo = addTo || newProps;
 
 			for (var name in newProps) {
-					can.Construct._overwrite(addTo, oldProps, name, newProps[name]);
+				can.Construct._overwrite(addTo, oldProps, name, newProps[name]);
 			}
 		};
 
@@ -336,7 +336,7 @@ steal('can/util/string', function (can) {
 						can.dev.warn('can/construct/construct.js: extending a can.Construct without calling extend');
 					}
 					//!steal-remove-end
-					
+
 					return this.constructor !== Constructor &&
 					// We are being called without `new` or we are extending.
 					arguments.length && Constructor.constructorExtends ? Constructor.extend.apply(Constructor, arguments) :

--- a/construct/construct_test.js
+++ b/construct/construct_test.js
@@ -164,6 +164,10 @@ steal('can/construct', function () {
 
 				set name(value) {
 					this._name = value;
+				},
+
+				get name() {
+					return this._name;
 				}
 			});
 
@@ -171,7 +175,7 @@ steal('can/construct', function () {
 			test.base = 2;
 			equal(test.age, 42, 'Getter called properly');
 			test.name = 'David';
-			equal(test._name, 'David', 'Setter ran');
+			equal(test.name, 'David', 'Setter ran');
 		});
 	}
 });

--- a/construct/super/super.js
+++ b/construct/super/super.js
@@ -26,6 +26,8 @@ steal('can/util', 'can/construct', function (can, Construct) {
 			can.each(getset, function (method) {
 				if(isFunction(_super[method]) && isFunction(descriptor[method])) {
 					descriptor[method] = getSuper(_super, method, descriptor[method]);
+				} else if(!isFunction(descriptor[method])) {
+					descriptor[method] = _super[method];
 				}
 			});
 		}

--- a/construct/super/super_test.js
+++ b/construct/super/super_test.js
@@ -72,6 +72,8 @@ steal("can/construct/super", function () {
 	 }
 	 })*/
 
+	// To avoid JSHint complaining about the missing getter
+	/* jshint ignore:start */
 	if(Object.getOwnPropertyDescriptor) {
 		test("_super supports getters and setters", function () {
 			var Person = can.Construct.extend({
@@ -81,6 +83,10 @@ steal("can/construct/super", function () {
 
 				set name(value) {
 					this._name = value;
+				},
+
+				get name() {
+					return this._name;
 				}
 			});
 
@@ -98,7 +104,8 @@ steal("can/construct/super", function () {
 			test.base = 2;
 			equal(test.age, 50, 'Getter and _super works');
 			test.name = 'David';
-			equal(test._name, 'David_super', 'Setter ran');
+			equal(test.name, 'David_super', 'Setter ran');
 		});
 	}
+	/* jshint ignore:end */
 });


### PR DESCRIPTION
This pull request adds ES5 getter/setter support in object definitions and also makes it possible to use `_super` with the can.Construct.super plugin. Closes #1337.
