### PR TITLE
makes live style tags work 

### DIFF
--- a/view/parser/parser.js
+++ b/view/parser/parser.js
@@ -62,7 +62,7 @@ steal(function(){
 	// var fillAttrs = makeMap("checked,compact,declare,defer,disabled,ismap,multiple,nohref,noresize,noshade,nowrap,readonly,selected");
 
 	// Special Elements (can contain anything)
-	var special = makeMap("script,style");
+	var special = makeMap("script");
 
 	// Callback names on `handler`.
 	var tokenTypes = "start,end,close,attrStart,attrEnd,attrValue,chars,comment,special,done".split(",");

--- a/view/stache/html_section.js
+++ b/view/stache/html_section.js
@@ -112,7 +112,7 @@ steal("can/util","can/view/target","./utils.js","./mustache_core.js",function( c
 				data = decodeHTML(data);
 			}
 			if(this.targetStack.length) {
-				this.targetStack[this.targetStack.length-1].children.push(data);
+				can.last(this.targetStack).children.push(data);
 			} else {
 				this[this.data].push(data);
 			}
@@ -123,13 +123,12 @@ steal("can/util","can/view/target","./utils.js","./mustache_core.js",function( c
 				this.inverseCompiled = target(this.inverseData, can.document || can.global.document);
 				delete this.inverseData;
 			}
-			delete this.targetData;
-			delete this.targetStack;
+			this.targetStack = this.targetData = null;
 			return this.compiled;
 		},
 		children: function(){
 			if(this.targetStack.length) {
-				return this.targetStack[this.targetStack.length-1].children;
+				return can.last(this.targetStack).children;
 			} else {
 				return this[this.data];
 			}
@@ -139,7 +138,7 @@ steal("can/util","can/view/target","./utils.js","./mustache_core.js",function( c
 			return !this.targetData.length;
 		}
 	});
-
+	HTMLSectionBuilder.HTMLSection = HTMLSection;
 	return HTMLSectionBuilder;
 
 });

--- a/view/stache/stache.js
+++ b/view/stache/stache.js
@@ -23,7 +23,8 @@ steal(
 		"svg": svgNamespace,
 		// this allows a partial to start with g.
 		"g": svgNamespace
-	};
+	},
+		textContentOnlyTag = {style: true, script: true};
 
 	function stache(template){
 		
@@ -44,7 +45,13 @@ steal(
 				// If text should be inserted and HTML escaped
 				text: false,
 				// which namespace we are in
-				namespaceStack: []
+				namespaceStack: [],
+				// for style and script tags
+				// we create a special TextSectionBuilder and add things to that
+				// when the element is done, we compile the text section and 
+				// add it as a callback to `section`.
+				textContentOnly: null
+				
 			},
 			// This function is a catch all for taking a section and figuring out
 			// how to create a "renderer" that handles the functionality for a 
@@ -108,7 +115,8 @@ steal(
 					attr: state.attr && state.attr.name,
 					// <content> elements should be considered direclty nested
 					directlyNested: state.sectionElementStack.length ?
-						lastElement === "section" || lastElement === "custom": true
+						lastElement === "section" || lastElement === "custom": true,
+					textContentOnly: !!state.textContentOnly
 				};
 				return overwrites ? can.simpleExtend(cur, overwrites) : cur;
 			},
@@ -153,11 +161,13 @@ steal(
 				} else {
 					section.push(state.node);
 					
-					state.sectionElementStack.push( isCustomTag ? 'custom': 'element' );
+					state.sectionElementStack.push( isCustomTag ? 'custom': tagName );
 					
 					// If it's a custom tag with content, we need a section renderer.
 					if( isCustomTag ) {
 						section.startSubSection();
+					} else if(textContentOnlyTag[tagName]) {
+						state.textContentOnly = new TextSectionBuilder();
 					}
 				}
 				
