### PR TITLE
Backport compute set value for input type radio and checkbox

### DIFF
--- a/compute/proto_compute.js
+++ b/compute/proto_compute.js
@@ -79,7 +79,7 @@ steal('can/util', 'can/util/bind', 'can/util/batch', function (can, bind) {
 
 	var updateOnChange = function(compute, newValue, oldValue, batchNum){
 		// Only trigger event when value has changed
-		if (newValue !== oldValue) {
+		if (newValue !== oldValue || compute._triggerOnSameValue) {
 			can.batch.trigger(compute, batchNum ? {type: "change", batchNum: batchNum} : 'change', [
 				newValue,
 				oldValue

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -814,4 +814,102 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		ta.appendChild(frag);
 		can.trigger(document.getElementById("click-me"), "click");
 	});
+
+	test('input type="radio" can-value compute rejects new value (#1518)', function() {
+		var template = can.view.mustache(
+			'<input type="radio" name="siblingRadios" can-value="alwaysMaybeCompute" value="yes"/>' +
+		  '<input type="radio" name="siblingRadios" can-value="alwaysMaybeCompute" value="no"/>' +
+		  '<input type="radio" name="siblingRadios" can-value="alwaysMaybeCompute" value="maybe"/>'
+		);
+
+		// Compute rejects all values, is always false
+		var alwaysMaybeCompute = can.compute('maybe', function(newVal, oldVal) {
+			return 'maybe';
+		});
+
+		var frag = template({
+			alwaysMaybeCompute: alwaysMaybeCompute
+		});
+
+		var ta = document.getElementById("qunit-fixture");
+		ta.appendChild(frag);
+
+		var firstInput = ta.getElementsByTagName("input")[0];
+		var secondInput = ta.getElementsByTagName("input")[1];
+		var thirdInput = ta.getElementsByTagName("input")[2];
+
+		// Set the first radio to "true"
+		firstInput.checked = true;
+		can.trigger(firstInput, "change");
+
+		equal(alwaysMaybeCompute(), 'maybe', "Change not applied");
+		equal(firstInput.checked, false, "First input not checked");
+		equal(secondInput.checked, false, "Second input not checked");
+		equal(thirdInput.checked, true, "Third input checked");
+	});
+
+
+	test('input type="checkbox" can-value compute rejects new value (#1518)', function() {
+		var template = can.view.mustache('<input type="checkbox" can-value="alwaysFalseCompute" />');
+
+		// Compute rejects all values, is always false
+		var alwaysFalseCompute = can.compute(false, function(newVal, oldVal) {
+			return false;
+		});
+
+		var frag = template({
+			alwaysFalseCompute: alwaysFalseCompute
+		});
+
+		var ta = document.getElementById("qunit-fixture");
+		ta.appendChild(frag);
+
+		var input = ta.getElementsByTagName("input")[0];
+
+		// Set the <input> to "true"
+		input.checked = true;
+		can.trigger(input, "change");
+
+		equal(alwaysFalseCompute(), false, "Change not applied");
+		equal(input.checked, false, "Input reflects actual value");
+	});
+
+	test('<select> can-value compute rejects new value (#1518)', function() {
+		var template = can.view.mustache(
+			'<select can-value="alwaysMaybeCompute">' +
+				'<option value="-1"></option>' +
+				'<option value="yes">Yes</option>' +
+				'<option value="no">No</option>' +
+				'<option value="maybe">Maybe</option>' +
+			'</select>'
+		);
+
+		// Compute rejects all values, is always false
+		var alwaysMaybeCompute = can.compute('maybe', function(newVal, oldVal) {
+			return 'maybe';
+		});
+
+		var frag = template({
+			alwaysMaybeCompute: alwaysMaybeCompute
+		});
+
+		var ta = document.getElementById("qunit-fixture");
+		ta.appendChild(frag);
+
+		var select = ta.getElementsByTagName("select")[0];
+		var options = select.options;
+
+		can.trigger(select, "change");
+		equal(options[3].selected, true, 'The default value is correct');
+
+		options[2].selected = true;
+		can.trigger(select, "change");
+
+		equal(alwaysMaybeCompute(), 'maybe', "Change not applied");
+		equal(options[0].selected, false, "First option not checked");
+		equal(options[1].selected, false, "Second option not checked");
+		equal(options[2].selected, false, "Third option not checked");
+		equal(options[3].selected, true, "Fourth option checked");
+	});
+
 });


### PR DESCRIPTION
Closes #1518 

- Passed a reference to the radio input's parent compute (I named it `abstractValue`) to the `Checked` control.
- Added a `triggerWhileUnchanged` option to the event object passed to `can.dispatch` and subsequently `onchanged` to coerce the child computes to trigger `change` events despite their values not changing.
- If a radio input is selected and the value that's passed to the setter doesn't stick, I trigger a change event on the `abstractValue` and set `triggerWhileUnchanged` to true so that each radio input can read the actual value and set itself to the selected/not-selected state.
- In the case of a "checkbox" type input, we just re-run that input's `check` function again so that it can detect the actual value
- `<select>` inputs already handled the persisted compute value correctly. I just added a test. 