### PR TITLE
All can-import tests are passing again

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,3 +2,4 @@
 [*]
 end_of_line = LF
 indent_style = tab
+trim_trailing_whitespace = false

--- a/component/component.js
+++ b/component/component.js
@@ -95,7 +95,6 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 			// ### setup
 			// When a new component instance is created, setup bindings, render the template, etc.
 			setup: function (el, componentTagData) {
-
 				// Setup values passed to component
 				var initialScopeData = {
 						"%root": componentTagData.scope.attr("%root")
@@ -133,7 +132,10 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 				// Get the value in the viewModel for each attribute
 				// the hookup should probably happen after?
 				can.each(can.makeArray(el.attributes), function (node, index) {
-
+					if(componentTagData.preventDataBindings) {
+						return;
+					}
+					
 					var nodeName = node.name,
 						name = can.camelize(nodeName.toLowerCase()),
 						value = node.value;
@@ -222,6 +224,10 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 				var handlers = {};
 				// Setup reverse bindings
 				can.each(bindingsData, function (bindingData, prop) {
+					if(componentTagData.preventDataBindings) {
+						return;
+					}
+
 					if(bindingData.childToParent) {
 						handlers[prop] = function (ev, newVal) {
 							// Check that this property is not being changed because
@@ -261,7 +267,9 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 				this.scope = this.viewModel = viewModel;
 				can.data($el, "scope", this.scope);
 				can.data($el, "viewModel", this.scope);
-				can.data($el,"preventDataBindings", true);
+				if(!componentTagData.preventDataBindings) {
+					can.data($el,"preventDataBindings", true);
+				}
 
 				// Create a real Scope object out of the viewModel property
 				// The scope used to render the component's template.

--- a/component/component.js
+++ b/component/component.js
@@ -95,6 +95,7 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 			// ### setup
 			// When a new component instance is created, setup bindings, render the template, etc.
 			setup: function (el, componentTagData) {
+
 				// Setup values passed to component
 				var initialScopeData = {
 						"%root": componentTagData.scope.attr("%root")
@@ -120,7 +121,8 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 							teardownFunctions[i]();
 						}
 					},
-					$el = can.$(el);
+					$el = can.$(el),
+					setupBindings = !can.data($el,"preventDataBindings");
 
 				// ## Scope
 
@@ -131,70 +133,68 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 
 				// Get the value in the viewModel for each attribute
 				// the hookup should probably happen after?
-				can.each(can.makeArray(el.attributes), function (node, index) {
-					if(componentTagData.preventDataBindings) {
-						return;
-					}
-					
-					var nodeName = node.name,
-						name = can.camelize(nodeName.toLowerCase()),
-						value = node.value;
+				if(setupBindings) {
+					can.each(can.makeArray(el.attributes), function (node, index) {
+						var nodeName = node.name,
+							name = can.camelize(nodeName.toLowerCase()),
+							value = node.value;
 
-					//!steal-remove-start
-					// user tried to pass something like id="{foo}", so give them a good warning
-					if(ignoreAttributesRegExp.test(name) && value[0] === "{" && value[value.length-1] === "}") {
-						can.dev.warn("can/component: looks like you're trying to pass "+name+" as an attribute into a component, "+
-						"but it is not a supported attribute");
-					}
-					//!steal-remove-end
+						//!steal-remove-start
+						// user tried to pass something like id="{foo}", so give them a good warning
+						if(ignoreAttributesRegExp.test(name) && value[0] === "{" && value[value.length-1] === "}") {
+							can.dev.warn("can/component: looks like you're trying to pass "+name+" as an attribute into a component, "+
+							"but it is not a supported attribute");
+						}
+						//!steal-remove-end
 
-					var isDataBindings = bindings.dataBindingsRegExp.test(nodeName);
-					// Ignore attributes already present in the ScopeMappings.
-					if (component.constructor.attributeScopeMappings[name] ||
-						ignoreAttributesRegExp.test(name) ||
-						// we will handle
-						( viewCallbacks.attr(nodeName) && !isDataBindings ) ) {
-						return;
-					}
-					// Only setup bindings if attribute looks like `foo="{bar}"`
-					if(value[0] === "{" && value[value.length-1] === "}") {
-						value = value.substr(1, value.length - 2 );
-					} else if(!isDataBindings){
-						// Legacy template types will crossbind "foo=bar"
-						if(componentTagData.templateType !== "legacy") {
-							initialScopeData[name] = value;
+						var isDataBindings = bindings.dataBindingsRegExp.test(nodeName);
+						// Ignore attributes already present in the ScopeMappings.
+						if (component.constructor.attributeScopeMappings[name] ||
+							ignoreAttributesRegExp.test(name) ||
+							// we will handle
+							( viewCallbacks.attr(nodeName) && !isDataBindings ) ) {
 							return;
 						}
-					}
-
-					var bindingData = bindings.attributeNameInfo(nodeName);
-					bindingData.propName = can.camelize(bindingData.propName);
-					bindingsData[bindingData.propName] = bindingData;
-
-					// Use logic from bindings
-					var compute = bindings.getParentCompute(el, componentTagData.scope, value, {});
-
-					// if we actually got a compute
-					if(compute && compute.isComputed) {
-
-						if(bindingData.parentToChild) {
-							bindings.bindParentToChild(el, compute, function(newValue){
-								viewModel.attr(bindingData.propName, newValue);
-							}, viewModelPropertyUpdates, bindingData.propName);
-
-							// Set the value to be added to the viewModel
-							var initialValue = compute();
-							if(initialValue !== undefined) {
-								initialScopeData[bindingData.propName] = initialValue;
+						// Only setup bindings if attribute looks like `foo="{bar}"`
+						if(value[0] === "{" && value[value.length-1] === "}") {
+							value = value.substr(1, value.length - 2 );
+						} else if(!isDataBindings){
+							// Legacy template types will crossbind "foo=bar"
+							if(componentTagData.templateType !== "legacy") {
+								initialScopeData[name] = value;
+								return;
 							}
 						}
 
-						bindingsData[bindingData.propName].parentCompute = compute;
+						var bindingData = bindings.attributeNameInfo(nodeName);
+						bindingData.propName = can.camelize(bindingData.propName);
+						bindingsData[bindingData.propName] = bindingData;
 
-					} else {
-						initialScopeData[bindingData.propName] = compute;
-					}
-				});
+						// Use logic from bindings
+						var compute = bindings.getParentCompute(el, componentTagData.scope, value, {});
+
+						// if we actually got a compute
+						if(compute && compute.isComputed) {
+
+							if(bindingData.parentToChild) {
+								bindings.bindParentToChild(el, compute, function(newValue){
+									viewModel.attr(bindingData.propName, newValue);
+								}, viewModelPropertyUpdates, bindingData.propName);
+
+								// Set the value to be added to the viewModel
+								var initialValue = compute();
+								if(initialValue !== undefined) {
+									initialScopeData[bindingData.propName] = initialValue;
+								}
+							}
+
+							bindingsData[bindingData.propName].parentCompute = compute;
+
+						} else {
+							initialScopeData[bindingData.propName] = compute;
+						}
+					});
+				}
 
 				if (this.constructor.Map) {
 					// If `Map` property is set on the constructor use it to wrap the `initialScopeData`
@@ -223,32 +223,29 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 				// Object to hold the bind handlers so we can tear them down
 				var handlers = {};
 				// Setup reverse bindings
-				can.each(bindingsData, function (bindingData, prop) {
-					if(componentTagData.preventDataBindings) {
-						return;
-					}
-
-					if(bindingData.childToParent) {
-						handlers[prop] = function (ev, newVal) {
-							// Check that this property is not being changed because
-							// it's scope value just changed
-							if (!viewModelPropertyUpdates[prop]) {
-								bindingData.parentCompute(newVal);
+				if(setupBindings) {
+					can.each(bindingsData, function (bindingData, prop) {
+						if(bindingData.childToParent) {
+							handlers[prop] = function (ev, newVal) {
+								// Check that this property is not being changed because
+								// it's scope value just changed
+								if (!viewModelPropertyUpdates[prop]) {
+									bindingData.parentCompute(newVal);
+								}
+							};
+							viewModel.bind(prop, handlers[prop]);
+							// it's possible there's nothing to update
+							if(bindingData.syntaxStyle === 'new' && bindingData.parentCompute) {
+								bindings.initializeValues(bindingData,
+									// call read so functions can be exported correctly.
+									prop === "." ? viewModel : can.compute.read(viewModel, can.compute.read.reads(prop), {}).value,
+									bindingData.parentCompute, function(){}, function(ev, newVal){
+									bindingData.parentCompute(newVal);
+								});
 							}
-						};
-						viewModel.bind(prop, handlers[prop]);
-						// it's possible there's nothing to update
-						if(bindingData.syntaxStyle === 'new' && bindingData.parentCompute) {
-							bindings.initializeValues(bindingData,
-								// call read so functions can be exported correctly.
-								prop === "." ? viewModel : can.compute.read(viewModel, can.compute.read.reads(prop), {}).value,
-								bindingData.parentCompute, function(){}, function(ev, newVal){
-								bindingData.parentCompute(newVal);
-							});
 						}
-
-					}
-				});
+					});
+				}
 				// Setup the attributes bindings
 				if (!can.isEmptyObject(this.constructor.attributeScopeMappings) || componentTagData.templateType !== "legacy") {
 					// Bind on the `attributes` event and update the viewModel.
@@ -267,9 +264,7 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 				this.scope = this.viewModel = viewModel;
 				can.data($el, "scope", this.scope);
 				can.data($el, "viewModel", this.scope);
-				if(!componentTagData.preventDataBindings) {
-					can.data($el,"preventDataBindings", true);
-				}
+				can.data($el,"preventDataBindings", true);
 
 				// Create a real Scope object out of the viewModel property
 				// The scope used to render the component's template.

--- a/view/import/import.js
+++ b/view/import/import.js
@@ -32,7 +32,8 @@ steal("can/util", "can/view/callbacks", function(can){
 		if(handOffTag) {
 			var callback = can.view.tag(handOffTag);
 			callback(el, can.extend(tagData, {
-				scope: scope
+				scope: scope,
+				preventDataBindings: true
 			}));
 
 			can.data(can.$(el), "viewModel", importPromise);

--- a/view/import/import.js
+++ b/view/import/import.js
@@ -1,6 +1,7 @@
 steal("can/util", "can/view/callbacks", function(can){
 
 	can.view.tag("can-import", function(el, tagData){
+		var $el = can.$(el);
 		var moduleName = el.getAttribute("from");
 
 		// If the module is part of the helpers pass that into can.import
@@ -21,8 +22,8 @@ steal("can/util", "can/view/callbacks", function(can){
 		}
 
 		// Set the viewModel to the promise
-		can.data(can.$(el), "viewModel", importPromise);
-		can.data(can.$(el), "scope", importPromise);
+		can.data($el, "viewModel", importPromise);
+		can.data($el, "scope", importPromise);
 
 		// Set the scope
 		var scope = tagData.scope.add(importPromise);
@@ -31,13 +32,14 @@ steal("can/util", "can/view/callbacks", function(can){
 		var handOffTag = el.getAttribute("can-tag");
 		if(handOffTag) {
 			var callback = can.view.tag(handOffTag);
+			can.data($el,"preventDataBindings", true);
 			callback(el, can.extend(tagData, {
-				scope: scope,
-				preventDataBindings: true
+				scope: scope
 			}));
+			can.data($el,"preventDataBindings", false);
 
-			can.data(can.$(el), "viewModel", importPromise);
-			can.data(can.$(el), "scope", importPromise);
+			can.data($el, "viewModel", importPromise);
+			can.data($el, "scope", importPromise);
 		}
 		// Render the subtemplate and register nodeLists
 		else {

--- a/view/import/import_test.js
+++ b/view/import/import_test.js
@@ -61,8 +61,8 @@ steal('can/view/stache/', 'can/component/', 'can/view/stache/intermediate_and_im
 
 
 
-		/*asyncTest("can use an import's value", function(){
-			var template = "<can-import from='can/view/import/test/person' #person='{value}' />hello {{person.name}}";
+		asyncTest("can use an import's value", function(){
+			var template = "<can-import from='can/view/import/test/person' {^value}='*person' />hello {{*person.name}}";
 
 			var iai = getIntermediateAndImports(template);
 
@@ -73,10 +73,10 @@ steal('can/view/stache/', 'can/component/', 'can/view/stache/intermediate_and_im
 				equal(res.childNodes[2].nodeValue, "world", "Got the person.name from the import");
 				start();
 			});
-		});*/
+		});
 
-		/*asyncTest("can import a template and use it", function(){
-			var template = "<can-import from='can/view/import/test/other.stache!' #other='{value}' />{{> other}}";
+		asyncTest("can import a template and use it", function(){
+			var template = "<can-import from='can/view/import/test/other.stache!' {^value}='*other' />{{> *other}}";
 
 			can.stache.async(template).then(function(renderer){
 				var frag = renderer();
@@ -88,9 +88,9 @@ steal('can/view/stache/', 'can/component/', 'can/view/stache/intermediate_and_im
 					QUnit.start();
 				});
 			});
-		});*/
+		});
 
-		/*asyncTest("importing a template works with can-tag", function(){
+		asyncTest("importing a template works with can-tag", function(){
 			Component.extend({
 				tag: "my-waiter",
 				template: can.stache("{{#isResolved}}" +
@@ -100,7 +100,7 @@ steal('can/view/stache/', 'can/component/', 'can/view/stache/intermediate_and_im
 				"{{/eq}}")
 			});
 
-			var template = "<can-import from='can/view/import/test/other.stache!' #other='{value}' can-tag='my-waiter'>{{> other}}</can-import>";
+			var template = "<can-import from='can/view/import/test/other.stache!' {^value}='*other' can-tag='my-waiter'>{{> *other}}</can-import>";
 
 			can.stache.async(template).then(function(renderer){
 				var frag = renderer();
@@ -111,10 +111,10 @@ steal('can/view/stache/', 'can/component/', 'can/view/stache/intermediate_and_im
 					QUnit.start();
 				});
 			});
-		});*/
+		});
 
-		/*asyncTest("can dynamically import a template and use it", function(){
-			var template = "<can-import from='can/view/import/test/other-dynamic.stache!' #other='{value}'/>{{> other}}";
+		asyncTest("can dynamically import a template and use it", function(){
+			var template = "<can-import from='can/view/import/test/other-dynamic.stache!' {^value}='*other'/>{{> *other}}";
 
 			can.stache.async(template).then(function(renderer){
 				var frag = renderer();
@@ -127,6 +127,6 @@ steal('can/view/stache/', 'can/component/', 'can/view/stache/intermediate_and_im
 				});
 			});
 
-		});*/
+		});
 
 	});

--- a/view/import/import_test.js
+++ b/view/import/import_test.js
@@ -76,7 +76,22 @@ steal('can/view/stache/', 'can/component/', 'can/view/stache/intermediate_and_im
 		});
 
 		asyncTest("can import a template and use it", function(){
-			var template = "<can-import from='can/view/import/test/other.stache!' {^value}='*other' />{{> *other}}";
+			var template = "<can-import from='can/view/import/test/other.stache!' {^@value}='*other' />{{{*other()}}}";
+
+			can.stache.async(template).then(function(renderer){
+				var frag = renderer();
+
+				// Import will happen async
+				can["import"]("can/view/import/test/other.stache!").then(function(){
+					equal(frag.childNodes[3].firstChild.nodeValue, "hi there", "Partial was renderered right after the can-import");
+
+					QUnit.start();
+				});
+			});
+		});
+
+		asyncTest("can import a template and use it using the > syntax", function(){
+			var template = "<can-import from='can/view/import/test/other.stache!' {^@value}='*other' />{{> *other}}";
 
 			can.stache.async(template).then(function(renderer){
 				var frag = renderer();
@@ -97,15 +112,16 @@ steal('can/view/stache/', 'can/component/', 'can/view/stache/intermediate_and_im
 				"<content></content>" +
 				"{{else}}" +
 				"<div class='loading'></div>" +
-				"{{/eq}}")
+				"{{/isResolved}}")
 			});
 
-			var template = "<can-import from='can/view/import/test/other.stache!' {^value}='*other' can-tag='my-waiter'>{{> *other}}</can-import>";
+			var template = "<can-import from='can/view/import/test/other.stache!' {^@value}='*other' can-tag='my-waiter'>{{{*other()}}}</can-import>";
 
 			can.stache.async(template).then(function(renderer){
-				var frag = renderer();
+				var frag = renderer(new can.Map());
 
 				can["import"]("can/view/import/test/other.stache!").then(function(){
+					ok(frag.childNodes[0].childNodes.length > 1, "Something besides a text node is inserted");
 					equal(frag.childNodes[0].childNodes[2].firstChild.nodeValue, "hi there", "Partial worked with can-tag");
 
 					QUnit.start();
@@ -114,7 +130,7 @@ steal('can/view/stache/', 'can/component/', 'can/view/stache/intermediate_and_im
 		});
 
 		asyncTest("can dynamically import a template and use it", function(){
-			var template = "<can-import from='can/view/import/test/other-dynamic.stache!' {^value}='*other'/>{{> *other}}";
+			var template = "<can-import from='can/view/import/test/other-dynamic.stache!' {^@value}='*other'/>{{> *other}}";
 
 			can.stache.async(template).then(function(renderer){
 				var frag = renderer();

--- a/view/stache/mustache_core.js
+++ b/view/stache/mustache_core.js
@@ -212,7 +212,7 @@ steal("can/util",
 							isArgument: true
 						}).value;
 
-						if (scopePartialName === null) {
+						if (scopePartialName === null || !scopePartialName && localPartialName[0] === '*') {
 							return can.frag("");
 						}
 						if (scopePartialName) {


### PR DESCRIPTION
This updates all of the can-import tests to use the new binding syntax.
One of the tests uses this method:

```handlebars
<can-import from='can/view/import/test/other.stache!' {^@value}='*other'
/>

{{{*other()}}}
```

While all of the others use the old syntax:

```handlebars
<can-import from='can/view/import/test/other.stache!' {^@value}='*other'
/>

{{> *other}}
```

So we know that both do work.

One change I had to make was to prevent can.Component from setting up
it's own bindings when can-import is used with `can-tag`. This is
because the bindings are performed in can/view/bindings instead.

Closes #2042 and #2044