### PR TITLE
Add can.fixture.resource method for generating fixtures based on CRUD standards

### DIFF
--- a/util/fixture/fixture.js
+++ b/util/fixture/fixture.js
@@ -404,6 +404,37 @@ steal('can/util', 'can/util/string', 'can/util/object', function (can) {
 			});
 			return data;
 		},
+		// ## can.fixture.resource
+		// Create the fixture routes for default CRUD actions
+		resource: function(resource, store, opts) {
+			if (!resource || !store) {
+				return null;
+			}
+
+			opts = opts || {};
+
+			var ajaxMethods = can.extend({
+				findAll: 'GET',
+				findOne: 'GET',
+				create: 'POST',
+				update: 'PUT',
+				destroy: 'DELETE'
+			}, opts.ajaxMethods || {});
+
+			var id = opts.id || 'id',
+				createURLFromResource = function(resource, name, id) {
+					resource = resource.replace(/\/+$/, "");
+					if (name === "findAll" || name === "create") {
+						return resource;
+					} else {
+						return resource + "/{" + id + "}";
+					}
+				};
+
+			for (var method in ajaxMethods) {
+				can.fixture('' + ajaxMethods[method] + ' ' + createURLFromResource(resource, method, id), store[method]);
+			}
+		},
 		// ## can.fixture.store
 		// Make a store of objects to use when making requests against fixtures.
 		store: function (count, make, filter) {

--- a/util/fixture/fixture_test.js
+++ b/util/fixture/fixture_test.js
@@ -105,6 +105,41 @@ steal('can/util/fixture', 'can/model', 'can/test', 'steal-qunit', function () {
 		});
 	}
 
+	test('can.fixture.resource', function () {
+		stop();
+		var store = can.fixture.store('thing', 1000, function (i) {
+			return {
+				id: i,
+				name: 'thing ' + i
+			};
+		}, function (item, settings) {
+			if (settings.data.searchText) {
+				var regex = new RegExp('^' + settings.data.searchText);
+				return regex.test(item.name);
+			}
+		});
+
+		can.fixture.resource('/things', store);
+
+		can.ajax({
+			url: 'things',
+			dataType: 'json',
+			data: {
+				offset: 100,
+				limit: 200,
+				order: ['name ASC'],
+				searchText: 'thing 2'
+			},
+			fixture: '-things',
+			success: function (things) {
+				equal(things.data[0].name, 'thing 29', 'first item is correct');
+				equal(things.data.length, 11, 'there are 11 items');
+				start();
+			}
+		});
+
+	});
+
 	test('can.fixture.store fixtures', function () {
 		stop();
 		can.fixture.store('thing', 1000, function (i) {


### PR DESCRIPTION
This method generates fixtures based on standard CRUD operations. Feel free to critique and provide suggestions for a better way to do this.

``` js
var User = can.Model.extend({
  resource: '/users'
},{})

var usersStore = can.fixture.store(100, function(i) {
  return {
    name: 'User ' + i
  }
})

can.fixture.resource('/users', usersStore)
```

/cc @alexisabril 
