### PR TITLE
Turns back on live-binding in custom attributes

### DIFF
--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -1491,16 +1491,21 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 	
 		var map = new can.Map({
 			actions: ["action1", "action2"],
-			action1: function(){console.log("item 1 clicked")},
-			action2: function(){console.log("item 2 clicked")}
+			action1: function(){
+				equal(calling, 0,"action1");
+			},
+			action2: function(){
+				equal(calling, 1,"action2");
+			}
 		});
 	
-		var frag = template(map);
+		var frag = template(map),
+			lis = frag.firstChild.getElementsByTagName("li");
 	
-		var ta = document.getElementById("qunit-fixture");
-		ta.appendChild(frag);
-		var list = ta.childNodes[0];
-		QUnit.equal(ta.innerHTML, "<ul><li can-click=\"action1\">action1</li><li can-click=\"action2\">action2</li></ul>", 'attributes not proccesed');
+		var calling = 0;
+		can.trigger(lis[0], "click");
+		calling  = 1;
+		can.trigger(lis[1], "click");
 	});
 	
 

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -1485,4 +1485,24 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 	});
 
 	
+	test("renders dynamic custom attributes (#1800)", function () {
+	
+		var template = can.view.stache("<ul>{{#actions}}<li can-click='{{.}}'>{{.}}</li>{{/actions}}</ul>");
+	
+		var map = new can.Map({
+			actions: ["action1", "action2"],
+			action1: function(){console.log("item 1 clicked")},
+			action2: function(){console.log("item 2 clicked")}
+		});
+	
+		var frag = template(map);
+	
+		var ta = document.getElementById("qunit-fixture");
+		ta.appendChild(frag);
+		var list = ta.childNodes[0];
+		QUnit.equal(ta.innerHTML, "<ul><li can-click=\"action1\">action1</li><li can-click=\"action2\">action2</li></ul>", 'attributes not proccesed');
+	});
+	
+
+	
 });

--- a/view/stache/stache.js
+++ b/view/stache/stache.js
@@ -274,20 +274,15 @@ steal(
 				}
 				// `{{}}` in an attribute like `class="{{}}"`
 				else if(state.attr) {
-					// if in a special
-					if( viewCallbacks.attr(state.attr.name ) && !state.attr.value ) {
-						this.attrValue("{{"+text+"}}");
-					} else {
-						
-						if(!state.attr.section) {
-							state.attr.section = new TextSectionBuilder();
-							if(state.attr.value) {
-								state.attr.section.add(state.attr.value);
-							}
+
+					if(!state.attr.section) {
+						state.attr.section = new TextSectionBuilder();
+						if(state.attr.value) {
+							state.attr.section.add(state.attr.value);
 						}
-						makeRendererAndUpdateSection(state.attr.section, mode, expression );
 					}
-					
+					makeRendererAndUpdateSection(state.attr.section, mode, expression );
+
 				}
 				// `{{}}` in a tag like `<div {{}}>`
 				else if(state.node) {


### PR DESCRIPTION
For #1800.  Most likely fixes #1770.  Thanks @beno for the test.