### PR TITLE
Namespacing Fix

### DIFF
--- a/construct/construct.js
+++ b/construct/construct.js
@@ -1,9 +1,9 @@
 // steal-clean
 steal('can/util/string', function (can) {
 	// ## construct.js
-	// `can.Construct`  
+	// `can.Construct`
 	// _This is a modified version of
-	// [John Resig's class](http://ejohn.org/blog/simple-javascript-inheritance/).  
+	// [John Resig's class](http://ejohn.org/blog/simple-javascript-inheritance/).
 	// It provides class level inheritance and callbacks._
 	// A private flag used to initialize a new class instance without
 	// initializing it's bindings.
@@ -113,7 +113,7 @@ steal('can/util/string', function (can) {
 			if (inst.setup) {
 				args = inst.setup.apply(inst, arguments);
 			}
-			// Call `init` if there is an `init`  
+			// Call `init` if there is an `init`
 			// If `setup` returned `args`, use those as the arguments
 			if (inst.init) {
 				inst.init.apply(inst, args || arguments);
@@ -362,6 +362,10 @@ steal('can/util/string', function (can) {
 				_fullName = can.underscore(fullName.replace(/\./g, "_"));
 				_shortName = can.underscore(shortName);
 
+				if (can.isPlainObject(current[shortName])) {
+					can.extend(Constructor, current[shortName]);
+				}
+
 				//!steal-remove-start
 				if (current[shortName]) {
 					can.dev.warn("can/construct/construct.js: There's already something called " + fullName);
@@ -438,7 +442,7 @@ steal('can/util/string', function (can) {
 			/**
 			 * @prototype
 			 */
-			return Constructor; //  
+			return Constructor; //
 			/**
 			 * @property {Object} can.Construct.prototype.constructor constructor
 			 * @parent can.Construct.prototype


### PR DESCRIPTION
We use namespacing a lot accross the application, and we encountered an issue when we create for example:
Model.Leave.Type, and then Model.Leave
This will cause the initial Model.Leave object containing the Type to be overwritten by Model.Leave constructor.
The fix will extend the new constructor with initial object properties.