### PR TITLE
Add map.backup options to allow serialize/custom backup method

### DIFF
--- a/map/backup/backup.js
+++ b/map/backup/backup.js
@@ -20,17 +20,32 @@ steal('can/util', 'can/compute', 'can/map', 'can/util/object', function (can) {
 			return oldSetup.apply(this, arguments);
 		},
 
-		backup: function () {
-			this._backupStore(this.attr());
+		backup: function (options) {
+
+			options = options || {}
+
+			if (options === true){
+				options = {serialize: true, removeAttr: false}
+			}
+			if (typeof options === 'string'){
+				options = {fn: options, removeAttr: false}
+			}
+			options.fn = options.fn || (options.serialize ? 'serialize' : 'attr')
+			options.removeAttr = options.removeAttr === undefined ? true : options.removeAttr
+
+			this._backupStore.options = can.extend({}, options)
+			this._backupStore(this[options.fn]());
 			return this;
 		},
 		isDirty: function (checkAssociations) {
-			return this._backupStore() && !can.Object.same(this.attr(), this._backupStore(), undefined, undefined, undefined, !! checkAssociations);
+			var options = this._backupStore.options
+			return this._backupStore() && !can.Object.same(this[options.fn](), this._backupStore(), undefined, undefined, undefined, !! checkAssociations);
 		},
 		restore: function (restoreAssociations) {
+			var options = this._backupStore.options
 			var props = restoreAssociations ? this._backupStore() : flatProps(this._backupStore(), this);
 			if (this.isDirty(restoreAssociations)) {
-				this.attr(props, true);
+				this.attr(props, options.removeAttr);
 			}
 			return this;
 		}

--- a/map/backup/backup_test.js
+++ b/map/backup/backup_test.js
@@ -115,4 +115,26 @@ steal("can/map/backup", "can/model", "can/test", "steal-qunit", function () {
 
 		recipe.attr('name', 'cheese');
 	});
+
+	test('use backup custom method via options', function () {
+		var Map = can.Map.extend({
+			customBackup: function(){
+				return {
+					first: this.attr('first')
+				}
+			}
+		});
+		var map = new Map({first: 'John', last: 'Galt'})
+		map.backup('customBackup');
+		map.attr('last', 'Dow');
+		ok(!map.isDirty(), 'last value does not affect isDirty');
+		map.attr('first', 'Jane');
+		ok(map.isDirty(), 'first value is does affect isDirty');
+
+		map.restore();
+		ok(map.attr('first') == 'John', 'first is restored');
+		ok(map.attr('last') == 'Dow', 'last not affected by restore');
+		ok(!map.isDirty(), 'isDirty is false');
+	});
+
 });

--- a/map/backup/doc/backup.md
+++ b/map/backup/doc/backup.md
@@ -10,6 +10,11 @@ and lets you restore the original values of an Map's properties after they are c
 Here is an example showing how to use `[can.Map.backup.prototype.backup backup]` to save values,
 `[can.Map.backup.prototype.restore restore]` to restore them, and `[can.Map.backup.prototype.isDirty isDirty]`
 
+By default `backup` uses `attr` function on the map to get backup value, 
+if you want to use `serialize` or custom method use `options` parameter of 
+`[can.Map.backup.prototype.backup backup]` method. 
+
+
 to check if the Map has changed:
 
 ```

--- a/map/backup/doc/prototype.backup.md
+++ b/map/backup/doc/prototype.backup.md
@@ -4,12 +4,24 @@
 
 @description Save the values of the properties of an Map.
 
-@signature `map.backup()`
+@signature `map.backup( [options] )`
 
 `backup` backs up the current state of the properties of an Observe and marks
 the Observe as clean. If any of the properties change value, the original
 values can be restored with [can.Map.backup.prototype.restore restore].
 
+By default `backup` uses `attr` function on the map to get value backup value, 
+if you want to use `serialize` or custom method use `options` parameter 
+
+@param {object|string|bool} backup options:
+ `object` - options object supports following params: `serialize`, `fn`, `removeAttr`.  
+ `{serialize: true, removeAttr: true}` - means `serialize` method will be used for backup value, 
+ `removeAttr` means that while restore absent attributes in backup value will be removed from map, 
+ (note that if `serialize` or custom method is used for backup, `removeAttr` is `false` if not stated explicitly)  
+ `string` - means method on map to be used for backup the same as `{fn: 'string'}` 
+ `true` - is the same if `serialize` string is passed
+ 
+  
 @return {can.Map} The map, for chaining.
 
 @body
@@ -37,7 +49,8 @@ ingredients: [{
  quantity: '2 tablespoons'
 }]
 });
-recipe.backup();
+
+recipe.backup('serialize'); // `serialize` method will be used
 
 recipe.attr('title', 'Flapjack Mix');
 recipe.title;     // 'Flapjack Mix'


### PR DESCRIPTION
Add backup options to allow `serialize/custom` method to be used instead of `attr`
This adds test and docs as well.