### PR TITLE
Fix issue with #unless helper and computes - #1202

### DIFF
--- a/view/mustache/mustache.js
+++ b/view/mustache/mustache.js
@@ -1924,7 +1924,10 @@ steal('can/util',
 			 *     {{/unless}}
 			 */
 			'unless': function (expr, options) {
-				return Mustache._helpers['if'].fn.apply(this, [can.isFunction(expr) ? can.compute(function() { return !expr(); }) : !expr, options]);
+				return Mustache._helpers['if'].fn.apply(this, [expr, can.extend({}, options, {
+					fn: options.inverse,
+					inverse: options.fn
+				})]);
 			},
 
 			// Implements the `each` built-in helper.

--- a/view/mustache/mustache_test.js
+++ b/view/mustache/mustache_test.js
@@ -570,13 +570,18 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 
 	test("Handlebars helper: unless", function () {
 		var t = {
-			template: "{{#unless missing}}Andy is missing!{{/unless}}",
-			expected: "Andy is missing!",
+			template: "{{#unless missing}}Andy is missing!{{/unless}}" +
+			          "{{#unless isCool}} But he wasn't cool anyways.{{/unless}}",
+			expected: "Andy is missing! But he wasn't cool anyways.",
 			data: {
 				name: 'Andy'
 			},
 			liveData: new can.Map({
-				name: 'Andy'
+				name: 'Andy',
+				// #1202 #unless does not work with computes
+				isCool: can.compute(function () {
+					return t.liveData.attr("missing");
+				})
 			})
 		};
 

--- a/view/stache/mustache_helpers.js
+++ b/view/stache/mustache_helpers.js
@@ -122,7 +122,10 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 			return helpers.is.apply(this, arguments);
 		},
 		'unless': function (expr, options) {
-			return helpers['if'].apply(this, [can.isFunction(expr) ? can.compute(function() { return !expr(); }) : !expr, options]);
+			return helpers['if'].apply(this, [expr, can.extend({}, options, {
+				fn: options.inverse,
+				inverse: options.fn
+			})]);
 		},
 		'with': function (expr, options) {
 			var ctx = expr;

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -596,13 +596,18 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 
 	test("Handlebars helper: unless", function () {
 		var t = {
-			template: "{{#unless missing}}Andy is missing!{{/unless}}",
-			expected: "Andy is missing!",
+			template: "{{#unless missing}}Andy is missing!{{/unless}}" +
+			          "{{#unless isCool}} But he wasn't cool anyways.{{/unless}}",
+			expected: "Andy is missing! But he wasn't cool anyways.",
 			data: {
 				name: 'Andy'
 			},
 			liveData: new can.Map({
-				name: 'Andy'
+				name: 'Andy',
+				// #1202 #unless does not work with computes
+				isCool: can.compute(function () {
+					return t.liveData.attr("missing");
+				})
 			})
 		};
 


### PR DESCRIPTION
A demo page showing the error can be found here: http://jsbin.com/pucucidofa/edit?html,js,output

The change essentially makes the `unless` helper a proxy to the `if` helper, but it flips the `fn` and `inverse` callbacks. All tests were updated to first expose the bug, and then the fix was implemented.