### PR TITLE
Allows component to export a method to the parent scope.

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -234,7 +234,8 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 						// it's possible there's nothing to update
 						if(bindingData.parentCompute) {
 							bindings.initializeValues(bindingData,
-								prop === "." ? viewModel : viewModel.attr(prop),
+								// call read so functions can be exported correctly.
+								prop === "." ? viewModel : can.compute.read(viewModel, can.compute.read.reads(prop), {}).value,
 								bindingData.parentCompute, function(){}, function(ev, newVal){
 								bindingData.parentCompute(newVal);
 							});

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -1435,7 +1435,7 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 	test("two-way element empty value (1996)", function(){
 
 
-		var template = can.view.stache("<input can-value='age'/>");
+		var template = can.stache("<input can-value='age'/>");
 
 		var map = new can.Map();
 
@@ -1461,6 +1461,27 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 
 		equal(map.attr("age"), "", "updated from input");
 
+	});
+	
+	test("exporting methods (#2051)", function(){
+		can.Component.extend({
+			tag : 'foo-bar',
+			viewModel : {
+				method : function() {
+					ok(true, "foo called");
+					return 5;
+				}
+			}
+		});
+		
+		var template = can.stache("<foo-bar {^@method}='*refKey'></foo-bar>{{*refKey()}}");
+
+		var frag = template({});
+		equal( frag.lastChild.nodeValue, "5");
+		
+		
+
+		
 	});
 
 	


### PR DESCRIPTION
fixes #2051

Basically, we use `can.compute.read` to read a correct key value.  

Components won't be able to export quite as well as normal bindings.   For example, you can't export a method's value.   This is for performance reasons.  To be able to export a method's value, we'd have to create another compute.  Perhaps this is the right thing to do, but I'd like to avoid it.