### PR TITLE
Add can-delimeter option for multiple select boxes

### DIFF
--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -304,10 +304,10 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 			event = [event];
 		}
 
-        var multipleSelectDelimeter = ";";
-        if (el.hasAttribute("can-delimeter")) {
-            multipleSelectDelimeter = el.getAttribute("can-delimeter");
-        }
+		var multipleSelectDelimeter = ";";
+		if (el.hasAttribute("can-delimeter")) {
+			multipleSelectDelimeter = el.getAttribute("can-delimeter");
+		}
 
 		var hasChildren = el.nodeName.toLowerCase() === "select",
 			isMultiselectValue = prop === "value" && hasChildren && el.multiple,

--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -304,6 +304,11 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 			event = [event];
 		}
 
+        var multipleSelectDelimeter = ";";
+        if (el.hasAttribute("can-delimeter")) {
+            multipleSelectDelimeter = el.getAttribute("can-delimeter");
+        }
+
 		var hasChildren = el.nodeName.toLowerCase() === "select",
 			isMultiselectValue = prop === "value" && hasChildren && el.multiple,
 			isStringValue,
@@ -312,7 +317,7 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 				lastSet = newVal;
 				if(isMultiselectValue) {
 					if (newVal && typeof newVal === 'string') {
-						newVal = newVal.split(";");
+						newVal = newVal.split(multipleSelectDelimeter);
 						isStringValue = true;
 					}
 					// When given something else, try to make it an array and deal with it
@@ -370,7 +375,7 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 						}
 					});
 
-					return isStringValue ? values.join(";"): values;
+					return isStringValue ? values.join(multipleSelectDelimeter): values;
 				}
 
 				return can.attr.get(el, prop);

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -1508,6 +1508,55 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		can.trigger(lis[1], "click");
 	});
 	
+	test("can-value select multiple with values seperated by a ,", function () {
+		var template = can.view.stache(
+			"<select can-value='color' multiple can-delimeter=','>" +
+			"<option value='red'>Red</option>" +
+			"<option value='green'>Green</option>" +
+			"<option value='ultraviolet'>Ultraviolet</option>" +
+			"</select>");
 
-	
+		var map = new can.Map({
+			color: "red"
+		});
+
+		stop();
+		var frag = template(map);
+
+		var ta = document.getElementById("qunit-fixture");
+		ta.appendChild(frag);
+
+		var inputs = ta.getElementsByTagName("select"),
+			options = inputs[0].getElementsByTagName('option');
+
+		// Wait for Multiselect.set() to be called.
+		setTimeout(function() {
+			equal(inputs[0].value, 'red', "default value set");
+
+			map.attr("color", "green");
+			equal(inputs[0].value, 'green', "alternate value set");
+
+			options[0].selected = true;
+
+			equal(map.attr("color"), "green", "not yet updated from input");
+			can.trigger(inputs[0], "change");
+			equal(map.attr("color"), "red,green", "updated from input");
+
+			map.removeAttr("color");
+			equal(inputs[0].value, '', "attribute removed from map");
+
+			options[1].selected = true;
+			can.trigger(inputs[0], "change");
+			equal(map.attr("color"), "green", "updated from input");
+
+			map.attr("color", "red,green");
+
+			ok(options[0].selected, 'red option selected from map');
+			ok(options[1].selected, 'green option selected from map');
+			ok(!options[2].selected, 'ultraviolet option NOT selected from map');
+
+			can.remove(can.$(inputs));
+			start();
+		}, 1);
+	});
 });

--- a/view/bindings/doc/select-multiple.md
+++ b/view/bindings/doc/select-multiple.md
@@ -61,6 +61,9 @@ string are used as values to match against `<option>` tag values.
 
 @demo can/view/bindings/doc/select_multiple_string.html
 
+If `can-delimeter` is provided as an attribute to the select element,
+it will be used instead of `;`.
+
 ## Cross binding undefined 
 
 If the `KEY` value begins as undefined [can.Map] property like:


### PR DESCRIPTION
can-delimeter is an attribute on the select.  If present it will
be used on multiple select boxes to map to string values.  ; is still
default.
