### PR TITLE
Support for comparator objects in list/plugin/sort

### DIFF
--- a/list/sort/sort.js
+++ b/list/sort/sort.js
@@ -87,6 +87,15 @@ steal('can/util', 'can/list', function () {
 			if (comparator && typeof comparator === 'function') {
 				return comparator(a, b);
 			}
+			
+			if (typeof comparator === 'object' && comparator.property) {
+				a = a[comparator.property];
+				b = b[comparator.property];
+				
+				if (comparator.direction === 'desc') {
+					return a === b ? 0 : a > b ? -1 : 1;
+				}
+			}
 
 			return a === b ? 0 : a < b ? -1 : 1;
 		},

--- a/list/sort/sort_test.js
+++ b/list/sort/sort_test.js
@@ -114,6 +114,72 @@ steal("can/list/sort", "can/test", "can/view/mustache", "can/view/stache", "can/
 		equal(list[0].name, 'high');
 	});
 
+	test('Defining a comparator object with descending direction', 1, function () {
+		var list = new can.List([{
+			priority: 4,
+			name: 'low'
+		}, {
+			priority: 1,
+			name: 'high'
+		}, {
+			priority: 2,
+			name: 'middle'
+		}, {
+			priority: 3,
+			name: 'mid'
+		}, {
+			priority: 5,
+			name: 'lowest'
+		}]);
+		list.attr('comparator', { property: 'priority', direction: 'desc' });
+		equal(list[0].name, 'lowest');
+	});
+	
+	test('Defining a comparator object with default ascending direction', 1, function () {
+		var list = new can.List([{
+			priority: 4,
+			name: 'low'
+		}, {
+			priority: 1,
+			name: 'high'
+		}, {
+			priority: 2,
+			name: 'middle'
+		}, {
+			priority: 3,
+			name: 'mid'
+		}, {
+			priority: 5,
+			name: 'lowest'
+		}]);
+		list.attr('comparator', { property: 'priority' });
+		equal(list[0].name, 'high');
+	});
+	
+	test('Defining a descending comparator object and verify live binding works', 2, function () {
+		var list = new can.List([{
+			priority: 4,
+			name: 'low'
+		}, {
+			priority: 1,
+			name: 'high'
+		}, {
+			priority: 2,
+			name: 'middle'
+		}, {
+			priority: 3,
+			name: 'mid'
+		}, {
+			priority: 5,
+			name: 'lowest'
+		}]);
+		list.attr('comparator', { property: 'priority' });
+		equal(list[0].name, 'high');
+	
+		list.push({ priority: 0, name: 'super' });
+		equal(list[0].name, 'super');
+	});
+
 	test('Defining a comparator property that is a function of a can.Map', 4, function () {
 		var list = new can.Map.List([
 			new can.Map({


### PR DESCRIPTION
This adds support for list sort comparator objects, so sort direction can be provided as opposed to defining a sort function. 

Potential solution for #1643.

``` js
var list = new can.List([{
  priority: 4,
  name: 'low'
}, {
  priority: 1,
  name: 'high'
}, {
  priority: 2,
  name: 'middle'
}, {
  priority: 3,
  name: 'mid'
}, {
  priority: 5,
  name: 'lowest'
}]);

list.attr('comparator', { property: 'priority', direction: 'desc' });
```

TODO:
- [x] Fix whitespace to original format
- [ ] Add documentation
