### PR TITLE
Fixing FF debugging functions conflicting with Can Map and Event functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js: 0.10
 before_script: node_modules/.bin/bower install

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "canjs",
   "repo": "bitovi/canjs",
   "description": "Can do JavaScript MVC",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "main": "can.js",
   "keywords": [
     "mvc",

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,17 @@
 @parent guides 5
 -->
 
+__2.2.7__ ( Jul 24 2015 )
+
+- [can.compute change handler context should be the function not the can.Compute object](https://github.com/bitovi/canjs/issues/1763)
+- [Provide a getter and setter compute interface for non-map-like targets](https://github.com/bitovi/canjs/issues/1719)
+- [Unable to load canjs in node.js environment](https://github.com/bitovi/canjs/issues/1711)
+- [Makes scope.computeData listen to every observable in scope when value is not defined.](https://github.com/bitovi/canjs/pull/1709)
+- [&lt;select can-value=&quot;{value}&quot; with undefined value and option without value](https://github.com/bitovi/canjs/issues/1679)
+- [Conditional can-EVENT bindings don&#39;t work in stache](https://github.com/bitovi/canjs/issues/1650)
+- [Event handlers attached on Component&#39;s init (event) are not called. ](https://github.com/bitovi/canjs/issues/1623)
+
+
 __2.2.6__ ( May 20 2015 )
 
 - [Fix calling define getters on map initialization](https://github.com/bitovi/canjs/pull/1704)

--- a/component/component.js
+++ b/component/component.js
@@ -282,22 +282,9 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/control", "ca
 				this._control = new this.constructor.Control(el, {
 					// Pass the viewModel to the control so we can listen to it's changes from the controller.
 					scope: this.scope,
-					viewModel: this.scope
+					viewModel: this.scope,
+					destroy: callTeardownFunctions
 				});
-
-				// If control has a 'destroy' event, unbind the properties after its called #1415
-				if(this._control && this._control.destroy){
-					var oldDestroy = this._control.destroy;
-					this._control.destroy = function(){
-						oldDestroy.apply(this, arguments);
-						callTeardownFunctions();
-					};
-					this._control.on();
-				} else {
-					can.bind.call(el, "removed", function () {
-						callTeardownFunctions();
-					});
-				}
 
 				// ## Rendering
 
@@ -478,6 +465,11 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/control", "ca
 			// Call `can.Control.prototype.off` function on this instance to cleanup the bindings.
 			can.Control.prototype.off.apply(this, arguments);
 			this._bindings.readyComputes = {};
+		},
+		destroy: function() {
+			if(typeof this.options.destroy === 'function') {
+				this.options.destroy.apply(this, arguments);
+			}
 		}
 	});
 

--- a/component/component_test.js
+++ b/component/component_test.js
@@ -1558,6 +1558,30 @@ steal("can", "can/map/define", "can/component", "can/view/stache" ,"can/route", 
 
 	});
 
+	test("attach events on init", function(){
+		expect(2);
+		can.Component.extend({
+			tag: 'app-foo',
+			template: can.stache('<div>click me</div>'),
+			events: {
+				init: function(){
+					this.on("div", 'click', 'doSomethingfromInit');
+				},
+				inserted: function(){
+					this.on("div", 'click', 'doSomethingfromInserted');
+				},
+				doSomethingfromInserted: function(){
+					ok(true, "bound in inserted");
+				},
+				doSomethingfromInit: function(){
+					ok(true, "bound in init");
+				}
+			}
+		});
+		can.append( can.$("#qunit-fixture"), can.stache("<app-foo></app-foo>")({}));
+		can.trigger(can.$('#qunit-fixture div'), 'click');
+	});
+
 	if(can.isFunction(Object.keys)) {
 		test('<content> node list cleans up properly as direct child (#1625, #1627)', 2, function() {
 			var size = Object.keys(can.view.nodeLists.nodeMap).length;

--- a/compute/proto_compute.js
+++ b/compute/proto_compute.js
@@ -289,8 +289,16 @@ steal('can/util', 'can/util/bind', 'can/compute/read.js','can/compute/get_value_
 					return target.unbind(eventName || propertyName, handler);
 				};
 			} else {
-				this._get = can.proxy(this._get, target);
-				this._set = can.proxy(this._set, target);
+				this._get = function() {
+					return can.getObject(propertyName, [target]);
+				};
+				this._set = function(value) {
+					// allow setting properties n levels deep, if separated with dot syntax
+					var properties = propertyName.split("."),
+						leafPropertyName = properties.pop(),
+						targetProperty = can.getObject(properties.join('.'), [target]);
+					targetProperty[leafPropertyName] = value;
+				};
 			}
 		},
 

--- a/documentjs.json
+++ b/documentjs.json
@@ -11,12 +11,14 @@
 					"**/*_test.js",
 					"Gruntfile.js"]
 			},
+			"ignoreTemplateRender": true,
 			"parent" : "canjs"
 		},
 		"guides": {
 			"glob": {
 				"pattern": "{guides/*.md,*.md}"
 			},
+			"ignoreTemplateRender": true,
 			"parent": "guides"
 		}
 	}

--- a/event/event.js
+++ b/event/event.js
@@ -35,7 +35,7 @@ steal('can/util/can.js', function (can) {
 	can.addEvent = function (event, handler) {
 		// Initialize event cache.
 		var allEvents = this.__bindEvents || (this.__bindEvents = {}),
-			eventList = allEvents[event] || (allEvents[event] = []);
+			eventList = allEvents.hasOwnProperty(event) && allEvents[event] || (allEvents[event] = []);
 
 		// Add the event
 		eventList.push({

--- a/list/doc/prototype.splice.md
+++ b/list/doc/prototype.splice.md
@@ -7,7 +7,7 @@
 @param {Number} index where to start removing or inserting elements
 
 @param {Number} [howMany] the number of elements to remove
- If _howMany_ is not provided, `splice` will all elements from `index` to the end of the List.
+ If _howMany_ is not provided, `splice` will remove all elements from `index` to the end of the List.
 
 @param {*} newElements elements to insert into the List
 

--- a/map/map.js
+++ b/map/map.js
@@ -447,7 +447,7 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 			__get: function (attr) {
 				if (attr) {
 					// If property is a compute return the result, otherwise get the value directly
-					if (this._computedBindings[attr]) {
+					if (this.hasOwnProperty(attr) && this._computedBindings[attr]) {
 						return this[attr]();
 					} else {
 						return this._data[attr];
@@ -530,7 +530,7 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 			},
 			// Directly sets a property on this `object`.
 			___set: function (prop, val) {
-				if ( this._computedBindings[prop] ) {
+				if (this.hasOwnProperty(prop) && this._computedBindings[prop] ) {
 					this[prop](val);
 				} else {
 					this._data[prop] = val;

--- a/observe/observe_test.js
+++ b/observe/observe_test.js
@@ -1384,4 +1384,46 @@ steal('can/util', "can/observe", 'can/map', 'can/list', "can/test", "steal-qunit
 		equal(person._bindings, 0, "After unbinding no bindings");
 	});
 
+	test('compute bound to object property (#1719)', 4, function () {
+		var obj = {};
+		obj.foo = 'bar';
+
+		var value = can.compute(obj, 'foo', 'change');
+		equal(value(), 'bar', 'property retrieved correctly');
+
+		value('baz');
+		equal(obj.foo, 'baz', 'property changed correctly');
+
+		var handler = function(ev, newVal, oldVal) {
+			equal(newVal, 'qux', 'change handler newVal correct');
+			equal(oldVal, 'baz', 'change handler oldVal correct');
+		};
+		value.bind('change', handler);
+		value('qux');
+		value.unbind('change', handler);
+	});
+
+	test('compute bound to nested object property (#1719)', 4, function () {
+		var obj = {
+			prop: {
+				subprop: {
+					foo: 'bar'
+				}
+			}
+		};
+
+		var value = can.compute(obj, 'prop.subprop.foo', 'change');
+		equal(value(), 'bar', 'property retrieved correctly');
+
+		value('baz');
+		equal(obj.prop.subprop.foo, 'baz', 'property changed correctly');
+
+		var handler = function(ev, newVal, oldVal) {
+			equal(newVal, 'qux', 'change handler newVal correct');
+			equal(oldVal, 'baz', 'change handler oldVal correct');
+		};
+		value.bind('change', handler);
+		value('qux');
+		value.unbind('change', handler);
+	});
 });

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
 		"steal-tools": "~0.7.1",
 		"steal-benchmark": "~0.0.1",
 		"testee": "^0.1.3",
-		"zombie": "~2.0.8"
+		"zombie": "~2.0.8",
+		"documentjs": "0.3.0-pre.5"
 	},
 	"scripts": {
 		"test": "grunt test"
@@ -133,7 +134,8 @@
 			"lodash",
 			"browserify",
 			"grunt-banner",
-			"steal-benchmark"
+			"steal-benchmark",
+			"documentjs"
 		]
 	},
 	"browser": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "can",
 	"title": "CanJS",
 	"description": "MIT-licensed, client-side, JavaScript framework that makes building rich web applications easy.",
-	"version": "2.2.6",
+	"version": "2.2.7",
 	"author": {
 		"name": "Bitovi",
 		"email": "contact@bitovi.com",

--- a/route/route.md
+++ b/route/route.md
@@ -26,7 +26,7 @@ should start with either a character (a-Z) or colon (:).  Examples:
 
 @body
 
-## Video
+## Use
 
 Watch this video for an overview of can.route's functionality and an example showing how to connect two tab widgets to the browser's history:
 

--- a/route/route.md
+++ b/route/route.md
@@ -9,15 +9,7 @@
 
 @description Manage browser history and
 client state by synchronizing the window.location.hash with
-an [can.Map].
-
-Watch this video for an overview of can.route's functionality and an example showing how to connect two tab widgets to the browser's history:
-
-<iframe width="662" height="372" src="https://www.youtube.com/embed/ef0LKDiaPZ0" frameborder="0" allowfullscreen></iframe>
-
-In the following CanJS community we also talk about web application routing:
-
-<iframe width="662" height="372" src="https://www.youtube.com/watch?v=0Hhuv5Qru9k" frameborder="0" allowfullscreen></iframe>
+a [can.Map].
 
 @signature `can.route( template [, defaults] )`
 
@@ -33,6 +25,16 @@ should start with either a character (a-Z) or colon (:).  Examples:
 @return {can.route}
 
 @body
+
+## Video
+
+Watch this video for an overview of can.route's functionality and an example showing how to connect two tab widgets to the browser's history:
+
+<iframe width="662" height="372" src="https://www.youtube.com/embed/ef0LKDiaPZ0" frameborder="0" allowfullscreen></iframe>
+
+In the following CanJS community we also talk about web application routing:
+
+<iframe width="662" height="372" src="https://www.youtube.com/embed/0Hhuv5Qru9k" frameborder="0" allowfullscreen></iframe>
 
 ## Background Information
 

--- a/util/batch/batch.md
+++ b/util/batch/batch.md
@@ -3,28 +3,33 @@
 
 
 [can.batch.start `can.batch.start( batchStopHandler )`] and
-[can.batch.stop `can.batch.stop( force, callStart )`] are used to specify 
+[can.batch.stop `can.batch.stop( force, callStart )`] are used to specify
 atomic operations. `start`
 prevents change events from being fired until `stop` is called.
 
-The following listens to changes on a `player`:
+This `player` has a favorite `tvshow`. We are listening for any changes to her
+preferences.
 
-	var player = new can.Map({
+    var player = new can.Map({
       tvshow: "The Simpsons"
     });
 
-    player.bind("change",function(ev, attr, how, newVal, oldVal){
-      console.log("changed", attr );
+    player.bind("change", function(ev, attr, how, newVal, oldVal) {
+      console.log("[change triggered] " + how + ": " + attr);
     });
 
-The "change" callback handler does not get called until
-after `tvshow` is removed, `song` is added, and `stopBatch`
-is called.
+Normally, if a favorite `tvshow` were replaced with a favorite `song`, the
+"change" callback handler would immediately be called when `tvshow` is removed
+and when `song` is added.
+
+By incorporating `can.batch`, the calls to the "change" callback handler will
+not occur until after `tvshow` is removed, `song` is added, and
+`can.batch.stop` is called.
 
     can.batch.start();
 
     player.removeAttr("tvshow");
-    player.attr("song","What makes you beautiful");
+    player.attr("song", "What makes you beautiful");
 
     can.batch.stop();
 
@@ -33,112 +38,121 @@ to use batch operations.
 
 ## Correctness
 
-Sometimes, an object can be temporarily in an invalid
+Sometimes, an object can temporarily be in an invalid
 state. For example, the previous `player` should have
 a `tvshow` or `song` property, but not both. Event listeners should
-never be called in an intermediate state.  We can make this happen
-with `startBatch`, `stopBatch` and
-the [can.Map.setter `can/map/setter`] plugin as follows:
+never be called in an intermediate state. The
+[can.Map.prototype.define `can/map/define`] plugin uses `can.batch.start` and
+`can.batch.stop` to accomplish this when calling a `setter`.
 
-    // Selection constructor function inherits from Observe
-    Player = can.Map({
+    import "can/map/define/"
 
-      // called when setting tvshow
-      setTvshow: function(newVal, success){
-        can.batch.start();
-        this.removeAttr("song")
-        success(newVal);
-        can.batch.stop();
-      },
-      // called when setting song
-      setSong: function(newVal, success){
-        can.batch.start();
-        this.removeAttr("tvshow")
-        success(newVal);
-        can.batch.stop();
+    var Player = can.Map.extend({
+      define: {
+        tvshow: {
+          set: function(newValue) {
+            this.removeAttr("song");
+
+            return newValue;
+          }
+        },
+        song: {
+          set: function(newValue) {
+            this.removeAttr("tvshow");
+
+            return newValue;
+          }
+        }
       }
     });
 
-    // a new selection instance
-    var player =   new Player({song: "Amish Paradise"});
+    var player = new Player({ song: "Amish Paradise" });
 
-    player.bind("change", function( ev, attr, how, newVal, oldVal ){
-      console.log("changed", attr, how, player.attr() );
+    player.bind("change", function(ev, attr, how, newVal, oldVal){
+      var song = this.attr("song");
+      var tvshow = this.attr("tvshow");
+
+      if(song) {
+        console.log("The greatest song is " + song + ". TV is overrated.");
+      }
+      if(tvshow) {
+        console.log("The greatest TV show is " + tvshow +
+          ". Music is overrated.");
+      }
     });
 
-    console.log("start")
-    player.attr("tvshow","Breaking Bad");
-    console.log("end")
+    player.attr("tvshow", "Breaking Bad");
 
-Use `startBatch` and `stopBatch` to make sure events
-are triggered when an observe is in a valid state.
+Use `can.batch.start` and `can.batch.stop` to ensure that events
+are only triggered when a subject is in a valid state.
 
 ## Performance
 
-CanJS synchronously sends events when a property changes.
+CanJS synchronously dispatches events when a property changes.
 This makes certain patterns easier. For example, if you
-are doing live-binding, and change a property, the DOM is
+are utilizing live-binding and change a property, the DOM is
 immediately updated.
 
 Occasionally, you may find yourself changing many properties at once. To
 prevent live-binding from performing unnecessary updates,
-write the property updates within a `startBatch`/`stopBatch`.
+update the properties within a pair of calls to `can.batch.start` and
+`can.batch.stop`.
 
-Consider a list of items like:
+Consider this list of items.
 
     var items = new Items([
       {selected: false},
       {selected: true},
       {selected: false}
-    ])
+    ]);
 
-And a template that renders the number of selected items:
+This template renders the number of selected items.
 
-    var template = can.mustache("{{count}}")
+    var renderer = can.stache("{{count}}");
 
-	$("#itemCount").html(template({
-	  count: function(){
-	      var count = 0;
-	      items.each(function(item){
-	        count += item.attr('selected') ? 1 : 0
-	      })
-	      return count
-	   }
-	}))
+    $("#itemCount").html(renderer({
+      count: function() {
+        var count = 0;
+        items.each(function(item) {
+          count += item.attr("selected") ? 1 : 0;
+        });
+        console.log(count);
+        return count;
+      }
+    }));
 
-The following updates the DOM once per click:
+Using `can.batch` will ensure that the DOM is only updated once the whole list
+of items has been updated instead of every time an individual item is flipped.
 
-    $("#selectAll").click(function(){
-        can.batch.start()
-        items.each(function(item){
-          item.attr('selected', true)
-        })
-        can.batch.stop()
-    })
+    $("#selectAll").click(function() {
+      can.batch.start();
+      items.each(function(item){
+        item.attr('selected', true);
+      });
+      can.batch.stop();
+    });
 
 ## batchNum
 
-All events created within a `start` / `stop` share the same batchNum value. To
-respond only once for a given batchNum, you can do it like:
+All events created within a set of `start` / `stop` calls share the same
+batchNum value. This can be used to respond only once for a given batchNum.
 
     var batchNum;
-    obs.bind("change", function( ev, attr, how, newVal, oldVal ){
-     if( !ev.batchNum || ev.batchNum !== batchNum ) {
-       batchNum = ev.batchNum;
-       // do your code here!
-     }
+    obs.bind("change", function(ev, attr, how, newVal, oldVal) {
+      if(!ev.batchNum || ev.batchNum !== batchNum) {
+        batchNum = ev.batchNum;
+        // your code here!
+      }
     });
 
 ## Automatic Batching
 
-Libraries like Angular and Ember always batch
-operations. Set this up with:
+Libraries like Angular and Ember always batch operations. This behavior can be
+reproduced by batching everything that happens within the same thread of
+execution and/or within 10ms of each other.
 
     can.batch.start();
-    setTimeout(function(){
+    setTimeout(function() {
       can.batch.stop(true, true);
-      setTimeout(arguments.callee, 10)
-    },10);
-
-This batches everything that happens within the same thread of execution
-and/or within 10 ms of each other.
+      setTimeout(arguments.callee, 10);
+    }, 10);

--- a/util/mootools/mootools.js
+++ b/util/mootools/mootools.js
@@ -364,6 +364,7 @@ steal('can/util/can.js', 'can/util/attr', 'mootools', 'can/event', 'can/util/fra
 		can.get = function (wrapped, index) {
 			return wrapped[index];
 		};
+		/* This breaks MooTools More Drag and we don't care about old versions of IE
 		// Overwrite to handle IE not having an id.
 		// IE barfs if text node.
 		var idOf = Slick.uidOf;
@@ -375,6 +376,7 @@ steal('can/util/can.js', 'can/util/attr', 'mootools', 'can/event', 'can/util/fra
 				return Math.random();
 			}
 		};
+		*/
 		Element.NativeEvents.hashchange = 2;
 
 		// Setup attributes events

--- a/util/mootools/mootools.js
+++ b/util/mootools/mootools.js
@@ -364,7 +364,6 @@ steal('can/util/can.js', 'can/util/attr', 'mootools', 'can/event', 'can/util/fra
 		can.get = function (wrapped, index) {
 			return wrapped[index];
 		};
-		/* This breaks MooTools More Drag and we don't care about old versions of IE
 		// Overwrite to handle IE not having an id.
 		// IE barfs if text node.
 		var idOf = Slick.uidOf;
@@ -376,7 +375,6 @@ steal('can/util/can.js', 'can/util/attr', 'mootools', 'can/event', 'can/util/fra
 				return Math.random();
 			}
 		};
-		*/
 		Element.NativeEvents.hashchange = 2;
 
 		// Setup attributes events

--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -312,8 +312,16 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 				return;
 			}
 			var val = this.options.value();
+			// For https://github.com/bitovi/canjs/issues/1679. We don't want to set
+			// null or undefined on select fields because Chrome shows it as blank
+			if(val == null && this.element[0].nodeName.toUpperCase() !== "SELECT") {
+				val = '';
+			}
+
 			// Set the element's value to match the attribute that was passed in
-			this.element[0].value = (val == null ? '' : val);
+			if(val != null) {
+				this.element[0].value = val;
+			}
 		},
 		// If the input value changes, this will set the live bound data to reflect the change.
 			// If the input value changes, this will set the live bound data to reflect the change.

--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -271,6 +271,15 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 		// Bind the handler defined above to the element we're currently processing and the event name provided in this
 		// attribute name (can-click="foo")
 		can.bind.call(el, event, handler);
+
+		// Create a handler that will unbind itself and the event when the attribute is removed from the DOM
+		var attributesHandler = function(ev) {
+			if(ev.attributeName === attributeName && !this.getAttribute(attributeName)) {
+				can.unbind.call(el, event, handler);
+				can.unbind.call(el, 'attributes', attributesHandler);
+			}
+		};
+		can.bind.call(el, 'attributes', attributesHandler);
 	});
 
 

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -838,4 +838,32 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		can.trigger(document.getElementById("click-me"), "click");
 		
 	});
+
+	test('Conditional can-EVENT bindings are bound/unbound', 2, function () {
+		stop();
+		var state = new can.Map({
+			enableClick: true,
+			clickHandler: function () {
+				ok(true, '"click" was handled');
+			}
+		});
+
+		var template = can.stache('<button id="find-me" {{#if enableClick}}can-click="{clickHandler}"{{/if}}></button>');
+		var frag = template(state);
+
+		var sandbox = document.getElementById("qunit-fixture");
+		sandbox.appendChild(frag);
+
+		var btn = document.getElementById('find-me');
+
+		can.trigger(btn, 'click');
+
+		state.attr('enableClick', false);
+
+		can.trigger(btn, 'click');
+
+		state.attr('enableClick', true);
+
+		can.trigger(btn, 'click');
+	});
 });

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -840,7 +840,6 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 	});
 
 	test('Conditional can-EVENT bindings are bound/unbound', 2, function () {
-		stop();
 		var state = new can.Map({
 			enableClick: true,
 			clickHandler: function () {
@@ -857,13 +856,17 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		var btn = document.getElementById('find-me');
 
 		can.trigger(btn, 'click');
-
 		state.attr('enableClick', false);
 
-		can.trigger(btn, 'click');
+		stop();
+		setTimeout(function() {
+			can.trigger(btn, 'click');
+			state.attr('enableClick', true);
 
-		state.attr('enableClick', true);
-
-		can.trigger(btn, 'click');
+			setTimeout(function() {
+				can.trigger(btn, 'click');
+				start();
+			}, 10);
+		}, 10);
 	});
 });

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -869,4 +869,19 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 			}, 10);
 		}, 10);
 	});
+
+	test("<select can-value={value}> with undefined value selects option without value", function () {
+
+		var template = can.view.stache("<select can-value='opt'><option>Loading...</option></select>");
+
+		var map = new can.Map();
+
+		var frag = template(map);
+
+		var ta = document.getElementById("qunit-fixture");
+		ta.appendChild(frag);
+
+		var select = ta.childNodes[0];
+		QUnit.equal(select.selectedIndex, 0, 'Got selected index');
+	});
 });

--- a/view/live/live.js
+++ b/view/live/live.js
@@ -663,6 +663,7 @@ steal('can/util', 'can/view/elements.js', 'can/view', 'can/view/node_lists', 'ca
 	};
 	live.attr = live.simpleAttribute;
 	live.attrs = live.attributes;
+	live.getAttributeParts = getAttributeParts;
 	var newLine = /(\r|\n)+/g;
 	var getValue = function (val) {
 		var regexp = /^["'].*["']$/;

--- a/view/stache/doc/can-import.md
+++ b/view/stache/doc/can-import.md
@@ -24,5 +24,5 @@ Example:
 </my-tabs>
 ```
 
-Currently this __only__ works with [can/view/autorender] and the [can/view/stache/system] plugin.
+Currently this __only__ works with [can/view/autorender] or the [can/view/stache/system] plugin.
 

--- a/view/stache/doc/stashe.md
+++ b/view/stache/doc/stashe.md
@@ -65,7 +65,7 @@ __HTML Result__
 
 To update the html using live-binding, change an observable value:
 
-	data.attr('message', 5)
+	data.attr('messages', 5)
 
 This updates this paragraph in the HTML Result to:
 

--- a/view/stache/live_attr.js
+++ b/view/stache/live_attr.js
@@ -1,0 +1,57 @@
+// # can/view/stache/live.js
+// 
+// This provides live binding for stache attributes.  
+
+steal("can/util",
+	"can/view/live",
+	"can/view/elements.js",
+	"can/view/callbacks",
+	function(can, live, elements, viewCallbacks) {
+
+	live = live || can.view.live;
+	elements = elements || can.view.elements;
+	viewCallbacks = viewCallbacks || can.view.callbacks;
+
+	return {
+		attributes: function(el, compute, scope, options) {
+			var oldAttrs = {};
+			
+			var setAttrs = function (newVal) {
+				var newAttrs = live.getAttributeParts(newVal),
+					name;
+				for(name in newAttrs) {
+					var newValue = newAttrs[name],
+						oldValue = oldAttrs[name];
+					if(newValue !== oldValue) {
+						can.attr.set(el, name, newValue);
+						var callback = viewCallbacks.attr(name);
+						if(callback) {
+							callback(el, {
+								attributeName: name,
+								scope: scope,
+								options: options
+							});
+						}
+					}
+					delete oldAttrs[name];
+				}
+				for(name in oldAttrs) {
+					elements.removeAttr(el, name);
+				}
+				oldAttrs = newAttrs;
+			};
+			
+			var handler = function (ev, newVal) {
+				setAttrs(newVal);
+			};
+
+			compute.bind('change', handler);
+			can.bind.call(el, 'removed', function() {
+				compute.unbind('change', handler);
+			});
+
+			// current value has been set
+			setAttrs(compute());
+		}
+	};
+});

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -4019,4 +4019,23 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 		// Helpers evaluated 3rd time...
 		state.attr('parent.child', 'bar');
 	});
+
+	test('Custom attribute callbacks are called when in a conditional within a live section', 8, function () {
+		can.view.attr('test-attr', function(el, attrData) {
+			ok(true, "test-attr called");
+			equal(attrData.attributeName, 'test-attr', "attributeName set correctly");
+			ok(attrData.scope, "scope isn't undefined");
+			ok(attrData.options, "options isn't undefined");
+		});
+
+		var state = new can.Map({
+			showAttr: true
+		});
+
+		var template = can.stache('<button id="find-me" {{#if showAttr}}test-attr{{/if}}></button>');
+		template(state);
+
+		state.attr('showAttr', false);
+		state.attr('showAttr', true);
+	});
 });

--- a/view/stache/text_section.js
+++ b/view/stache/text_section.js
@@ -1,4 +1,4 @@
-steal("can/util", "can/view/live","./utils.js",function(can, live, utils){
+steal("can/util", "can/view/live","./utils.js", "./live_attr.js", function(can, live, utils, liveStache) {
 	live = live || can.view.live;
 	
 	var TextSectionBuilder = function(){
@@ -41,7 +41,7 @@ steal("can/util", "can/view/live","./utils.js",function(can, live, utils){
 					if(state.attr) {
 						live.simpleAttribute(this, state.attr, compute);
 					} else {
-						live.attributes( this, compute );
+						liveStache.attributes(this, compute, scope, options);
 					}
 					compute.unbind("change", emptyHandler);
 				} else {


### PR DESCRIPTION
FF introduced a debugging function called watch. This meant that if you had a property labeled watch, it would throw an exception. 