### PR TITLE
Breaking Test to ensure that model is removed from store on ID change

### DIFF
--- a/model/model_test.js
+++ b/model/model_test.js
@@ -1748,5 +1748,19 @@ steal("can/model", 'can/map/attributes', "can/test", "can/util/fixture", functio
 
 	});
 
+
+	test("Models should be removed from store when id is changed", function(){
+		var Task = can.Model.extend({},{});
+		var t1 = new Task({id: 1, name: "MyTask"});
+
+		t1.bind('change', function(){});
+		ok(Task.store[1].name === "MyTask", "Model with id 1 should be in store");
+
+		t1.attr("id", 5);
+		ok(Task.store[1].name === "MyTask", "Model is 5 should be in store");
+		ok(typeof Task.store[1] === "undefined", "Model with id 1 should be removed from store");
+	});
+
+
 });
 


### PR DESCRIPTION
Breaking Test to accompany issue #1463.

This is a (currently) breaking test to check that a model is removed from the store if the ID changes. Typically the ID shouldn't change during the life of a model. But under some circumstances such as creating/saving - the ID might not be known on creation and only resolved after saving. This test should ensure that the old model is removed when the ID is updated/changed.