### PR TITLE
Previous behavior restored for "old" two-way binding syntax

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -95,7 +95,7 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 			// ### setup
 			// When a new component instance is created, setup bindings, render the template, etc.
 			setup: function (el, componentTagData) {
-				
+
 				// Setup values passed to component
 				var initialScopeData = {
 						"%root": componentTagData.scope.attr("%root")
@@ -129,11 +129,11 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 				can.each(this.constructor.attributeScopeMappings, function (val, prop) {
 					initialScopeData[prop] = el.getAttribute(can.hyphenate(val));
 				});
-				
+
 				// Get the value in the viewModel for each attribute
 				// the hookup should probably happen after?
 				can.each(can.makeArray(el.attributes), function (node, index) {
-					
+
 					var nodeName = node.name,
 						name = can.camelize(nodeName.toLowerCase()),
 						value = node.value;
@@ -145,12 +145,12 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 						"but it is not a supported attribute");
 					}
 					//!steal-remove-end
-					
+
 					var isDataBindings = bindings.dataBindingsRegExp.test(nodeName);
 					// Ignore attributes already present in the ScopeMappings.
 					if (component.constructor.attributeScopeMappings[name] ||
 						ignoreAttributesRegExp.test(name) ||
-						// we will handle 
+						// we will handle
 						( viewCallbacks.attr(nodeName) && !isDataBindings ) ) {
 						return;
 					}
@@ -164,7 +164,7 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 							return;
 						}
 					}
-					
+
 					var bindingData = bindings.attributeNameInfo(nodeName);
 					bindingData.propName = can.camelize(bindingData.propName);
 					bindingsData[bindingData.propName] = bindingData;
@@ -179,14 +179,14 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 							bindings.bindParentToChild(el, compute, function(newValue){
 								viewModel.attr(bindingData.propName, newValue);
 							}, viewModelPropertyUpdates, bindingData.propName);
-							
+
 							// Set the value to be added to the viewModel
 							var initialValue = compute();
 							if(initialValue !== undefined) {
 								initialScopeData[bindingData.propName] = initialValue;
 							}
 						}
-						
+
 						bindingsData[bindingData.propName].parentCompute = compute;
 
 					} else {
@@ -232,14 +232,14 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 						};
 						viewModel.bind(prop, handlers[prop]);
 						// it's possible there's nothing to update
-						if(bindingData.parentCompute) {
+						if(bindingData.syntaxStyle === 'new' && bindingData.parentCompute) {
 							bindings.initializeValues(bindingData,
 								prop === "." ? viewModel : viewModel.attr(prop),
 								bindingData.parentCompute, function(){}, function(ev, newVal){
 								bindingData.parentCompute(newVal);
 							});
 						}
-						
+
 					}
 				});
 				// Setup the attributes bindings
@@ -382,7 +382,7 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 								}
 
 							} else {
-								// we are rendering default content so this content should 
+								// we are rendering default content so this content should
 								// use the same scope as the <content> tag was found within.
 								lightTemplateData = contentTagData;
 							}
@@ -407,7 +407,7 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 					if(componentTagData.templateType === "legacy") {
 						frag = can.view.frag(componentTagData.subtemplate ? componentTagData.subtemplate(shadowScope, componentTagData.options.add(options)) : "");
 					} else {
-						// we need to be the parent ... or we need to 
+						// we need to be the parent ... or we need to
 						frag = componentTagData.subtemplate ?
 							componentTagData.subtemplate(shadowScope, componentTagData.options.add(options), nodeList) :
 							document.createDocumentFragment();

--- a/component/component_bindings_test.js
+++ b/component/component_bindings_test.js
@@ -247,7 +247,7 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can", "can/map/define", 
 			var hello = frag.firstChild;
 
 			equal(can.trim( innerHTML(hello) ), "Hello World");
-			
+
 			can.Component.extend({
 				tag: "hello-world-no-template",
 				leakScope: false,
@@ -1126,7 +1126,7 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can", "can/map/define", 
 				idData: "id-success",
 				classData: "class-success"
 			};
-			
+
 			var frag = can.stache(
 				"<stay-classy {(id)}='idData'" +
 				" {(class)}='classData'></stay-classy>")(data);
@@ -1231,9 +1231,9 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can", "can/map/define", 
 
 		});
 