@@ -177,6 +187,10 @@ steal(
 				
 				if( isCustomTag ) {
 					renderer = section.endSubSectionAndReturnRenderer();
+				}
+				if(textContentOnlyTag[tagName]) {
+					section.last().add(state.textContentOnly.compile(copyState()));
+					state.textContentOnly = null;
 				}
 				
 				var oldNode = section.pop();
@@ -243,10 +257,9 @@ steal(
 				}
 			},
 			chars: function( text ) {
-				section.add(text);
+				(state.textContentOnly || section).add(text);
 			},
 			special: function( text ){
-				
 				
 				var firstAndText = mustacheCore.splitModeFromExpression(text, state),
 					mode = firstAndText.mode,
@@ -254,7 +267,7 @@ steal(
 				
 				
 				if(expression === "else") {
-					(state.attr && state.attr.section ? state.attr.section : section).inverse();
+					(state.attr && state.attr.section ? state.attr.section : state.textContentOnly || section).inverse();
 					return;
 				}
 				
@@ -299,12 +312,10 @@ steal(
 						makeRendererAndUpdateSection(state.node.section, mode, expression );
 					} else {
 						throw new Error(mode+" is currently not supported within a tag.");
-					}
-					
-					
-					
-				} else {
-					makeRendererAndUpdateSection(section, mode, expression );
+					}	
+				}
+				else {
+					makeRendererAndUpdateSection( state.textContentOnly || section, mode, expression );
 				}
 			},
 			comment: function( text ) {

--- a/view/stache/stache.js
+++ b/view/stache/stache.js
@@ -312,7 +312,7 @@ steal(
 						makeRendererAndUpdateSection(state.node.section, mode, expression );
 					} else {
 						throw new Error(mode+" is currently not supported within a tag.");
-					}	
+					}
 				}
 				else {
 					makeRendererAndUpdateSection( state.textContentOnly || section, mode, expression );

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -4565,7 +4565,7 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can/view/stache", "can/v
 			
 			map = new can.Map({showGreen: true});
 			frag = can.stache('<style>body {color: {{#showGreen}}green{{/showGreen}} }</style>')(map);
-			ontent = frag.firstChild.firstChild.nodeValue;
+			content = frag.firstChild.firstChild.nodeValue;
 			equal(content,"body {color: green }","sub expressions work");
 			
 		});

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -4556,6 +4556,19 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can/view/stache", "can/v
 			
 			
 		});
+		
+		test("rendering style tag (#2035)",function(){
+			var map = new can.Map({color: 'green'});
+			var frag = can.stache('<style>body {color: {{color}} }</style>')(map);
+			var content = frag.firstChild.firstChild.nodeValue;
+			equal(content,"body {color: green }","got the right style text");
+			
+			map = new can.Map({showGreen: true});
+			frag = can.stache('<style>body {color: {{#showGreen}}green{{/showGreen}} }</style>')(map);
+			ontent = frag.firstChild.firstChild.nodeValue;
+			equal(content,"body {color: green }","sub expressions work");
+			
+		});
 
 		// PUT NEW TESTS RIGHT BEFORE THIS!
 	}

--- a/view/stache/test.html
+++ b/view/stache/test.html
@@ -1,4 +1,7 @@
 <title>can/view/stache</title>
+<style>
+	body {color: green}
+</style>
 <script type="text/javascript" src="../../bower_components/modernizr/modernizr.js"></script>
 <script src="../../node_modules/steal/steal.js" main="can/view/stache/stache_test"></script>
 <div id="qunit-fixture"></div>

--- a/view/stache/text_section.js
+++ b/view/stache/text_section.js
@@ -37,16 +37,24 @@ steal("can/util", "can/view/live","./utils.js", "./live_attr.js", function(can, 
 				var value = compute();
 				
 				if( compute.computeInstance.hasDependencies ) {
-					if(state.attr) {
+					if(state.textContentOnly) {
+						live.text(this, compute);
+					}
+					else if(state.attr) {
 						live.simpleAttribute(this, state.attr, compute);
-					} else {
+					} 
+					else {
 						liveStache.attributes(this, compute, scope, options);
 					}
 					compute.computeInstance.unbind("change", can.k);
 				} else {
-					if(state.attr) {
+					if(state.textContentOnly) {
+						this.nodeValue = value;
+					}
+					else if(state.attr) {
 						can.attr.set(this, state.attr, value);
-					} else {
+					} 
+					else {
 						live.setAttributes(this, value);
 					}
 				}

--- a/view/stache/text_section.js
+++ b/view/stache/text_section.js
@@ -42,7 +42,7 @@ steal("can/util", "can/view/live","./utils.js", "./live_attr.js", function(can, 
 					}
 					else if(state.attr) {
 						live.simpleAttribute(this, state.attr, compute);
-					} 
+					}
 					else {
 						liveStache.attributes(this, compute, scope, options);
 					}
@@ -53,7 +53,7 @@ steal("can/util", "can/view/live","./utils.js", "./live_attr.js", function(can, 
 					}
 					else if(state.attr) {
 						can.attr.set(this, state.attr, value);
-					} 
+					}
 					else {
 						live.setAttributes(this, value);
 					}


### PR DESCRIPTION
Closes #2035

The big change here was to identify when we are in a `textContentOnly` element in stache.  When this is the case, we create a `TextSectionBuilder` and start adding things to that.  Once the element is done, we compile it and add it to the main `HTMLSectionBuilder`.