-		
+
 		test("passing id works now", function(){
-			
+
 			can.Component.extend({
 				tag: 'my-thing',
 				template: can.stache('hello')
@@ -1242,7 +1242,7 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can", "can/map/define", 
 			var frag = stache(new can.Map({productId: 123}));
 			equal( can.viewModel(frag.firstChild).attr("id"), 123);
 		});
-		
+
 
 		test("stache conditionally nested components calls inserted once (#967)", function(){
 			expect(2);
@@ -1507,12 +1507,12 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can", "can/map/define", 
 			equal(removeCount, 2, 'internal removed twice');
 
 		});
-		
+
 		test("references scopes are available to bindings nested in components (#2029)", function(){
 
 			var template = can.stache('<export-er {^value}="*reference" />'+
 				'<wrap-er><simple-example {key}="*reference"/></wrap-er>');
-							
+
 			can.Component.extend({
 				tag : "wrap-er"
 			});
@@ -1530,20 +1530,88 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can", "can/map/define", 
 							equal(textNode.nodeValue, "100", "updated value with reference");
 							start();
 						}, 10);
-	
+
 					}
 				}
 			});
-	
+
 			can.Component.extend({
 				tag : "simple-example",
 				template : can.stache("{{key}}"),
 				viewModel : {}
 			});
 			var frag = template({});
-	
+
 		});
-		
+
+		test('two-way binding syntax PRIOR to v2.3 shall NOT let a child property initialize an undefined parent property (#2020)', function(){
+			var renderer = can.stache('<pa-rent/>');
+
+			can.Component.extend({
+				tag : 'pa-rent',
+				template: can.stache('<chi-ld child-prop="{parentProp}" />')
+			});
+
+			can.Component.extend({
+				tag : 'chi-ld',
+				viewModel: {
+					childProp: 'bar'
+				}
+			});
+
+			var frag = renderer({});
+
+			var parentVM = can.viewModel(frag.firstChild);
+			var childVM = can.viewModel(frag.firstChild.firstChild);
+
+			equal(parentVM.attr('parentProp'), undefined, 'parentProp is undefined');
+			equal(childVM.attr('childProp'), 'bar', 'childProp is bar');
+
+			parentVM.attr('parentProp', 'foo');
+
+			equal(parentVM.attr('parentProp'), 'foo', 'parentProp is foo');
+			equal(childVM.attr('childProp'), 'foo', 'childProp is foo');
+
+			childVM.attr('childProp', 'baz');
+
+			equal(parentVM.attr('parentProp'), 'baz', 'parentProp is baz');
+			equal(childVM.attr('childProp'), 'baz', 'childProp is baz');
+		});
+
+		test('two-way binding syntax INTRODUCED in v2.3 ALLOWS a child property to initialize an undefined parent property', function(){
+			var renderer = can.stache('<pa-rent/>');
+
+			can.Component.extend({
+				tag : 'pa-rent',
+				template: can.stache('<chi-ld {(child-prop)}="parentProp" />')
+			});
+
+			can.Component.extend({
+				tag : 'chi-ld',
+				viewModel: {
+					childProp: 'bar'
+				}
+			});
+
+			var frag = renderer({});
+
+			var parentVM = can.viewModel(frag.firstChild);
+			var childVM = can.viewModel(frag.firstChild.firstChild);
+
+			equal(parentVM.attr('parentProp'), 'bar', 'parentProp is bar');
+			equal(childVM.attr('childProp'), 'bar', 'childProp is bar');
+
+			parentVM.attr('parentProp', 'foo');
+
+			equal(parentVM.attr('parentProp'), 'foo', 'parentProp is foo');
+			equal(childVM.attr('childProp'), 'foo', 'childProp is foo');
+
+			childVM.attr('childProp', 'baz');
+
+			equal(parentVM.attr('parentProp'), 'baz', 'parentProp is baz');
+			equal(childVM.attr('childProp'), 'baz', 'childProp is baz');
+		});
+
 	}
 
 	makeTest("can/component new bindings dom", document);

--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -75,15 +75,15 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 		var propName = "$value",
 			attrValue = can.trim(removeBrackets(el.getAttribute("can-value"))),
 			getterSetter;
-		
+
 		if (el.nodeName.toLowerCase() === "input" && ( el.type === "checkbox" || el.type === "radio" ) ) {
-			
+
 			var property = getScopeCompute(el, data.scope, attrValue, {});
 			if (el.type === "checkbox") {
-				
+
 				var trueValue = can.attr.has(el, "can-true-value") ? el.getAttribute("can-true-value") : true,
 					falseValue = can.attr.has(el, "can-false-value") ? el.getAttribute("can-false-value") : false;
-				
+
 				getterSetter = can.compute(function(newValue){
 					// jshint eqeqeq: false
 					if(arguments.length) {
@@ -97,7 +97,7 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 			else if(el.type === "radio") {
 				// radio is two-way bound to if the property value
 				// equals the element value
-				
+
 				getterSetter = can.compute(function(newValue){
 					// jshint eqeqeq: false
 					if(arguments.length) {
@@ -121,7 +121,7 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 		else if (isContentEditable(el)) {
 			propName = "$innerHTML";
 		}
-		
+
 		bindings(el, data, {
 			attrValue: attrValue,
 			propName: propName,
@@ -162,7 +162,7 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 	};
 
 	var handleEvent = function (el, data) {
-		
+
 		// Get the `event` name and if we are listening to the element or viewModel.
 		// The attribute name is the name of the event.
 		var attributeName = data.attributeName,
@@ -172,34 +172,34 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 				attributeName.substr("can-".length) :
 				removeBrackets(attributeName, '(', ')'),
 			onBindElement = legacyBinding;
-		
+
 		if(event.charAt(0) === "$") {
 			event = event.substr(1);
 			onBindElement = true;
 		}
-		
-		
+
+
 		// This is the method that the event will initially trigger. It will look up the method by the string name
 		// passed in the attribute and call it.
 		var handler = function (ev) {
 				var attrVal = el.getAttribute(attributeName);
 				if (!attrVal) { return; }
-				
+
 				var $el = can.$(el),
 					viewModel = can.viewModel($el[0]);
-				
+
 				// expression.parse will read the attribute
 				// value and parse it identically to how mustache helpers
 				// get parsed.
 				var expr = expression.parse(removeBrackets(attrVal),{lookupRule: "method", methodRule: "call"});
-				
+
 				if(!(expr instanceof expression.Call) && !(expr instanceof expression.Helper)) {
 					var defaultArgs = can.map( [data.scope._context, $el].concat(can.makeArray(arguments) ), function(data){
 						return new expression.Literal(data);
 					});
 					expr = new expression.Call(expr, defaultArgs, {} );
 				}
-				
+
 				// We grab the first item and treat it as a method that
 				// we'll call.
 				var scopeData = data.scope.read(expr.methodExpr.key, {
@@ -224,17 +224,17 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 					return null;
 				}
 
-				
-				
-				// make a scope with these things just under 
-				
+
+
+				// make a scope with these things just under
+
 				var localScope = data.scope.add({
 					"@element": $el,
 					"@event": ev,
 					"@viewModel": viewModel,
 					"@scope": data.scope,
 					"@context": data.scope._context,
-					
+
 					"%element": this,
 					"$element": $el,
 					"%event": ev,
@@ -244,18 +244,18 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 				},{
 					notContext: true
 				});
-				
-				
+
+
 				var args = expr.args(localScope, null)(),
 					hash = expr.hash(localScope, null)();
-					
+
 				if(!can.isEmptyObject(hash)) {
 					args.push(hash);
 				}
-		
+
 				return scopeData.value.apply(scopeData.parent, args);
 			};
-		
+
 		// This code adds support for special event types, like can-enter="foo". special.enter (or any special[event]) is
 		// a function that returns an object containing an event and a handler. These are to be used for binding. For example,
 		// when a user adds a can-enter attribute, we'll bind on the keyup event, and the handler performs special logic to
@@ -268,11 +268,11 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 		// Bind the handler defined above to the element we're currently processing and the event name provided in this
 		// attribute name (can-click="foo")
 		can.bind.call(onBindElement ? el : can.viewModel(el), event, handler);
-		
+
 		// Create a handler that will unbind itself and the event when the attribute is removed from the DOM
 		var attributesHandler = function(ev) {
 			if(ev.attributeName === attributeName && !this.getAttribute(attributeName)) {
-				
+
 				can.unbind.call(onBindElement ? el : can.viewModel(el), event, handler);
 				can.unbind.call(el, 'attributes', attributesHandler);
 			}
@@ -289,7 +289,7 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 	// ## (EVENT)
 	can.view.attr(/^\([\$?\w\.]+\)$/, handleEvent);
 
-	
+
 
 	var elementCompute = function(el, prop, event){
 		if(!event) {
@@ -303,7 +303,7 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 		if(!can.isArray(event)) {
 			event = [event];
 		}
-		
+
 		var hasChildren = el.nodeName.toLowerCase() === "select",
 			isMultiselectValue = prop === "value" && hasChildren && el.multiple,
 			isStringValue,
@@ -321,13 +321,13 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 					} else {
 						newVal = [];
 					}
-	
+
 					// Make an object containing all the options passed in for convenient lookup
 					var isSelected = {};
 					can.each(newVal, function (val) {
 						isSelected[val] = true;
 					});
-	
+
 					// Go through each &lt;option/&gt; element, if it has a value property (its a valid option), then
 					// set its selected property if it was in the list of vals that were just set.
 					can.each(el.childNodes, function (option) {
@@ -339,14 +339,14 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 					can.attr.setAttrOrProp(el, prop, newVal == null ? "" : newVal);
 				}
 				return newVal;
-				
+
 			};
-			
+
 		if(hasChildren) {
 			// have to set later ... probably only with mustache.
 			setTimeout(function(){ set(lastSet); },1);
 		}
-		
+
 		return can.compute(el[prop],{
 			on: function(updater){
 				can.each(event, function(eventName){
@@ -360,16 +360,16 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 			},
 			get: function(){
 				if(isMultiselectValue) {
-					
+
 					var values = [],
 						children = el.childNodes;
-	
+
 					can.each(children, function (child) {
 						if (child.selected && child.value) {
 							values.push(child.value);
 						}
 					});
-					
+
 					return isStringValue ? values.join(";"): values;
 				}
 
@@ -378,11 +378,11 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 			set: set
 		});
 	};
-	
+
 	var getValue = function(value){
 		return value && value.isComputed ? value() : value;
 	};
-	
+
 	var bindingsRegExp = /\{(\()?(\^)?([^\}\)]+)\)?\}/;
 	var attributeNameInfo = function(attributeName){
 		var matches = attributeName.match(bindingsRegExp);
@@ -396,15 +396,16 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 		var twoWay = !!matches[1],
 			childToParent = twoWay || !!matches[2],
 			parentToChild = twoWay || !childToParent;
-		
-		
+
+
 		return {
 			childToParent: childToParent,
 			parentToChild: parentToChild,
-			propName: matches[3]
+			propName: matches[3],
+			syntaxStyle: 'new'
 		};
 	};
-	
+
 	// parent compute
 	var getScopeCompute = function(el, scope, scopeProp, options){
 		var parentExpression = expression.parse(scopeProp,{baseMethodType: "Call"});
@@ -412,12 +413,12 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 	};
 	// child compute
 	var getElementCompute = function(el, attributeName, options){
-		
+
 		var attrName = can.camelize( options.propName || attributeName.substr(1) ),
 			firstChar = attrName.charAt(0),
 			isDOM = firstChar === "$",
 			childCompute;
-			
+
 		if(isDOM) {
 			childCompute = elementCompute(el, attrName.substr(1));
 		} else {
@@ -428,41 +429,41 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 		}
 		return childCompute;
 	};
-	
+
 	// parent -> child binding
 	var bindParentToChild = function(el, parentCompute, childUpdate, bindingsSemaphore, attrName){
-		
+
 		// setup listening on parent and forwarding to viewModel
 		var updateChild = function(ev, newValue){
 			// Save the viewModel property name so it is not updated multiple times.
 			bindingsSemaphore[attrName] = (bindingsSemaphore[attrName] || 0 )+1;
 			childUpdate(newValue);
-			
+
 			// only after the batch has finished, reduce the update counter
 			can.batch.after(function(){
 				--bindingsSemaphore[attrName];
 			});
 		};
-		
+
 		if(parentCompute && parentCompute.isComputed) {
 			parentCompute.bind("change", updateChild);
-		
+
 			can.one.call(el, 'removed', function() {
 				parentCompute.unbind("change", updateChild);
 			});
-			
+
 		}
-		
+
 		return updateChild;
 	};
-	
+
 	// child -> parent binding
 	// el -> the element
 	// parentUpdate -> a method that updates the parent
-	// 
+	//
 	var bindChildToParent = function(el, parentUpdate, childCompute, bindingsSemaphore, attrName, syncChild){
 		var parentUpdateIsFunction = typeof parentUpdate === "function";
-		
+
 		var updateScope = function(ev, newVal){
 			if (!bindingsSemaphore[attrName]) {
 				if(parentUpdateIsFunction) {
@@ -481,34 +482,34 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 				}
 			}
 		};
-		
+
 		if(childCompute && childCompute.isComputed) {
 			childCompute.bind("change", updateScope);
-		
+
 			can.one.call(el, 'removed', function() {
 				childCompute.unbind("change", updateScope);
 			});
 		}
-		
+
 		return updateScope;
 	};
-	
-	
+
+
 	// parentToChild, childToParent, initializeValues
 	var bindings = function(el, attrData, options){
-		
+
 		var attrName = attrData.attributeName;
 		// Get what we are binding to from the scope
 		var parentCompute = getScopeCompute(el, attrData.scope, options.attrValue || el.getAttribute(attrName) || ".", options);
-		
+
 		// Get what we are binding to from the child
 		var childCompute = getElementCompute(el, options.propName || attrName.replace(/^\{/,"").replace(/\}$/,""), options);
-		
+
 		// tracks which viewModel property is currently updating
 		var bindingsSemaphore = {},
 			updateChild,
 			updateScope;
-		
+
 		if(options.parentToChild){
 			// setup listening on parent and forwarding to viewModel
 			updateChild = bindParentToChild(el, parentCompute, childCompute, bindingsSemaphore, attrName);
@@ -517,18 +518,18 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 			// setup event binding on viewModel and forward to parent.
 			updateScope = bindChildToParent(el, parentCompute, childCompute, bindingsSemaphore, attrName, options.syncChildWithParent);
 		}
-		
+
 		if(options.initializeValues) {
 			initializeValues(options, childCompute, parentCompute, updateChild, updateScope);
 		}
-		
+
 		return {
 			parentCompute: parentCompute,
 			childCompute: childCompute
 		};
 	};
 	var initializeValues = function(options, childCompute, parentCompute, updateChild, updateScope){
-		
+
 		if(options.parentToChild && !options.childToParent) {
 			updateChild({}, getValue(parentCompute) );
 		}
@@ -546,7 +547,7 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 			updateChild({}, getValue(parentCompute) );
 		}
 	};
-	
+
 	var dataBindingsRegExp = /^\{[^\}]+\}$/;
 	can.view.attr(dataBindingsRegExp, function(el, attrData){
 		if(can.data(can.$(el),"preventDataBindings")){
@@ -554,16 +555,16 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 		}
 		var attrNameInfo = attributeNameInfo(attrData.attributeName);
 		attrNameInfo.initializeValues = true;
-		
+
 		bindings(el, attrData, attrNameInfo);
 	});
-	
+
 	// #ref-export shorthand
 	can.view.attr(/\*[\w\.\-_]+/, function(el, attrData) {
 		if(el.getAttribute(attrData.attributeName)) {
 			console.warn("&reference attributes can only export the view model.");
 		}
-		
+
 		var name = can.camelize( attrData.attributeName.substr(1).toLowerCase() );
 
 		var viewModel = can.viewModel(el);
@@ -571,13 +572,13 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 		refs._context.attr("*"+name, viewModel);
 
 	});
-	
+
 	return {
 		getParentCompute: getScopeCompute,
 		bindParentToChild: bindParentToChild,
 		bindChildToParent: bindChildToParent,
 		setupDataBinding: bindings,
-		// a regular expression that 
+		// a regular expression that
 		dataBindingsRegExp: dataBindingsRegExp,
 		attributeNameInfo: attributeNameInfo,
 		initializeValues: initializeValues


### PR DESCRIPTION
`foo="{bar}"`. A child property shall not initialize an undefined parent property. Resolves #2020