### PR TITLE
refactor binding to updating bindings when attributes change, but also unifies binding behavior

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -281,8 +281,6 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 								// use the same scope as the <content> tag was found within.
 								lightTemplateData = contentTagData;
 							}
-							// add a protected scope so the parent view model can be looked up
-							lightTemplateData.scope = lightTemplateData.scope.add(viewModel,{"protected": true, viewModel: true});
 
 							if(contentTagData.parentNodeList) {
 								var frag = subtemplate( lightTemplateData.scope, lightTemplateData.options, contentTagData.parentNodeList );

--- a/component/component.js
+++ b/component/component.js
@@ -12,8 +12,7 @@
 steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings","can/control", "can/observe", "can/view/mustache", "can/util/view_model", function (can, viewCallbacks, elements, bindings) {
 	// ## Helpers
 	// Attribute names to ignore for setting viewModel values.
-	var ignoreAttributesRegExp = /^(dataViewId|class|id|\[[\w\.-]+\]|#[\w\.-])$/i,
-		paramReplacer = /\{([^\}]+)\}/g;
+	var paramReplacer = /\{([^\}]+)\}/g;
 
 	/**
 	 * @add can.Component
@@ -37,22 +36,22 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 				// which ensures that the following code is ran only in constructors that extend `can.Component`.
 				if (can.Component) {
 					var self = this,
-						scope = this.prototype.scope || this.prototype.viewModel;
+						protoViewModel = this.prototype.scope || this.prototype.viewModel;
 
 					// Define a control using the `events` prototype property.
 					this.Control = ComponentControl.extend( this.prototype.events );
 
-					// Look to convert `scope` to a Map constructor function.
-					if (!scope || (typeof scope === "object" && ! (scope instanceof can.Map)  ) ) {
-						// If scope is an object, use that object as the prototype of an extended
+					// Look to convert `protoViewModel` to a Map constructor function.
+					if (!protoViewModel || (typeof protoViewModel === "object" && ! (protoViewModel instanceof can.Map)  ) ) {
+						// If protoViewModel is an object, use that object as the prototype of an extended
 						// Map constructor function.
 						// A new instance of that Map constructor function will be created and
 						// set a the constructor instance's viewModel.
-						this.Map = can.Map.extend(scope || {});
+						this.Map = can.Map.extend(protoViewModel || {});
 					}
-					else if (scope.prototype instanceof can.Map) {
+					else if (protoViewModel.prototype instanceof can.Map) {
 						// If viewModel is a can.Map constructor function, just use that.
-						this.Map = scope;
+						this.Map = protoViewModel;
 					}
 
 					// Look for default `@` values. If a `@` is found, these
@@ -97,21 +96,18 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 			setup: function (el, componentTagData) {
 
 				// Setup values passed to component
-				var initialScopeData = {
+				var initialViewModelData = {
 						"%root": componentTagData.scope.attr("%root")
 					},
 					component = this,
-				// If a template is not provided, we fall back to
-				// dynamic scoping regardless of settings.
+					// If a template is not provided, we fall back to
+					// dynamic scoping regardless of settings.
 					lexicalContent = ((typeof this.leakScope === "undefined" ?
 									   false :
 									   !this.leakScope) &&
 									  !!this.template),
-					bindingsData = {},
-					scope = this.scope || this.viewModel,
-				// tracks which viewModel property is currently updating
-					viewModelPropertyUpdates = {},
-				// the object added to the viewModel
+					
+				// the object added to the scope
 					viewModel,
 					frag,
 				// an array of teardown stuff that should happen when the element is removed
@@ -126,144 +122,46 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 
 				// ## Scope
 
-				// Add viewModel prototype properties marked with an "@" to the `initialScopeData` object
+				// Add viewModel prototype properties marked with an "@" to the `initialViewModelData` object
 				can.each(this.constructor.attributeScopeMappings, function (val, prop) {
-					initialScopeData[prop] = el.getAttribute(can.hyphenate(val));
+					initialViewModelData[prop] = el.getAttribute(can.hyphenate(val));
 				});
-
-				// Get the value in the viewModel for each attribute
-				// the hookup should probably happen after?
+				
 				if(setupBindings) {
-					can.each(can.makeArray(el.attributes), function (node, index) {
-						var nodeName = node.name,
-							name = can.camelize(nodeName.toLowerCase()),
-							value = node.value;
-
-						//!steal-remove-start
-						// user tried to pass something like id="{foo}", so give them a good warning
-						if(ignoreAttributesRegExp.test(name) && value[0] === "{" && value[value.length-1] === "}") {
-							can.dev.warn("can/component: looks like you're trying to pass "+name+" as an attribute into a component, "+
-							"but it is not a supported attribute");
-						}
-						//!steal-remove-end
-
-						var isDataBindings = bindings.dataBindingsRegExp.test(nodeName);
-						// Ignore attributes already present in the ScopeMappings.
-						if (component.constructor.attributeScopeMappings[name] ||
-							ignoreAttributesRegExp.test(name) ||
-							// we will handle
-							( viewCallbacks.attr(nodeName) && !isDataBindings ) ) {
-							return;
-						}
-						// Only setup bindings if attribute looks like `foo="{bar}"`
-						if(value[0] === "{" && value[value.length-1] === "}") {
-							value = value.substr(1, value.length - 2 );
-						} else if(!isDataBindings){
-							// Legacy template types will crossbind "foo=bar"
-							if(componentTagData.templateType !== "legacy") {
-								initialScopeData[name] = value;
-								return;
+					teardownFunctions.push(bindings.behaviors.viewModel(el, componentTagData, function(initialViewModelData){
+						
+						// Create the component's viewModel.
+						var protoViewModel = component.scope || component.viewModel;
+						if (component.constructor.Map) {
+							// If `Map` property is set on the constructor use it to wrap the `initialViewModelData`
+							viewModel = new component.constructor.Map(initialViewModelData);
+						} else if (protoViewModel instanceof can.Map) {
+							// If `component.viewModel` is instance of `can.Map` assign it to the `viewModel`
+							viewModel = protoViewModel;
+						} else if (can.isFunction(protoViewModel)) {
+							// If `component.viewModel` is a function, call the function and
+							var scopeResult = protoViewModel.call(component, initialViewModelData, componentTagData.scope, el);
+		
+							if (scopeResult instanceof can.Map) {
+								// If the function returns a can.Map, use that as the viewModel
+								viewModel = scopeResult;
+							} else if (scopeResult.prototype instanceof can.Map) {
+								// If `scopeResult` is of a `can.Map` type, use it to wrap the `initialViewModelData`
+								viewModel = new scopeResult(initialViewModelData);
+							} else {
+								// Otherwise extend `can.Map` with the `scopeResult` and initialize it with the `initialViewModelData`
+								viewModel = new(can.Map.extend(scopeResult))(initialViewModelData);
 							}
 						}
-
-						var bindingData = bindings.attributeNameInfo(nodeName);
-						bindingData.propName = can.camelize(bindingData.propName);
-						bindingsData[bindingData.propName] = bindingData;
-
-						// Use logic from bindings
-						var compute = bindings.getParentCompute(el, componentTagData.scope, value, {templateType: componentTagData.templateType});
-
-						// if we actually got a compute
-						if(compute && compute.isComputed) {
-
-							if(bindingData.parentToChild) {
-								bindings.bindParentToChild(el, compute, function(newValue){
-									viewModel.attr(bindingData.propName, newValue);
-								}, viewModelPropertyUpdates, bindingData.propName);
-
-								// Set the value to be added to the viewModel
-								var initialValue = compute();
-								if(initialValue !== undefined) {
-									initialScopeData[bindingData.propName] = initialValue;
-								}
-							}
-
-							bindingsData[bindingData.propName].parentCompute = compute;
-
-						} else {
-							initialScopeData[bindingData.propName] = compute;
-						}
-					});
-				}
-
-				if (this.constructor.Map) {
-					// If `Map` property is set on the constructor use it to wrap the `initialScopeData`
-					viewModel = new this.constructor.Map(initialScopeData);
-				} else if (scope instanceof can.Map) {
-					// If `this.scope` is instance of `can.Map` assign it to the `viewModel`
-					viewModel = scope;
-				} else if (can.isFunction(scope)) {
-					// If `this.viewModel` is a function, call the function and
-					var scopeResult = scope.call(this, initialScopeData, componentTagData.scope, el);
-
-					if (scopeResult instanceof can.Map) {
-						// If the function returns a can.Map, use that as the viewModel
-						viewModel = scopeResult;
-					} else if (scopeResult.prototype instanceof can.Map) {
-						// If `scopeResult` is of a `can.Map` type, use it to wrap the `initialScopeData`
-						viewModel = new scopeResult(initialScopeData);
-					} else {
-						// Otherwise extend `can.Map` with the `scopeResult` and initialize it with the `initialScopeData`
-						viewModel = new(can.Map.extend(scopeResult))(initialScopeData);
-					}
-				}
-
-				// ## Two way bindings
-
-				// Object to hold the bind handlers so we can tear them down
-				var handlers = {};
-				// Setup reverse bindings
-				if(setupBindings) {
-					can.each(bindingsData, function (bindingData, prop) {
-						if(bindingData.childToParent) {
-							handlers[prop] = function (ev, newVal) {
-								// Check that this property is not being changed because
-								// it's scope value just changed
-								if (!viewModelPropertyUpdates[prop]) {
-									bindingData.parentCompute(newVal);
-								}
-							};
-							viewModel.bind(prop, handlers[prop]);
-							// it's possible there's nothing to update
-							if(bindingData.syntaxStyle === 'new' && bindingData.parentCompute) {
-								bindings.initializeValues(bindingData,
-									// call read so functions can be exported correctly.
-									prop === "." ? viewModel : can.compute.read(viewModel, can.compute.read.reads(prop), {}).value,
-									bindingData.parentCompute, function(){}, function(ev, newVal){
-									bindingData.parentCompute(newVal);
-								});
-							}
-						}
-					});
-				}
-				// Setup the attributes bindings
-				if (!can.isEmptyObject(this.constructor.attributeScopeMappings) || componentTagData.templateType !== "legacy") {
-					// Bind on the `attributes` event and update the viewModel.
-					can.bind.call(el, "attributes", function (ev) {
-						// Convert attribute name from the `attribute-name` to the `attributeName` format.
-						var camelized = can.camelize(ev.attributeName);
-						if (!bindingsData[camelized] && !ignoreAttributesRegExp.test(camelized) ) {
-							// If there is a mapping for this attribute, update the `viewModel` attribute
-							viewModel.attr(camelized, el.getAttribute(ev.attributeName));
-						}
-					});
-
+						
+						return viewModel;
+					}, initialViewModelData));
 				}
 
 				// Set `viewModel` to `this.viewModel` and set it to the element's `data` object as a `viewModel` property
 				this.scope = this.viewModel = viewModel;
-				can.data($el, "scope", this.scope);
-				can.data($el, "viewModel", this.scope);
+				can.data($el, "scope", this.viewModel);
+				can.data($el, "viewModel", this.viewModel);
 				can.data($el,"preventDataBindings", true);
 
 				// Create a real Scope object out of the viewModel property
@@ -271,7 +169,7 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 				// However, if there is no template, the "light" dom is rendered with this anyway.
 				var shadowScope;
 				if(lexicalContent) {
-					shadowScope = can.view.Scope.refsScope().add(this.scope,{viewModel: true});
+					shadowScope = can.view.Scope.refsScope().add(this.viewModel,{viewModel: true});
 				} else {
 					// if this component has a template,
 					// render the template with it's own Refs scope
@@ -279,7 +177,7 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 					shadowScope = ( this.constructor.renderer ?
 						componentTagData.scope.add( new can.view.Scope.Refs() ) :
 						componentTagData.scope  )
-							.add(this.scope,{viewModel: true});
+							.add(this.viewModel,{viewModel: true});
 				}
 				var options = {
 						helpers: {}
@@ -312,20 +210,13 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 					addHelper(prop, can.view.simpleHelper(val));
 				});
 
-				// Teardown reverse bindings when the element is removed
-				teardownFunctions.push(function(){
-					can.each(handlers, function (handler, prop) {
-						viewModel.unbind(prop, handlers[prop]);
-					});
-				});
-
 				// ## `events` control
 
 				// Create a control to listen to events
 				this._control = new this.constructor.Control(el, {
 					// Pass the viewModel to the control so we can listen to it's changes from the controller.
-					scope: this.scope,
-					viewModel: this.scope,
+					scope: this.viewModel,
+					viewModel: this.viewModel,
 					destroy: callTeardownFunctions
 				});
 
@@ -425,6 +316,7 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 				can.view.nodeLists.update(nodeList, can.childNodes(el));
 			}
 		});
+	
 
 	var ComponentControl = can.Control.extend({
 			// Change lookup to first look in the viewModel.
@@ -456,13 +348,13 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 
 							// If we are listening directly on the `viewModel` set it as a delegate target.
 							if(key === "scope" || key === "viewModel") {
-								delegate = options.scope;
+								delegate = options.viewModel;
 								return "";
 							}
 
-							// Remove `scope.` from the start of the key and read the value from the `viewModel`.
+							// Remove `viewModel.` from the start of the key and read the value from the `viewModel`.
 							key = key.replace(/^(scope|^viewModel)\./,"");
-							value = can.compute.read(options.scope, can.compute.read.reads(key), {isArgument: true}).value;
+							value = can.compute.read(options.viewModel, can.compute.read.reads(key), {isArgument: true}).value;
 
 							// If `value` is undefined use `can.getObject` to get the value.
 							if(value === undefined) {

--- a/component/component_bindings_test.js
+++ b/component/component_bindings_test.js
@@ -1386,6 +1386,7 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can", "can/map/define", 
 				tag: 'destroyable-component',
 				events: {
 					destroy: function(){
+			
 						this.viewModel.attr('product', null);
 					}
 				}
@@ -1610,6 +1611,29 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can", "can/map/define", 
 
 			equal(parentVM.attr('parentProp'), 'baz', 'parentProp is baz');
 			equal(childVM.attr('childProp'), 'baz', 'childProp is baz');
+		});
+		
+		test("conditional attributes (#2077)", function(){
+			can.Component.extend({
+				tag: 'some-comp',
+				viewModel: {}
+			});
+			var template = can.stache("<some-comp {{#if preview}}next-page='{nextPage}'{{/if}}></some-comp>");
+			
+			var map = new can.Map({preview: true, nextPage: 2});
+			var frag = template(map);
+			
+			var vm = can.viewModel(frag.firstChild);
+			
+			stop();
+			
+			setTimeout(function(){
+				equal(vm.attr("nextPage"), 2);
+				start();
+			},10);
+			
+			
+			//debugger;
 		});
 
 	}

--- a/component/component_test.js
+++ b/component/component_test.js
@@ -1596,7 +1596,8 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can", "can/map/define", 
 			stacheResult = stacheFrag.childNodes[0].innerHTML.split(",");
 			mustacheResult = mustacheFrag.childNodes[0].innerHTML.split(",");
 			equal(stacheResult[2], "VALUE3", "stache  {{}} cross binds attribute");
-			equal(mustacheResult[2], "value 3", "mustache sticks with old value even though property has changed");
+			
+			equal(mustacheResult[2], "VALUE 3", "mustache sticks with old value even though property has changed");
 
 			equal(stacheResult[3], "value4", "stache sees new attributes");
 

--- a/util/attr/attr.js
+++ b/util/attr/attr.js
@@ -8,8 +8,13 @@ steal("can/util/can.js", function (can) {
 	// Acts as a polyfill for setImmediate which only works in IE 10+. Needed to make
 	// the triggering of `attributes` event async.
 	var setImmediate = can.global.setImmediate || function (cb) {
-				return setTimeout(cb, 0);
-			},
+			return setTimeout(cb, 0);
+		},
+		// this is a hack to deal with a problem with can-simple-dom
+		formElements = {"input": true, "textarea": true, "select": true},
+		hasProperty = function(el,attrName){
+			return (attrName in el) || formElements[el.nodeName.toLowerCase()];
+		},
 		attr = {
 			// This property lets us know if the browser supports mutation observers.
 			// If they are supported then that will be setup in can/util/jquery and those native events will be used to inform observers of attribute changes.
@@ -121,7 +126,7 @@ steal("can/util/can.js", function (can) {
 				// For all other attributes use `setAttribute` to set the new value.
 				if (typeof prop === "function") {
 					newValue = prop(el, val);
-				} else if (prop === true) {
+				} else if (prop === true && hasProperty(el, prop)) {
 					newValue = el[attrName] = true;
 
 					if (attrName === "checked" && el.type === "radio") {
@@ -130,7 +135,7 @@ steal("can/util/can.js", function (can) {
 						}
 					}
 
-				} else if (prop) {
+				} else if (prop !== true && hasProperty(el, prop)) {
 					newValue = val;
 					// https://github.com/canjs/canjs/issues/356
 					// But still needs to be set for <option>fields
@@ -141,8 +146,7 @@ steal("can/util/can.js", function (can) {
 						el.defaultValue = val;
 					}
 				} else {
-					el.setAttribute(attrName, val);
-					newValue = val;
+					attr.setAttribute(el, attrName, val);
 				}
 
 				// Now that the value has been set, for browsers without MutationObservers, check to see that value has changed and if so trigger the "attributes" event on the element.
@@ -150,6 +154,39 @@ steal("can/util/can.js", function (can) {
 					attr.trigger(el, attrName, oldValue);
 				}
 			},
+			setAttribute: (function(){
+				var doc = can.global.document;
+				if(doc && document.createAttribute) {
+					try {
+						doc.createAttribute("{}");
+					} catch(e) {
+						var invalidNodes = {},
+							attributeDummy = document.createElement('div');
+				
+						return function(el, attrName, val){
+							var first = attrName.charAt(0),
+								cachedNode,
+								node;
+							if((first === "{" || first === "(" || first === "*") && el.setAttributeNode) {
+								cachedNode = invalidNodes[attrName];
+								if(!cachedNode) {
+									attributeDummy.innerHTML = '<div ' + attrName + '=""></div>';
+									cachedNode = invalidNodes[attrName] = attributeDummy.childNodes[0].attributes[0];
+								}
+								node = cachedNode.cloneNode();
+								node.value = val;
+								el.setAttributeNode(node);
+							} else {
+								el.setAttribute(attrName, val);
+							}
+						};
+					}
+				}
+				return function(el, attrName, val){
+					el.setAttribute(attrName, val);
+				};
+				
+			})(),
 			// ## attr.trigger
 			// Used to trigger an "attributes" event on an element. Checks to make sure that someone is listening for the event and then queues a function to be called asynchronously using `setImmediate.
 			trigger: function (el, attrName, oldValue) {
@@ -171,9 +208,9 @@ steal("can/util/can.js", function (can) {
 			get: function (el, attrName) {
 				attrName = attrName.toLowerCase();
 				var prop = attr.map[attrName];
-				if(typeof prop === "string" && (prop in el) ) {
+				if(typeof prop === "string" && hasProperty(el, prop) ) {
 					return el[prop];
-				} else if(prop === true) {
+				} else if(prop === true && hasProperty(el, prop) ) {
 					return el[attrName];
 				}
 
@@ -194,9 +231,9 @@ steal("can/util/can.js", function (can) {
 				if (typeof setter === "function") {
 					setter(el, undefined);
 				}
-				if (setter === true) {
+				if (setter === true && hasProperty(el, attrName) ) {
 					el[attrName] = false;
-				} else if (typeof setter === "string") {
+				} else if (typeof setter === "string" && hasProperty(el, setter) ) {
 					el[setter] = "";
 				} else {
 					el.removeAttribute(attrName);

--- a/util/attr/attr_test.js
+++ b/util/attr/attr_test.js
@@ -102,7 +102,7 @@ steal('can/util', 'can/view/stache', 'can/util/attr', 'steal-qunit', function ()
 
 	test("Map special attributes", function () {
 
-		var div = document.createElement("div");
+		var div = document.createElement("label");
 
 		document.getElementById("qunit-fixture").appendChild(div);
 

--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -553,7 +553,7 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 								});
 							}
 						}
-					} 
+					}
 					// The parentCompute can sometimes be just an observable if the observable
 					// is on a plain JS object. This updates the observable to match whatever the
 					// new value is.

--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -4,7 +4,727 @@
 // for in template event bindings. These are usable in any mustache template, but mainly and documented
 // for use within can.Component.
 
-steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/control", "can/view/scope", "can/view/href", function (can, expression) {
+steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/control", "can/view/scope", "can/view/href", function (can, expression, viewCallbacks) {
+	
+	
+	var behaviors = {
+		// ### behaviors.viewModel
+		// Sets up all of an element's data binding attributes to "soon-to-be-created"
+		// `viewModel`. 
+		// This is primarily used by `can.Component` to ensure that its
+		// `viewModel` is initialized with values from the data bindings as quickly as possible.
+		// Component could look up the data binding values itself.  However, that lookup
+		// would have to be duplicated when the bindings are established.
+		// Instead, this uses the `makeDataBinding` helper, which allows creation of the `viewModel`
+		// after scope values have been looked up.
+		//
+		// - `makeViewModel(initialViewModelData)` - a function that returns the `viewModel`.
+		// - `initialViewModelData` any initial data that should already be added to the `viewModel`.
+		//
+		// Returns:
+		// - `function` - a function that tears all the bindings down. Component
+		// wants all the bindings active so cleanup can be done during a component being removed.
+		viewModel: function(el, tagData, makeViewModel, initialViewModelData){
+			initialViewModelData = initialViewModelData || {};
+			
+			var bindingsSemaphore = {},
+				viewModel,
+				onViewModels = [],
+				onTeardowns = {},
+				attributeViewModelBindings = can.extend({}, initialViewModelData);
+			
+			// For each attribute, 
+			can.each( can.makeArray(el.attributes), function(node){
+				// start the data binding process.
+				var res = makeDataBinding(node, el, {
+					templateType: tagData.templateType,
+					scope: tagData.scope,
+					semaphore: bindingsSemaphore,
+					getViewModel: function(){
+						return viewModel;
+					},
+					attributeViewModelBindings: attributeViewModelBindings
+				});
+				
+				// For bindings that change the viewModel,
+				if(res) {
+					// Save the initial value on the viewModel.
+					if(res.bindingInfo.parentToChild) {
+						initialViewModelData[res.viewModelName] = res.value;
+					}
+					// Save what needs to happen after the `viewModel` is created.
+					onViewModels.push(res.onViewModel);
+					// Save how to tear this down.  
+					onTeardowns[node.name] = res.onTeardown;
+				}
+			});
+			
+			// Create the `viewModel` and call what needs to be happen after
+			// the `viewModel` is created.
+			viewModel = makeViewModel(initialViewModelData);
+			
+			for(var i = 0, len = onViewModels.length; i < len; i++) {
+				onViewModels[i]();
+			}
+			
+			// Listen to attribute changes and re-initialize
+			// the bindings.
+			can.bind.call(el, "attributes", function (ev) {
+				var attrName = ev.attributeName;
+				
+				if( onTeardowns[attrName] ) {
+					onTeardowns[attrName]();
+				}
+				
+				var res = makeDataBinding({name: attrName, value: el.getAttribute(attrName)}, el, {
+					templateType: tagData.templateType,
+					scope: tagData.scope,
+					semaphore: {},
+					getViewModel: function(){
+						return viewModel;
+					},
+					attributeViewModelBindings: attributeViewModelBindings,
+					// always update the viewModel accordingly.
+					initializeValues: true
+				});
+				// The viewModel is created, so 
+				if(res) {
+					res.onViewModel();
+					onTeardowns[attrName] = res.onTeardown;
+				}
+			});
+			
+			return function(){
+				for(var attrName in onTeardowns) {
+					onTeardowns[attrName]();
+				}
+			};
+		},
+		// ### behaviors.data
+		// This is called when an individual data binding attribute is placed on an element.
+		// For example `{^value}="name"`.
+		data: function(el, attrData){
+			if(can.data(can.$(el),"preventDataBindings")){
+				return;
+			}
+			var viewModel = can.viewModel(el);
+			
+			var res = makeDataBinding({
+				name: attrData.attributeName,
+				value: el.getAttribute(attrData.attributeName)
+			}, el, {
+				templateType: attrData.templateType,
+				scope: attrData.scope,
+				semaphore: {},
+				getViewModel: function(){
+					return viewModel;
+				},
+				setupTeardown: true
+			});
+			if(res) {
+				res.onViewModel();
+			}
+		},
+		// ### behaviors.reference
+		// Provides the shorthand `*ref` behavior that exports the `viewModel`.
+		// For example `{^value}="name"`.
+		reference: function(el, attrData) {
+			if(el.getAttribute(attrData.attributeName)) {
+				console.warn("&reference attributes can only export the view model.");
+			}
+	
+			var name = can.camelize( attrData.attributeName.substr(1).toLowerCase() );
+	
+			var viewModel = can.viewModel(el);
+			var refs = attrData.scope.getRefs();
+			refs._context.attr("*"+name, viewModel);
+	
+		},
+		// ### behaviors.event
+		// The following section contains code for implementing the can-EVENT attribute.
+		// This binds on a wildcard attribute name. Whenever a view is being processed
+		// and can-xxx (anything starting with can-), this callback will be run.  Inside, its setting up an event handler
+		// that calls a method identified by the value of this attribute.
+		event: function(el, data) {
+	
+			// Get the `event` name and if we are listening to the element or viewModel.
+			// The attribute name is the name of the event.
+			var attributeName = data.attributeName,
+			// The old way of binding is can-X
+				legacyBinding = attributeName.indexOf('can-') === 0,
+				event = attributeName.indexOf('can-') === 0 ?
+					attributeName.substr("can-".length) :
+					removeBrackets(attributeName, '(', ')'),
+				onBindElement = legacyBinding;
+	
+			if(event.charAt(0) === "$") {
+				event = event.substr(1);
+				onBindElement = true;
+			}
+	
+	
+			// This is the method that the event will initially trigger. It will look up the method by the string name
+			// passed in the attribute and call it.
+			var handler = function (ev) {
+					var attrVal = el.getAttribute(attributeName);
+					if (!attrVal) { return; }
+	
+					var $el = can.$(el),
+						viewModel = can.viewModel($el[0]);
+	
+					// expression.parse will read the attribute
+					// value and parse it identically to how mustache helpers
+					// get parsed.
+					var expr = expression.parse(removeBrackets(attrVal),{lookupRule: "method", methodRule: "call"});
+	
+					if(!(expr instanceof expression.Call) && !(expr instanceof expression.Helper)) {
+						var defaultArgs = can.map( [data.scope._context, $el].concat(can.makeArray(arguments) ), function(data){
+							return new expression.Literal(data);
+						});
+						expr = new expression.Call(expr, defaultArgs, {} );
+					}
+	
+					// We grab the first item and treat it as a method that
+					// we'll call.
+					var scopeData = data.scope.read(expr.methodExpr.key, {
+						isArgument: true
+					});
+	
+					// We break out early if the first argument isn't available
+					// anywhere.
+	
+					if (!scopeData.value) {
+						scopeData = data.scope.read(expr.methodExpr.key, {
+							isArgument: true
+						});
+	
+						//!steal-remove-start
+						can.dev.warn("can/view/bindings: " + attributeName + " couldn't find method named " + expr.methodExpr.key, {
+							element: el,
+							scope: data.scope
+						});
+						//!steal-remove-end
+	
+						return null;
+					}
+	
+	
+	
+					// make a scope with these things just under
+	
+					var localScope = data.scope.add({
+						"@element": $el,
+						"@event": ev,
+						"@viewModel": viewModel,
+						"@scope": data.scope,
+						"@context": data.scope._context,
+	
+						"%element": this,
+						"$element": $el,
+						"%event": ev,
+						"%viewModel": viewModel,
+						"%scope": data.scope,
+						"%context": data.scope._context
+					},{
+						notContext: true
+					});
+	
+	
+					var args = expr.args(localScope, null)(),
+						hash = expr.hash(localScope, null)();
+	
+					if(!can.isEmptyObject(hash)) {
+						args.push(hash);
+					}
+	
+					return scopeData.value.apply(scopeData.parent, args);
+				};
+	
+			// This code adds support for special event types, like can-enter="foo". special.enter (or any special[event]) is
+			// a function that returns an object containing an event and a handler. These are to be used for binding. For example,
+			// when a user adds a can-enter attribute, we'll bind on the keyup event, and the handler performs special logic to
+			// determine on keyup if the enter key was pressed.
+			if (special[event]) {
+				var specialData = special[event](data, el, handler);
+				handler = specialData.handler;
+				event = specialData.event;
+			}
+			// Bind the handler defined above to the element we're currently processing and the event name provided in this
+			// attribute name (can-click="foo")
+			can.bind.call(onBindElement ? el : can.viewModel(el), event, handler);
+	
+			// Create a handler that will unbind itself and the event when the attribute is removed from the DOM
+			var attributesHandler = function(ev) {
+				if(ev.attributeName === attributeName && !this.getAttribute(attributeName)) {
+	
+					can.unbind.call(onBindElement ? el : can.viewModel(el), event, handler);
+					can.unbind.call(el, 'attributes', attributesHandler);
+				}
+			};
+			can.bind.call(el, 'attributes', attributesHandler);
+		},
+		// ### behaviors.value
+		// Behavior for the deprecated can-value
+		value: function(el, data) {
+			var propName = "$value",
+				attrValue = can.trim(removeBrackets(el.getAttribute("can-value"))),
+				getterSetter;
+	
+			if (el.nodeName.toLowerCase() === "input" && ( el.type === "checkbox" || el.type === "radio" ) ) {
+	
+				var property = getComputeFrom.scope(el, data.scope, attrValue, {});
+				if (el.type === "checkbox") {
+	
+					var trueValue = can.attr.has(el, "can-true-value") ? el.getAttribute("can-true-value") : true,
+						falseValue = can.attr.has(el, "can-false-value") ? el.getAttribute("can-false-value") : false;
+	
+					getterSetter = can.compute(function(newValue){
+						// jshint eqeqeq: false
+						if(arguments.length) {
+							property(newValue ? trueValue : falseValue);
+						}
+						else {
+							return property() == trueValue;
+						}
+					});
+				}
+				else if(el.type === "radio") {
+					// radio is two-way bound to if the property value
+					// equals the element value
+	
+					getterSetter = can.compute(function(newValue){
+						// jshint eqeqeq: false
+						if(arguments.length) {
+							if( newValue ) {
+								property(el.value);
+							}
+						}
+						else {
+							return property() == el.value;
+						}
+					});
+	
+				}
+				propName = "$checked";
+				attrValue = "getterSetter";
+				data.scope = new can.view.Scope({
+					getterSetter: getterSetter
+				});
+			}
+			// For contenteditable elements, we instantiate a Content control.
+			else if (isContentEditable(el)) {
+				propName = "$innerHTML";
+			}
+	
+			makeDataBinding({
+				name: "{("+propName+"})",
+				value: attrValue
+			}, el, {
+				templateType: data.templateType,
+				scope: data.scope,
+				semaphore: {},
+				initializeValues: true,
+				legacyBindings: true,
+				syncChildWithParent: true
+			});
+	
+		}
+	};
+	
+		
+	// ## Custom Attributes
+	// The following sets up the bindings functions to be called 
+	// when called in a template.
+	
+	// `{}="bar"` data bindings.
+	can.view.attr(/^\{[^\}]+\}$/, behaviors.data);
+
+	// `*ref-export` shorthand.
+	can.view.attr(/\*[\w\.\-_]+/, behaviors.reference);
+
+	// `(EVENT)` event bindings.
+	can.view.attr(/^\([\$?\w\.]+\)$/, behaviors.event);
+	
+	
+	//!steal-remove-start
+	function syntaxWarning(el, attrData) {
+		can.dev.warn('can/view/bindings/bindings.js: mismatched binding syntax - ' + attrData.attributeName);
+	}
+	can.view.attr(/^\(.+\}$/, syntaxWarning);
+	can.view.attr(/^\{.+\)$/, syntaxWarning);
+	can.view.attr(/^\(\{.+\}\)$/, syntaxWarning);
+	//!steal-remove-end
+
+	
+	// Legacy bindings.
+	can.view.attr(/can-[\w\.]+/, behaviors.event);
+	can.view.attr("can-value", behaviors.value);
+	
+	
+	// ## makeDataBinding
+	// Makes a data binding for a attribute `node`.  If the
+	// data binding involves a `viewModel`, an object will be returned
+	// that finishes the data binding once a `viewModel` has been created.
+	// - `node` - an attribute node or an object with a `name` and `value` property.
+	// - `el` - the element this binding belongs on.
+	// - `bindingData` - an object with:
+	//   - `templateType` - the type of template. Ex: "legacy" for mustache.
+	//   - `scope` - the `can.view.Scope`,
+	//   - `semaphore` - an object that keeps track of changes in different properties to prevent cycles,
+	//   - `getViewModel`  - a function that returns the `viewModel` when called.  This function can be passed around (not called) even if the 
+	//                       `viewModel` doesn't exist yet.
+	//   - `attributeViewModelBindings` - properties already specified as being a viewModel<->attribute (as opposed to viewModel<->scope) binding.
+	var makeDataBinding = function(node, el, bindingData){
+		
+		var bindingInfo = getBindingInfo(node, bindingData.attributeViewModelBindings, bindingData.templateType);
+		if(!bindingInfo) {
+			return;
+		}
+		var parentCompute = getComputeFrom[bindingInfo.parent](el, bindingData.scope, bindingInfo.parentName, bindingData);
+		var childCompute = getComputeFrom[bindingInfo.child](el, bindingData.scope, bindingInfo.childName, bindingData);
+		var updateParent;
+		
+		// Only bind to 
+		if(bindingInfo.parentToChild){
+			
+			var updateChild = bind.parentToChild(el, parentCompute, childCompute, bindingData.semaphore, bindingInfo.bindingAttributeName);
+		}
+		
+		var onViewModel = function(){
+			if(bindingInfo.childToParent){
+				// setup listening on parent and forwarding to viewModel
+				updateParent = bind.childToParent(el, parentCompute, childCompute, bindingData.semaphore, bindingInfo.bindingAttributeName,
+					bindingData.syncChildWithParent);
+			}
+			if(bindingData.initializeValues || bindingInfo.initializeValues) {
+				initializeValues(bindingInfo, childCompute, parentCompute, updateChild, updateParent);
+			}
+			
+			if(bindingData.setupTeardown) {
+				can.one.call(el, 'removed', onTeardown);
+			}
+		};
+		// TODO: onTeardown isn't returned?
+		var onTeardown = function() {
+			unbindUpdate(parentCompute, updateChild);
+			unbindUpdate(childCompute, updateParent);
+		};
+		if(bindingInfo.child === "viewModel") {
+			return {
+				value: getValue(parentCompute),
+				viewModelName: bindingInfo.childName,
+				onViewModel: onViewModel,
+				bindingInfo: bindingInfo,
+				onTeardown: onTeardown
+			};
+		} else {
+			onViewModel();
+		}
+	};
+	
+	// ## getBindingInfo
+	// takes a node object like {name, value} and returns
+	// an object with information about that binding.
+	// Properties:
+	// - `parent` - where is the parentName read from: "scope", "attribute", "viewModel".
+	// - `parentName` - what is the parent property that should be read.
+	// - `child` - where is the childName read from: "scope", "attribute", "viewModel".
+	//  - `childName` - what is the child property that should be read.
+	// - `parentToChild` - should changes in the parent update the child.
+	// - `childToParent` - should changes in the child update the parent.
+	// - `bindingAttributeName` - the attribute name that created this binding.
+	// - `initializeValues` - should parent and child be initialized to their counterpart.
+	// If undefined is return, there is no binding.
+	var getBindingInfo = function(node, attributeViewModelBindings, templateType){
+		var attributeName = node.name,
+			attributeValue = node.value;
+		
+		// Does this match the new binding syntax?
+		var matches = attributeName.match(bindingsRegExp);
+		if(!matches) {
+			var ignoreAttribute = ignoreAttributesRegExp.test(attributeName);
+			var vmName = can.camelize(attributeName);
+			
+			//!steal-remove-start
+			// user tried to pass something like id="{foo}", so give them a good warning
+			if(ignoreAttribute) {
+				can.dev.warn("can/component: looks like you're trying to pass "+attributeName+" as an attribute into a component, "+
+				"but it is not a supported attribute");
+			}
+			//!steal-remove-end
+			
+			// if this is handled by another binding or a attribute like `id`.
+			if ( ignoreAttribute || viewCallbacks.attr(attributeName) ) {
+				return;
+			}
+			var syntaxRight = attributeValue[0] === "{" && can.last(attributeValue) === "}";
+			var isAttributeToChild = templateType === "legacy" ? attributeViewModelBindings[vmName] : !syntaxRight;
+			var scopeName = syntaxRight ? attributeValue.substr(1, attributeValue.length - 2 ) : attributeValue;
+			if(isAttributeToChild) {
+				return {
+					bindingAttributeName: attributeName,
+					parent: "attribute",
+					parentName: attributeName,
+					child: "viewModel",
+					childName: vmName,
+					parentToChild: true,
+					childToParent: true
+				};
+			} else {
+				return {
+					bindingAttributeName: attributeName,
+					parent: "scope",
+					parentName: scopeName,
+					child: "viewModel",
+					childName: vmName,
+					parentToChild: true,
+					childToParent: true
+				};
+			}
+		}
+		
+		var twoWay = !!matches[1],
+			childToParent = twoWay || !!matches[2],
+			parentToChild = twoWay || !childToParent;
+		
+		var childName = matches[3];
+		var isDOM = childName.charAt(0) === "$";
+		if(isDOM) {
+			
+			return {
+				parent: "scope",
+				child: "attribute",
+				childToParent: childToParent,
+				parentToChild: parentToChild,
+				bindingAttributeName: attributeName,
+				childName: childName.substr(1),
+				parentName: attributeValue,
+				initializeValues: true
+			};
+		} else {
+			return {
+				parent: "scope",
+				child: "viewModel",
+				childToParent: childToParent,
+				parentToChild: parentToChild,
+				bindingAttributeName: attributeName,
+				childName: can.camelize(childName),
+				parentName: attributeValue,
+				initializeValues: true
+			};
+		}
+
+	};
+	// Regular expressions for getBindingInfo
+	var bindingsRegExp = /\{(\()?(\^)?([^\}\)]+)\)?\}/,
+		ignoreAttributesRegExp = /^(data-view-id|class|id|\[[\w\.-]+\]|#[\w\.-])$/i;
+	
+	
+	// ## getComputeFrom
+	// An object of helper functions that make a getter/setter compute
+	// on different types of objects.
+	var getComputeFrom = {
+		scope: function(el, scope, scopeProp, options){
+			var parentExpression = expression.parse(scopeProp,{baseMethodType: "Call"});
+			return parentExpression.value(scope, new can.view.Scope());
+		},
+		viewModel: function(el, scope, vmName, options) {
+			return can.compute(function(newVal){
+				var viewModel = options.getViewModel();
+				if(arguments.length) {
+					viewModel.attr(vmName,newVal);
+				} else {
+					return vmName === "." ? viewModel : can.compute.read(viewModel, can.compute.read.reads(vmName), {}).value;
+				}
+				
+			});
+		},
+		attribute: function(el, scope, prop, options, event){
+			if(!event) {
+				if(prop === "innerHTML") {
+					event = ["blur","change"];
+				}
+				else {
+					event = "change";
+				}
+			}
+			if(!can.isArray(event)) {
+				event = [event];
+			}
+	
+			var hasChildren = el.nodeName.toLowerCase() === "select",
+				isMultiselectValue = prop === "value" && hasChildren && el.multiple,
+				isStringValue,
+				lastSet,
+				scheduledAsyncSet = false,
+				set = function(newVal){
+					// Templates write parent's out before children.  This should probably change.
+					// But it means we don't do a set immediately.
+					if(hasChildren && !scheduledAsyncSet) {
+						scheduledAsyncSet = true;
+						setTimeout(function(){
+							set(newVal);
+						},1);
+					}
+					
+					lastSet = newVal;
+					if(isMultiselectValue) {
+						if (newVal && typeof newVal === 'string') {
+							newVal = newVal.split(";");
+							isStringValue = true;
+						}
+						// When given something else, try to make it an array and deal with it
+						else if (newVal) {
+							newVal = can.makeArray(newVal);
+						} else {
+							newVal = [];
+						}
+	
+						// Make an object containing all the options passed in for convenient lookup
+						var isSelected = {};
+						can.each(newVal, function (val) {
+							isSelected[val] = true;
+						});
+	
+						// Go through each &lt;option/&gt; element, if it has a value property (its a valid option), then
+						// set its selected property if it was in the list of vals that were just set.
+						can.each(el.childNodes, function (option) {
+							if (option.value) {
+								option.selected = !! isSelected[option.value];
+							}
+						});
+					} else {
+						if(!options.legacyBindings && hasChildren && ("selectedIndex" in el)) {
+							el.selectedIndex = -1;
+						}
+						can.attr.setAttrOrProp(el, prop, newVal == null ? "" : newVal);
+					}
+					return newVal;
+	
+				},
+				get = function(){
+					if(isMultiselectValue) {
+	
+						var values = [],
+							children = el.childNodes;
+	
+						can.each(children, function (child) {
+							if (child.selected && child.value) {
+								values.push(child.value);
+							}
+						});
+	
+						return isStringValue ? values.join(";"): values;
+					}
+	
+					return can.attr.get(el, prop);
+				};
+			
+			// Parent is hydrated before children.  So we do
+			// a tiny wait to do any sets.
+			if(hasChildren) {
+				// have to set later ... probably only with mustache.
+				setTimeout(function(){
+					scheduledAsyncSet = true;
+				},1);
+			}
+	
+			return can.compute(get(),{
+				on: function(updater){
+					can.each(event, function(eventName){
+						can.bind.call(el,eventName, updater);
+					});
+				},
+				off: function(updater){
+					can.each(event, function(eventName){
+						can.unbind.call(el,eventName, updater);
+					});
+				},
+				get: get,
+				set: set
+			});
+		}
+	};
+	
+	// ## bind
+	// An object with helpers that perform bindings in a certain direction.  
+	// These use the semaphore to prevent cycles.
+	var bind = {
+		// child -> parent binding
+		// el -> the element
+		// parentUpdate -> a method that updates the parent
+		childToParent: function(el, parentUpdate, childCompute, bindingsSemaphore, attrName, syncChild){
+			var parentUpdateIsFunction = typeof parentUpdate === "function";
+	
+			var updateScope = function(ev, newVal){
+				if (!bindingsSemaphore[attrName]) {
+					if(parentUpdateIsFunction) {
+						parentUpdate(newVal);
+						if( syncChild ) {
+							if(parentUpdate() !== childCompute()) {
+								bindingsSemaphore[attrName] = (bindingsSemaphore[attrName] || 0 )+1;
+								childCompute(parentUpdate());
+								can.batch.after(function(){
+									--bindingsSemaphore[attrName];
+								});
+							}
+						}
+					} else if(parentUpdate instanceof can.Map) {
+						parentUpdate.attr(newVal, true);
+					}
+				}
+			};
+	
+			if(childCompute && childCompute.isComputed) {
+				childCompute.bind("change", updateScope);
+			}
+	
+			return updateScope;
+		},
+		// parent -> child binding
+		parentToChild: function(el, parentCompute, childUpdate, bindingsSemaphore, attrName){
+	
+			// setup listening on parent and forwarding to viewModel
+			var updateChild = function(ev, newValue){
+				// Save the viewModel property name so it is not updated multiple times.
+				bindingsSemaphore[attrName] = (bindingsSemaphore[attrName] || 0 )+1;
+				childUpdate(newValue);
+	
+				// only after the batch has finished, reduce the update counter
+				can.batch.after(function(){
+					--bindingsSemaphore[attrName];
+				});
+			};
+	
+			if(parentCompute && parentCompute.isComputed) {
+				parentCompute.bind("change", updateChild);
+			}
+	
+			return updateChild;
+		}
+	};
+	
+	// ## initializeValues
+	var initializeValues = function(options, childCompute, parentCompute, updateChild, updateScope){
+
+		if(options.parentToChild && !options.childToParent) {
+			updateChild({}, getValue(parentCompute) );
+		}
+		else if(!options.parentToChild && options.childToParent) {
+			updateScope({}, getValue(childCompute) );
+		}
+		// Two way
+		// Update child or parent depending on who has a value.
+		// If both have a value, update the child.
+		else if( getValue(childCompute) === undefined) {
+			updateChild({}, getValue(parentCompute) );
+		} else if(getValue(parentCompute) === undefined) {
+			updateScope({}, getValue(childCompute) );
+		} else {
+			updateChild({}, getValue(parentCompute) );
+		}
+	};
+	
 	/**
 	 * @function isContentEditable
 	 * @hide
@@ -60,80 +780,17 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 				return value.substr(1, value.length - 2);
 			}
 			return value;
+		},
+		getValue = function(value){
+			return value && value.isComputed ? value() : value;
+		},
+		unbindUpdate = function(compute, updateOther){
+			if(compute && compute.isComputed && typeof updateOther === "function") {
+				compute.unbind("change", updateOther);
+			}
 		};
 
-	// ## can-value
-	// Implement the `can-value` special attribute
-	//
-	// ### Usage
-	//
-	// 		<input can-value="name" />
-	//
-	// When a view engine finds this attribute, it will call this callback. The value of the attribute
-	// should be a string representing some value in the current scope to cross-bind to.
-	can.view.attr("can-value", function (el, data) {
-		var propName = "$value",
-			attrValue = can.trim(removeBrackets(el.getAttribute("can-value"))),
-			getterSetter;
-
-		if (el.nodeName.toLowerCase() === "input" && ( el.type === "checkbox" || el.type === "radio" ) ) {
-
-			var property = getScopeCompute(el, data.scope, attrValue, {});
-			if (el.type === "checkbox") {
-
-				var trueValue = can.attr.has(el, "can-true-value") ? el.getAttribute("can-true-value") : true,
-					falseValue = can.attr.has(el, "can-false-value") ? el.getAttribute("can-false-value") : false;
-
-				getterSetter = can.compute(function(newValue){
-					// jshint eqeqeq: false
-					if(arguments.length) {
-						property(newValue ? trueValue : falseValue);
-					}
-					else {
-						return property() == trueValue;
-					}
-				});
-			}
-			else if(el.type === "radio") {
-				// radio is two-way bound to if the property value
-				// equals the element value
-
-				getterSetter = can.compute(function(newValue){
-					// jshint eqeqeq: false
-					if(arguments.length) {
-						if( newValue ) {
-							property(el.value);
-						}
-					}
-					else {
-						return property() == el.value;
-					}
-				});
-
-			}
-			propName = "$checked";
-			attrValue = "getterSetter";
-			data.scope = new can.view.Scope({
-				getterSetter: getterSetter
-			});
-		}
-		// For contenteditable elements, we instantiate a Content control.
-		else if (isContentEditable(el)) {
-			propName = "$innerHTML";
-		}
-
-		bindings(el, data, {
-			attrValue: attrValue,
-			propName: propName,
-			childToParent: true,
-			parentToChild: true,
-			initializeValues: true,
-			syncChildWithParent: true,
-			legacyBindings: true
-		});
-
-	});
-
+	
 	// ## Special Event Types (can-SPECIAL)
 
 	// A special object, similar to [$.event.special](http://benalman.com/news/2010/03/jquery-special-events/),
@@ -162,459 +819,10 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 		}
 	};
 
-	var handleEvent = function (el, data) {
 
-		// Get the `event` name and if we are listening to the element or viewModel.
-		// The attribute name is the name of the event.
-		var attributeName = data.attributeName,
-		// The old way of binding is can-X
-			legacyBinding = attributeName.indexOf('can-') === 0,
-			event = attributeName.indexOf('can-') === 0 ?
-				attributeName.substr("can-".length) :
-				removeBrackets(attributeName, '(', ')'),
-			onBindElement = legacyBinding;
-
-		if(event.charAt(0) === "$") {
-			event = event.substr(1);
-			onBindElement = true;
-		}
-
-
-		// This is the method that the event will initially trigger. It will look up the method by the string name
-		// passed in the attribute and call it.
-		var handler = function (ev) {
-				var attrVal = el.getAttribute(attributeName);
-				if (!attrVal) { return; }
-
-				var $el = can.$(el),
-					viewModel = can.viewModel($el[0]);
-
-				// expression.parse will read the attribute
-				// value and parse it identically to how mustache helpers
-				// get parsed.
-				var expr = expression.parse(removeBrackets(attrVal),{lookupRule: "method", methodRule: "call"});
-
-				if(!(expr instanceof expression.Call) && !(expr instanceof expression.Helper)) {
-					var defaultArgs = can.map( [data.scope._context, $el].concat(can.makeArray(arguments) ), function(data){
-						return new expression.Literal(data);
-					});
-					expr = new expression.Call(expr, defaultArgs, {} );
-				}
-
-				// We grab the first item and treat it as a method that
-				// we'll call.
-				var scopeData = data.scope.read(expr.methodExpr.key, {
-					isArgument: true
-				});
-
-				// We break out early if the first argument isn't available
-				// anywhere.
-
-				if (!scopeData.value) {
-					scopeData = data.scope.read(expr.methodExpr.key, {
-						isArgument: true
-					});
-
-					//!steal-remove-start
-					can.dev.warn("can/view/bindings: " + attributeName + " couldn't find method named " + expr.methodExpr.key, {
-						element: el,
-						scope: data.scope
-					});
-					//!steal-remove-end
-
-					return null;
-				}
-
-
-
-				// make a scope with these things just under
-
-				var localScope = data.scope.add({
-					"@element": $el,
-					"@event": ev,
-					"@viewModel": viewModel,
-					"@scope": data.scope,
-					"@context": data.scope._context,
-
-					"%element": this,
-					"$element": $el,
-					"%event": ev,
-					"%viewModel": viewModel,
-					"%scope": data.scope,
-					"%context": data.scope._context
-				},{
-					notContext: true
-				});
-
-
-				var args = expr.args(localScope, null)(),
-					hash = expr.hash(localScope, null)();
-
-				if(!can.isEmptyObject(hash)) {
-					args.push(hash);
-				}
-
-				return scopeData.value.apply(scopeData.parent, args);
-			};
-
-		// This code adds support for special event types, like can-enter="foo". special.enter (or any special[event]) is
-		// a function that returns an object containing an event and a handler. These are to be used for binding. For example,
-		// when a user adds a can-enter attribute, we'll bind on the keyup event, and the handler performs special logic to
-		// determine on keyup if the enter key was pressed.
-		if (special[event]) {
-			var specialData = special[event](data, el, handler);
-			handler = specialData.handler;
-			event = specialData.event;
-		}
-		// Bind the handler defined above to the element we're currently processing and the event name provided in this
-		// attribute name (can-click="foo")
-		can.bind.call(onBindElement ? el : can.viewModel(el), event, handler);
-
-		// Create a handler that will unbind itself and the event when the attribute is removed from the DOM
-		var attributesHandler = function(ev) {
-			if(ev.attributeName === attributeName && !this.getAttribute(attributeName)) {
-
-				can.unbind.call(onBindElement ? el : can.viewModel(el), event, handler);
-				can.unbind.call(el, 'attributes', attributesHandler);
-			}
-		};
-		can.bind.call(el, 'attributes', attributesHandler);
+	can.bindings = {
+		behaviors: behaviors,
+		getBindingInfo: getBindingInfo
 	};
-
-	// ## can-EVENT
-	// The following section contains code for implementing the can-EVENT attribute.
-	// This binds on a wildcard attribute name. Whenever a view is being processed
-	// and can-xxx (anything starting with can-), this callback will be run.  Inside, its setting up an event handler
-	// that calls a method identified by the value of this attribute.
-	can.view.attr(/can-[\w\.]+/, handleEvent);
-	// ## (EVENT)
-	can.view.attr(/^\([\$?\w\.]+\)$/, handleEvent);
-
-
-
-	var elementCompute = function(el, prop, event, options){
-		if(!event) {
-			if(prop === "innerHTML") {
-				event = ["blur","change"];
-			}
-			else {
-				event = "change";
-			}
-		}
-		if(!can.isArray(event)) {
-			event = [event];
-		}
-
-		var hasChildren = el.nodeName.toLowerCase() === "select",
-			isMultiselectValue = prop === "value" && hasChildren && el.multiple,
-			isStringValue,
-			lastSet,
-			scheduledAsyncSet = false,
-			set = function(newVal){
-				// Templates write parent's out before children.  This should probably change.
-				// But it means we don't do a set immediately.
-				if(hasChildren && !scheduledAsyncSet) {
-					scheduledAsyncSet = true;
-					setTimeout(function(){
-						set(newVal);
-					},1);
-				}
-				
-				lastSet = newVal;
-				if(isMultiselectValue) {
-					if (newVal && typeof newVal === 'string') {
-						newVal = newVal.split(";");
-						isStringValue = true;
-					}
-					// When given something else, try to make it an array and deal with it
-					else if (newVal) {
-						newVal = can.makeArray(newVal);
-					} else {
-						newVal = [];
-					}
-
-					// Make an object containing all the options passed in for convenient lookup
-					var isSelected = {};
-					can.each(newVal, function (val) {
-						isSelected[val] = true;
-					});
-
-					// Go through each &lt;option/&gt; element, if it has a value property (its a valid option), then
-					// set its selected property if it was in the list of vals that were just set.
-					can.each(el.childNodes, function (option) {
-						if (option.value) {
-							option.selected = !! isSelected[option.value];
-						}
-					});
-				} else {
-					if(!options.legacyBindings && hasChildren && ("selectedIndex" in el)) {
-						el.selectedIndex = -1;
-					}
-					can.attr.setAttrOrProp(el, prop, newVal == null ? "" : newVal);
-					
-					
-				}
-				return newVal;
-
-			};
-		
-		// Parent is hydrated before children.  So we do
-		// a tiny wait to do any sets.
-		if(hasChildren) {
-			// have to set later ... probably only with mustache.
-			setTimeout(function(){
-				scheduledAsyncSet = true;
-			},1);
-		}
-
-		return can.compute(el[prop],{
-			on: function(updater){
-				can.each(event, function(eventName){
-					can.bind.call(el,eventName, updater);
-				});
-			},
-			off: function(updater){
-				can.each(event, function(eventName){
-					can.unbind.call(el,eventName, updater);
-				});
-			},
-			get: function(){
-				if(isMultiselectValue) {
-
-					var values = [],
-						children = el.childNodes;
-
-					can.each(children, function (child) {
-						if (child.selected && child.value) {
-							values.push(child.value);
-						}
-					});
-
-					return isStringValue ? values.join(";"): values;
-				}
-
-				return can.attr.get(el, prop);
-			},
-			set: set
-		});
-	};
-
-	var getValue = function(value){
-		return value && value.isComputed ? value() : value;
-	};
-
-	var bindingsRegExp = /\{(\()?(\^)?([^\}\)]+)\)?\}/;
-	var attributeNameInfo = function(attributeName){
-		var matches = attributeName.match(bindingsRegExp);
-		if(!matches) {
-			return {
-				childToParent: true,
-				parentToChild: true,
-				propName: attributeName
-			};
-		}
-		var twoWay = !!matches[1],
-			childToParent = twoWay || !!matches[2],
-			parentToChild = twoWay || !childToParent;
-
-
-		return {
-			childToParent: childToParent,
-			parentToChild: parentToChild,
-			propName: matches[3],
-			syntaxStyle: 'new'
-		};
-	};
-
-	// parent compute
-	var getScopeCompute = function(el, scope, scopeProp, options){
-		var parentExpression = expression.parse(scopeProp,{baseMethodType: "Call"});
-		return parentExpression.value(scope, new can.view.Scope());
-	};
-	// child compute
-	var getElementCompute = function(el, attributeName, options){
-
-		var attrName = can.camelize( options.propName || attributeName.substr(1) ),
-			firstChar = attrName.charAt(0),
-			isDOM = firstChar === "$",
-			childCompute;
-
-		if(isDOM) {
-			childCompute = elementCompute(el, attrName.substr(1), undefined, options);
-		} else {
-			var childExpression = expression.parse(attrName,{baseMethodType: "Call"});
-			var childContext = can.viewModel(el);
-			var childScope = new can.view.Scope(childContext);
-			childCompute = childExpression.value(childScope, new can.view.Scope(), {});
-		}
-		return childCompute;
-	};
-
-	// parent -> child binding
-	var bindParentToChild = function(el, parentCompute, childUpdate, bindingsSemaphore, attrName){
-
-		// setup listening on parent and forwarding to viewModel
-		var updateChild = function(ev, newValue){
-			// Save the viewModel property name so it is not updated multiple times.
-			bindingsSemaphore[attrName] = (bindingsSemaphore[attrName] || 0 )+1;
-			childUpdate(newValue);
-
-			// only after the batch has finished, reduce the update counter
-			can.batch.after(function(){
-				--bindingsSemaphore[attrName];
-			});
-		};
-
-		if(parentCompute && parentCompute.isComputed) {
-			parentCompute.bind("change", updateChild);
-
-			can.one.call(el, 'removed', function() {
-				parentCompute.unbind("change", updateChild);
-			});
-
-		}
-
-		return updateChild;
-	};
-
-	// child -> parent binding
-	// el -> the element
-	// parentUpdate -> a method that updates the parent
-	//
-	var bindChildToParent = function(el, parentUpdate, childCompute, bindingsSemaphore, attrName, syncChild){
-		var parentUpdateIsFunction = typeof parentUpdate === "function";
-
-		var updateScope = function(ev, newVal){
-			if (!bindingsSemaphore[attrName]) {
-				if(parentUpdateIsFunction) {
-					parentUpdate(newVal);
-					if( syncChild ) {
-						if(parentUpdate() !== childCompute()) {
-							bindingsSemaphore[attrName] = (bindingsSemaphore[attrName] || 0 )+1;
-							childCompute(parentUpdate());
-							can.batch.after(function(){
-								--bindingsSemaphore[attrName];
-							});
-						}
-					}
-				} else if(parentUpdate instanceof can.Map) {
-					parentUpdate.attr(newVal, true);
-				}
-			}
-		};
-
-		if(childCompute && childCompute.isComputed) {
-			childCompute.bind("change", updateScope);
-
-			can.one.call(el, 'removed', function() {
-				childCompute.unbind("change", updateScope);
-			});
-		}
-
-		return updateScope;
-	};
-
-
-	// parentToChild, childToParent, initializeValues
-	var bindings = function(el, attrData, options){
-
-		var attrName = attrData.attributeName;
-		// Get what we are binding to from the scope
-		var parentCompute = getScopeCompute(el, attrData.scope, options.attrValue || el.getAttribute(attrName) || ".", options);
-
-		// Get what we are binding to from the child
-		var childCompute = getElementCompute(el, options.propName || attrName.replace(/^\{/,"").replace(/\}$/,""), options);
-
-		// tracks which viewModel property is currently updating
-		var bindingsSemaphore = {},
-			updateChild,
-			updateScope;
-
-		if(options.parentToChild){
-			// setup listening on parent and forwarding to viewModel
-			updateChild = bindParentToChild(el, parentCompute, childCompute, bindingsSemaphore, attrName);
-		}
-		if(options.childToParent){
-			// setup event binding on viewModel and forward to parent.
-			updateScope = bindChildToParent(el, parentCompute, childCompute, bindingsSemaphore, attrName, options.syncChildWithParent);
-		}
-
-		if(options.initializeValues) {
-			initializeValues(options, childCompute, parentCompute, updateChild, updateScope);
-		}
-
-		return {
-			parentCompute: parentCompute,
-			childCompute: childCompute
-		};
-	};
-	var initializeValues = function(options, childCompute, parentCompute, updateChild, updateScope){
-
-		if(options.parentToChild && !options.childToParent) {
-			updateChild({}, getValue(parentCompute) );
-		}
-		else if(!options.parentToChild && options.childToParent) {
-			updateScope({}, getValue(childCompute) );
-		}
-		// Two way
-		// Update child or parent depending on who has a value.
-		// If both have a value, update the child.
-		else if( getValue(childCompute) === undefined) {
-			updateChild({}, getValue(parentCompute) );
-		} else if(getValue(parentCompute) === undefined) {
-			updateScope({}, getValue(childCompute) );
-		} else {
-			updateChild({}, getValue(parentCompute) );
-		}
-	};
-
-	//!steal-remove-start
-	
-	var syntaxWarning = function(el, attrData) {
-		can.dev.warn('can/view/bindings/bindings.js: mismatched binding syntax - ' + attrData.attributeName);
-	};
-		
-	can.view.attr(/^\(.+\}$/, syntaxWarning);
-
-	can.view.attr(/^\{.+\)$/, syntaxWarning);
-
-	can.view.attr(/^\(\{.+\}\)$/, syntaxWarning);
-	
-	//!steal-remove-end
-
-	var dataBindingsRegExp = /^\{[^\}]+\}$/;
-	can.view.attr(dataBindingsRegExp, function(el, attrData){
-		if(can.data(can.$(el),"preventDataBindings")){
-			return;
-		}
-		var attrNameInfo = attributeNameInfo(attrData.attributeName);
-		attrNameInfo.initializeValues = true;
-		attrNameInfo.templateType = attrData.templateType;
-		bindings(el, attrData, attrNameInfo);
-	});
-
-	// #ref-export shorthand
-	can.view.attr(/\*[\w\.\-_]+/, function(el, attrData) {
-		if(el.getAttribute(attrData.attributeName)) {
-			console.warn("&reference attributes can only export the view model.");
-		}
-
-		var name = can.camelize( attrData.attributeName.substr(1).toLowerCase() );
-
-		var viewModel = can.viewModel(el);
-		var refs = attrData.scope.getRefs();
-		refs._context.attr("*"+name, viewModel);
-
-	});
-
-	return {
-		getParentCompute: getScopeCompute,
-		bindParentToChild: bindParentToChild,
-		bindChildToParent: bindChildToParent,
-		setupDataBinding: bindings,
-		// a regular expression that
-		dataBindingsRegExp: dataBindingsRegExp,
-		attributeNameInfo: attributeNameInfo,
-		initializeValues: initializeValues
-	};
+	return can.bindings;
 });

--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -62,7 +62,7 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 					// For bindings that change the viewModel,
 					if(dataBinding.onCompleteBinding) {
 						// save the initial value on the viewModel.
-						if(dataBinding.bindingInfo.parentToChild) {
+						if(dataBinding.bindingInfo.parentToChild && dataBinding.value !== undefined) {
 							initialViewModelData[dataBinding.bindingInfo.childName] = dataBinding.value;
 						}
 						// Save what needs to happen after the `viewModel` is created.

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -4,6 +4,132 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 			document.getElementById("qunit-fixture").innerHTML = "";
 		}
 	});
+	
+	test("attributeNameInfo", function(){
+		// MUSTACHE BEHAVIOR
+		var info = can.bindings.getBindingInfo({name: "foo", value: "bar"},{foo: "@"},"legacy");
+		deepEqual(info,{
+			parent: "attribute",
+			child: "viewModel",
+			parentToChild: true,
+			childToParent: true,
+			childName: "foo",
+			parentName: "foo",
+			bindingAttributeName: "foo"
+		}, "legacy with @");
+		
+
+		info = can.bindings.getBindingInfo({name: "foo-ed", value: "bar"},{},"legacy");
+		deepEqual(info, {
+			parent: "scope",
+			child: "viewModel",
+			parentToChild: true,
+			childToParent: true,
+			childName: "fooEd",
+			parentName: "bar",
+			bindingAttributeName: "foo-ed"
+		},"legacy");
+		
+		// ORIGINAL STACHE BEHAVIOR
+		info = can.bindings.getBindingInfo({name: "foo-ed", value: "bar"});
+		deepEqual(info, {
+			parent: "attribute",
+			child: "viewModel",
+			parentToChild: true,
+			childToParent: true,
+			childName: "fooEd",
+			parentName: "foo-ed",
+			bindingAttributeName: "foo-ed"
+		}, "OG stache attr binding");
+		
+		info = can.bindings.getBindingInfo({name: "foo-ed", value: "{bar}"});
+		deepEqual(info, {
+			parent: "scope",
+			child: "viewModel",
+			parentToChild: true,
+			childToParent: true,
+			childName: "fooEd",
+			parentName: "bar",
+			bindingAttributeName: "foo-ed"
+		}, "OG stache vm binding");
+		
+		// NEW BINDINGS
+		
+		// element based
+		info = can.bindings.getBindingInfo({name: "{$foo-ed}", value: "bar"});
+		deepEqual(info, {
+			parent: "scope",
+			child: "attribute",
+			childToParent: false,
+			parentToChild: true,
+			parentName: "bar",
+			childName: "foo-ed",
+			bindingAttributeName: "{$foo-ed}",
+			initializeValues: true
+		}, "new el binding");
+		
+		info = can.bindings.getBindingInfo({name: "{($foo-ed)}", value: "bar"});
+		deepEqual(info, {
+			parent: "scope",
+			child: "attribute",
+			childToParent: true,
+			parentToChild: true,
+			parentName: "bar",
+			childName: "foo-ed",
+			bindingAttributeName: "{($foo-ed)}",
+			initializeValues: true
+		}, "new el binding");
+		
+		info = can.bindings.getBindingInfo({name: "{^$foo-ed}", value: "bar"});
+		deepEqual(info, {
+			parent: "scope",
+			child: "attribute",
+			childToParent: true,
+			parentToChild: false,
+			parentName: "bar",
+			childName: "foo-ed",
+			bindingAttributeName: "{^$foo-ed}",
+			initializeValues: true
+		}, "new el binding");
+		
+		// vm based
+		info = can.bindings.getBindingInfo({name: "{foo-ed}", value: "bar"});
+		deepEqual(info, {
+			parent: "scope",
+			child: "viewModel",
+			parentToChild: true,
+			childToParent: false,
+			childName: "fooEd",
+			parentName: "bar",
+			bindingAttributeName: "{foo-ed}",
+			initializeValues: true
+		}, "new vm binding");
+		
+		info = can.bindings.getBindingInfo({name: "{(foo-ed)}", value: "bar"});
+		deepEqual(info, {
+			parent: "scope",
+			child: "viewModel",
+			parentToChild: true,
+			childToParent: true,
+			childName: "fooEd",
+			parentName: "bar",
+			bindingAttributeName: "{(foo-ed)}",
+			initializeValues: true
+		}, "new el binding");
+		
+		info = can.bindings.getBindingInfo({name: "{^foo-ed}", value: "bar"});
+		deepEqual(info, {
+			parent: "scope",
+			child: "viewModel",
+			parentToChild: false,
+			childToParent: true,
+			childName: "fooEd",
+			parentName: "bar",
+			bindingAttributeName: "{^foo-ed}",
+			initializeValues: true
+		}, "new el binding");
+		
+	});
 
 	var foodTypes = new can.List([{
 		title: "Fruits",
@@ -1641,5 +1767,7 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 			start();
 		}, 1);
 	});
+	
+
 
 });

--- a/view/mustache/mustache.js
+++ b/view/mustache/mustache.js
@@ -1612,16 +1612,7 @@ steal('can/util',
 		 * @static
 		 */
 
-		can.view.Options = can.view.Scope.extend({
-			init: function (data, parent) {
-				if (!data.helpers && !data.partials && !data.tags) {
-					data = {
-						helpers: data
-					};
-				}
-				can.view.Scope.prototype.init.apply(this, arguments);
-			}
-		});
+		
 
 		// ## Helpers
 		//

--- a/view/scope/scope.js
+++ b/view/scope/scope.js
@@ -11,323 +11,378 @@ steal(
 	'can/list',
 	'can/view',
 	'can/compute', function (can, makeComputeData) {
-
-
+		
 		/**
 		 * @add can.view.Scope
 		 */
-		var Scope = can.Construct.extend(
-
-			/**
-			 * @static
-			 */
-			{
-				// ## Scope.read
-				// Scope.read was moved to can.compute.read
-				// can.compute.read reads properties from a parent.  A much more complex version of getObject.
-				read: can.compute.read,
-				Refs: can.Map.extend({shortName: "ReferenceMap"},{}),
-				Break: function(){},
-				refsScope: function(){
-					return new can.view.Scope( new this.Refs() );
+		function Scope(context, parent, meta) {
+			// The obj that will be looked on for values.
+			this._context = context;
+			// The next Scope object whose context should be looked on for values.
+			this._parent = parent;
+			// If this is a special context, it can be labeled here.
+			// Options are:
+			// - viewModel - This is a viewModel
+			// - notContext - This can't be looked within using `./` and `../`. It will be skipped.  This is
+			//   for virtual contexts like those used by `%index`.
+			this._meta = meta || {};
+			
+			// A cache that can be used to store computes used to look up within this scope.
+			// For example if someone creates a compute to lookup `name`, another compute does not
+			// need to be created.
+			this.__cache = {};
+		}
+		
+		/**
+		 * @static
+		 */
+		can.simpleExtend(Scope, {
+			// ## Scope.read
+			// Scope.read was moved to can.compute.read
+			// can.compute.read reads properties from a parent.  A much more complex version of getObject.
+			read: can.compute.read,
+			// ## Scope.Refs
+			// A special type of `can.Map` used for the references scope.
+			Refs: can.Map.extend({shortName: "ReferenceMap"},{}),
+			
+			// ## Scope.refsScope
+			// A scope with a references scope in it and no parent. 
+			refsScope: function(){
+				return new can.view.Scope( new this.Refs() );
+			}
+		});
+		/**
+		 * @prototype
+		 */
+		can.simpleExtend(Scope.prototype,{
+			
+			// ## Scope.prototype.add
+			// Creates a new scope and sets the current scope to be the parent.
+			// ```
+			// var scope = new can.view.Scope([
+			//   {name:"Chris"}, 
+			//   {name: "Justin"}
+			// ]).add({name: "Brian"});
+			// scope.attr("name") //-> "Brian"
+			// ```
+			add: function (context, meta) {
+				if (context !== this._context) {
+					return new this.constructor(context, this, meta);
+				} else {
+					return this;
 				}
 			},
+			
+			// ## Scope.prototype.read
+			// Reads from the scope chain and returns the first non-`undefined` value.
+			// `read` deals mostly with setting up "context based" keys to start reading
+			// from the right scope.  Once the right scope is located, `_read` is called.
 			/**
-			 * @prototype
+			 * @hide
+			 * @param {can.mustache.key} attr A dot seperated path.  Use `"\."` if you have a property name that includes a dot.
+			 * @param {can.view.Scope.readOptions} options that configure how this gets read.
+			 * @return {{}}
+			 *   @option {Object} parent the value's immediate parent
+			 *   @option {can.Map|can.compute} rootObserve the first observable to read from.
+			 *   @option {Array<String>} reads An array of properties that can be used to read from the rootObserve to get the value.
+			 *   @option {*} value the found value
 			 */
-			{
-				init: function (context, parent, meta) {
-					this._context = context;
-					this._parent = parent;
-					this.__cache = {};
-					this._meta = meta || {};
-				},
-				get: can.__notObserve(function (key, options) {
-					
-					options = can.simpleExtend({
-						isArgument: true
-					}, options);
-					
-					var res = this.read(key, options);
-					return res.value;
-				}),
-				// ## Scope.prototype.attr
-				// Reads a value from the current context or parent contexts.
-				attr: can.__notObserve(function (key, value, options) {
-					// Reads for whatever called before attr.  It's possible
-					// that this.read clears them.  We want to restore them.
-					options = can.simpleExtend({
-						isArgument: true
-					}, options);
-
-					// Allow setting a value on the context
-					if(arguments.length === 2) {
-						var lastIndex = key.lastIndexOf('.'),
-							// Either get the paren of a key or the current context object with `.`
-							readKey = lastIndex !== -1 ? key.substring(0, lastIndex) : '.',
-							obj = this.read(readKey, options).value;
-
-						if(lastIndex !== -1) {
-							// Get the last part of the key which is what we want to set
-							key = key.substring(lastIndex + 1, key.length);
-						}
-
-						can.compute.set(obj, key, value, options);
-					} else {
-						return this.get(key, options);
-					}
-					
-				}),
-
-				// ## Scope.prototype.add
-				// Creates a new scope and sets the current scope to be the parent.
-				// ```
-				// var scope = new can.view.Scope([{name:"Chris"}, {name: "Justin"}]).add({name: "Brian"});
-				// scope.attr("name") //-> "Brian"
-				// ```
-				add: function (context, meta) {
-					if (context !== this._context) {
-						return new this.constructor(context, this, meta);
-					} else {
-						return this;
-					}
-				},
-
-				// ## Scope.prototype.computeData
-				// Finds the first location of the key in the scope and then provides a get-set compute that represents the key's value
-				// and other information about where the value was found.
-				computeData: function (key, options) {
-					return makeComputeData(this, key, options);
-				},
-
-				// ## Scope.prototype.compute
-				// Provides a get-set compute that represents a key's value.
-				compute: function (key, options) {
-					return this.computeData(key, options)
-						.compute;
-				},
-				getRefs: function(){
-					return this.getScope(function(scope){
-						return scope._context  instanceof Scope.Refs;
-					});
-				},
-				getViewModel: function(){
-					return this.getContext(function(scope){
-						return scope._meta.viewModel;
-					});
-				},
-				getContext: function(tester){
-					var res = this.getScope(tester);
-					return res && res._context;
-				},
-				getScope: function(tester){
-					var scope = this;
-					while (scope) {
-						if(tester(scope)) {
-							return scope;
-						}
-						scope = scope._parent;
-					}
-				},
-				getRoot: function(){
-					var cur = this,
-						child = this;
-						
-					while(cur._parent) {
-						child = cur;
-						cur = cur._parent;
-					}
-
-					if(cur._context instanceof Scope.Refs) {
-						cur = child;
-					}
-					return cur._context;
-				},
-				// this takes a scope and essentially copies its chain from
-				// right before the last Refs.  And it does not include the ref.
-				// this is a helper function to provide lexical semantics for refs.
-				// This will not be needed for leakScope: false.
-				cloneFromRef: function(){
-					var contexts = [];
-					var scope = this,
-						context,
-						parent;
-					while (scope) {
-						context = scope._context;
-						if(context instanceof Scope.Refs) {
-							parent = scope._parent;
-							break;
-						}
-						contexts.push(context);
-						scope = scope._parent;
-					}
-					if(parent) {
-						can.each(contexts, function(context){
-							parent = parent.add(context);
-						});
-						return parent;
-					} else {
-						return this;
-					}
-				},
-				// ## Scope.prototype.read
-				// Finds the first isntance of a key in the available scopes and returns the keys value along with the the observable the key
-				// was found in, readsData and the current scope.
-				/**
-				 * @hide
-				 * @param {can.mustache.key} attr A dot seperated path.  Use `"\."` if you have a property name that includes a dot.
-				 * @param {can.view.Scope.readOptions} options that configure how this gets read.
-				 * @return {{}}
-				 * @option {Object} parent the value's immediate parent
-				 * @option {can.Map|can.compute} rootObserve the first observable to read from.
-				 * @option {Array<String>} reads An array of properties that can be used to read from the rootObserve to get the value.
-				 * @option {*} value the found value
-				 */
-				read: function (attr, options) {
-					// skip protected
-					if(this._meta.protected) {
-						return this._parent.read(attr, options);
-					}
-					var isInCurrentContext = attr.substr(0, 2) === './',
-						isInParentContext = attr.substr(0, 3) === "../",
-						isCurrentContext = attr === "." || attr === "this",
-						isParentContext = attr === "..",
-						isContextBased = isInCurrentContext ||
-							isInParentContext ||
-							isCurrentContext ||
-							isParentContext;
-							
-					// notContent items can be read, but are skipped if you are doing .. sorta stuff.
-					if(isContextBased && this._meta.notContext) {
-						return this._parent.read(attr, options);
-					}
-					
-					// check if we should only look within current scope
-					var stopLookup;
-					if(isInCurrentContext) {
-						// set flag to halt lookup from walking up scope
-						stopLookup = true;
-						// stop lookup from checking parent scopes
-						attr = attr.substr(2);
-					}
-					// check if we should be running this on a parent.
-					else if (isInParentContext) {
-						return this._parent.read(attr.substr(3), options);
-					}
-					else if ( isCurrentContext ) {
-						return {
-							value: this._context
-						};
-					}
-					else if ( isParentContext ) {
-						return {
-							value: this._parent._context
-						};
-					} else if(attr === "%root") {
-						return { value: this.getRoot() };
-					}
-
-					// Array of names from splitting attr string into names.  ```"a.b\.c.d\\.e" //-> ['a', 'b', 'c', 'd.e']```
-					var names = can.compute.read.reads(attr),
-					// The current context (a scope is just data and a parent scope).
-						context,
-					// The current scope.
-						scope = names[0].key.charAt(0) === "*" ? this.getRefs() : this,
-
-					// If no value can be found, this is a list of of every observed
-					// object and property name to observe.
-						undefinedObserves = [],
-					// Tracks the first found observe.
-						currentObserve,
-					// Tracks the reads to get the value for a scope.
-						currentReads,
-
-						// Tracks the most likely observable to use as a setter.
-						setObserveDepth = -1,
-						currentSetReads,
-						currentSetObserve,
-					// Only search one reference scope for a variable.
-						searchedRefsScope = false,
-						refInstance,
-						readOptions = can.simpleExtend({
-							/* Store found observable, incase we want to set it as the rootObserve. */
-							foundObservable: function (observe, nameIndex) {
-								currentObserve = observe;
-								currentReads = names.slice(nameIndex);
-							},
-							earlyExit: function (parentValue, nameIndex) {
-								if (nameIndex > setObserveDepth) {
-									currentSetObserve = currentObserve;
-									currentSetReads = currentReads;
-									setObserveDepth = nameIndex;
-								}
-							}
-						}, options);
-
-					// Goes through each scope context provided until it finds the key (attr).  Once the key is found
-					// then it's value is returned along with an observe, the current scope and reads.
-					// While going through each scope context searching for the key, each observable found is returned and
-					// saved so that either the observable the key is found in can be returned, or in the case the key is not
-					// found in an observable the closest observable can be returned.
-
-					while (scope) {
-						context = scope._context;
-						refInstance = context instanceof Scope.Refs;
-
-						
-						
-						if ( context !== null &&
-							// if its a primitive type, keep looking up the scope, since there won't be any properties
-							(typeof context === "object" || typeof context === "function") &&
-							!( searchedRefsScope && refInstance ) &&
-							// If the scope is protected skip
-							! scope._meta.protected
-							) {
-
-							if(refInstance) {
-								searchedRefsScope = true;
-							}
-							var getObserves = can.__trapObserves();
-							
-							var data = can.compute.read(context, names, readOptions);
-							
-							var observes = getObserves();
-							// **Key was found**, return value and location data
-							if (data.value !== undefined) {
-								can.__observes(observes);
-								return {
-									scope: scope,
-									rootObserve: currentObserve,
-									value: data.value,
-									reads: currentReads
-								};
-							} else {
-								// save all old readings before we try the next scope
-								undefinedObserves.push.apply(undefinedObserves, observes);
-							}
-						}
-
-						if(!stopLookup) {
-							// Move up to the next scope.
-							scope = scope._parent;
-						} else {
-							scope = null;
-						}
-					}
-
-					// **Key was not found**, return undefined for the value.
-					// Make sure we listen to everything we checked for when the value becomes defined.
-					// Once it becomes defined, we won't have to listen to so many things.
-					can.__observes(undefinedObserves);
-					return {
-						setRoot: currentSetObserve,
-						reads: currentSetReads,
-						value: undefined
-					};
-
+			read: function (attr, options) {
+				// If it's the root, jump right to it.
+				if(attr === "%root") {
+					return { value: this.getRoot() };
 				}
-			});
+				
+				// Identify context based keys.  Context based keys try to
+				// specify a particular context a key should be within.
+				var isInCurrentContext = attr.substr(0, 2) === './',
+					isInParentContext = attr.substr(0, 3) === "../",
+					isCurrentContext = attr === "." || attr === "this",
+					isParentContext = attr === "..",
+					isContextBased = isInCurrentContext ||
+						isInParentContext ||
+						isCurrentContext ||
+						isParentContext;
+						
+				// `notContext` contexts should be skipped if the key is "context based".
+				// For example, the context that holds `%index`.
+				if(isContextBased && this._meta.notContext) {
+					return this._parent.read(attr, options);
+				}
+				
+				// If true, lookup stops after the current context. 
+				var currentScopeOnly;
+				
+				if(isInCurrentContext) {
+					// Stop lookup from checking parent scopes.
+					// Set flag to halt lookup from walking up scope.
+					currentScopeOnly = true;
+					attr = attr.substr(2);
+				}
+				else if (isInParentContext) {
+					// Read from the parent context.
+					return this._parent.read(attr.substr(3), options);
+				}
+				else if ( isCurrentContext ) {
+					return {
+						value: this._context
+					};
+				}
+				else if ( isParentContext ) {
+					return {
+						value: this._parent._context
+					};
+				}
+				
+				// if it's a reference scope, read from there.
+				var keyReads = can.compute.read.reads(attr);
+				if(keyReads[0].key.charAt(0) === "*") {
+					return this.getRefs()._read(keyReads, options, true);
+				} else {
+					return this._read(keyReads,options, currentScopeOnly);
+				}
+			},
+			// ## Scope.prototype._read
+			// 
+			_read: function(keyReads, options, currentScopeOnly){
 
+				// The current scope and context we are trying to find "keyReads" within.
+				var currentScope = this,
+					currentContext,
+
+				// If no value can be found, this is a list of of every observed
+				// object and property name to observe.
+					undefinedObserves = [],
+					
+				// Tracks the first found observe.
+					currentObserve,
+				// Tracks the reads to get the value from `currentObserve`.
+					currentReads,
+
+				// Tracks the most likely observable to use as a setter.
+					setObserveDepth = -1,
+					currentSetReads,
+					currentSetObserve,
+					
+					readOptions = can.simpleExtend({
+						/* Store found observable, incase we want to set it as the rootObserve. */
+						foundObservable: function (observe, nameIndex) {
+							currentObserve = observe;
+							currentReads = keyReads.slice(nameIndex);
+						},
+						earlyExit: function (parentValue, nameIndex) {
+							if (nameIndex > setObserveDepth) {
+								currentSetObserve = currentObserve;
+								currentSetReads = currentReads;
+								setObserveDepth = nameIndex;
+							}
+						}
+					}, options);
+
+				// Goes through each scope context provided until it finds the key (attr).  Once the key is found
+				// then it's value is returned along with an observe, the current scope and reads.
+				// While going through each scope context searching for the key, each observable found is returned and
+				// saved so that either the observable the key is found in can be returned, or in the case the key is not
+				// found in an observable the closest observable can be returned.
+
+				while (currentScope) {
+					currentContext = currentScope._context;
+
+					
+					
+					if ( currentContext !== null &&
+						// if its a primitive type, keep looking up the scope, since there won't be any properties
+						(typeof currentContext === "object" || typeof currentContext === "function")
+						) {
+
+						// Prevent computes from temporarily observing the reading of observables.
+						var getObserves = can.__trapObserves();
+						
+						var data = can.compute.read(currentContext, keyReads, readOptions);
+						
+						// Retrieve the observes that were read.
+						var observes = getObserves();
+						// If a **value was was found**, return value and location data.
+						if (data.value !== undefined) {
+							can.__observes(observes);
+							return {
+								scope: currentScope,
+								rootObserve: currentObserve,
+								value: data.value,
+								reads: currentReads
+							};
+						}
+						// Otherwise, save all observables that were read.  If no value
+						// is found, we will observe on all of them.
+						else {
+							undefinedObserves.push.apply(undefinedObserves, observes);
+						}
+					}
+
+					// 
+					if(currentScopeOnly) {
+						currentScope = null;
+					} else {
+						// Move up to the next scope.
+						currentScope = currentScope._parent;
+					}
+				}
+
+				// The **value was not found**, return `undefined` for the value.
+				// Make sure we listen to everything we checked for when the value becomes defined.
+				// Once it becomes defined, we won't have to listen to so many things.
+				can.__observes(undefinedObserves);
+				return {
+					setRoot: currentSetObserve,
+					reads: currentSetReads,
+					value: undefined
+				};
+			},
+			
+			// ## Scope.prototype.get
+			// Gets a value from the scope without being observable.
+			get: can.__notObserve(function (key, options) {
+				
+				options = can.simpleExtend({
+					isArgument: true
+				}, options);
+				
+				var res = this.read(key, options);
+				return res.value;
+			}),
+			// ## Scope.prototype.getScope
+			// Returns the first scope that passes the `tester` function.
+			getScope: function(tester){
+				var scope = this;
+				while (scope) {
+					if(tester(scope)) {
+						return scope;
+					}
+					scope = scope._parent;
+				}
+			},
+			// ## Scope.prototype.getContext
+			// Returns the first context whose scope passes the `tester` function.
+			getContext: function(tester){
+				var res = this.getScope(tester);
+				return res && res._context;
+			},
+			// ## Scope.prototype.getRefs
+			// Returns the first references scope.
+			// Used by `.read` when looking up `*key` and by the references
+			// view binding.
+			getRefs: function(){
+				return this.getScope(function(scope){
+					return scope._context  instanceof Scope.Refs;
+				});
+			},
+			// ## Scope.prototype.getRoot
+			// Returns the top most context that is not a references scope.
+			// Used by `.read` to provide `%root`.
+			getRoot: function(){
+				var cur = this,
+					child = this;
+					
+				while(cur._parent) {
+					child = cur;
+					cur = cur._parent;
+				}
+
+				if(cur._context instanceof Scope.Refs) {
+					cur = child;
+				}
+				return cur._context;
+			},
+			
+			
+			// ## Scope.prototype.attr
+			// Gets or sets a value in the scope without being observable.
+			attr: can.__notObserve(function (key, value, options) {
+				
+				
+				options = can.simpleExtend({
+					isArgument: true
+				}, options);
+
+				// Allow setting a value on the context
+				if(arguments.length === 2) {
+					var lastIndex = key.lastIndexOf('.'),
+						// Either get the paren of a key or the current context object with `.`
+						readKey = lastIndex !== -1 ? key.substring(0, lastIndex) : '.',
+						obj = this.read(readKey, options).value;
+
+					if(lastIndex !== -1) {
+						// Get the last part of the key which is what we want to set
+						key = key.substring(lastIndex + 1, key.length);
+					}
+
+					can.compute.set(obj, key, value, options);
+				} else {
+					return this.get(key, options);
+				}
+				
+			}),
+
+			
+
+			// ## Scope.prototype.computeData
+			// Finds the first location of the key in the scope and then provides a get-set compute that represents the key's value
+			// and other information about where the value was found.
+			computeData: function (key, options) {
+				return makeComputeData(this, key, options);
+			},
+
+			// ## Scope.prototype.compute
+			// Provides a get-set compute that represents a key's value.
+			compute: function (key, options) {
+				return this.computeData(key, options)
+					.compute;
+			},
+			// ## Scope.prototype.cloneFromRef
+			// 
+			// This takes a scope and essentially copies its chain from
+			// right before the last Refs.  And it does not include the ref.
+			// this is a helper function to provide lexical semantics for refs.
+			// This will not be needed for leakScope: false.
+			cloneFromRef: function(){
+				var contexts = [];
+				var scope = this,
+					context,
+					parent;
+				while (scope) {
+					context = scope._context;
+					if(context instanceof Scope.Refs) {
+						parent = scope._parent;
+						break;
+					}
+					contexts.push(context);
+					scope = scope._parent;
+				}
+				if(parent) {
+					can.each(contexts, function(context){
+						parent = parent.add(context);
+					});
+					return parent;
+				} else {
+					return this;
+				}
+			}
+		});
+		
 		can.view.Scope = Scope;
+		
+		function Options(data, parent, meta){
+			if (!data.helpers && !data.partials && !data.tags) {
+				data = {
+					helpers: data
+				};
+			}
+			Scope.call(this, data, parent, meta);
+		}
+		Options.prototype = new Scope();
+		Options.prototype.constructor = Options;
+		
+		can.view.Options = Options;
+		
 		return Scope;
 	});

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -4557,6 +4557,13 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can/view/stache", "can/v
 			
 		});
 
+		test("checked as a custom attribute", function(){
+			var map = new can.Map({
+				preview: true
+			});
+			var frag = can.stache("<div {{#if preview}}checked{{/if}}></div>")(map);
+			equal(frag.firstChild.getAttribute("checked"), "", "got attribute");
+		});
 		// PUT NEW TESTS RIGHT BEFORE THIS!
 	}
 

--- a/view/stache/text_section.js
+++ b/view/stache/text_section.js
@@ -35,7 +35,6 @@ steal("can/util", "can/view/live","./utils.js", "./live_attr.js", function(can, 
 				
 				compute.computeInstance.bind("change", can.k);
 				var value = compute();
-				
 				if( compute.computeInstance.hasDependencies ) {
 					if(state.attr) {
 						live.simpleAttribute(this, state.attr, compute);

--- a/view/stache/utils.js
+++ b/view/stache/utils.js
@@ -8,16 +8,7 @@ steal("can/util", "can/view/scope",function(can){
 		 * @hide
 		 * The Options scope.
 		 */
-	var Options = can.view.Scope.extend({
-		init: function (data, parent) {
-			if (!data.helpers && !data.partials && !data.tags) {
-				data = {
-					helpers: data
-				};
-			}
-			can.view.Scope.prototype.init.apply(this, arguments);
-		}
-	});
+	var Options = can.view.Options;
 	
 	return {
 		// Returns if something looks like an array.  This works for can.List

--- a/view/target/target.js
+++ b/view/target/target.js
@@ -41,19 +41,8 @@ steal("can/util", "can/view/elements.js",function(can, elements, vdom){
 			return clone.innerHTML === "<xyz></xyz>";
 		})(),
 		namespacesWork = typeof document !== "undefined" && !!document.createElementNS,
-		// A dummy element we use for creating non-standard attribute names (e.g. containing () and [])
-		attributeDummy = typeof document !== "undefined" ? document.createElement('div') : null,
 		// Sets the attribute on an element. Uses a hack when setAttribute complains
-		setAttribute = function(el, attrName, value) {
-			try {
-				el.setAttribute(attrName, value);
-			} catch(e) {
-				// We got an error. Set innerHTML with the non-standard attribute and clone
-				// that attribute node
-				attributeDummy.innerHTML = '<div ' + attrName + '="' + value + '"></div>';
-				el.setAttributeNode(attributeDummy.childNodes[0].attributes[0].cloneNode());
-			}
-		};
+		setAttribute = can.attr.setAttribute;
 
 	/**
 	 * @function cloneNode


### PR DESCRIPTION
For #2077.

This refactor removes all binding logic from can/component and puts it in can/view/bindings.

This was done by making `makeDataBinding` able to get the `viewModel` mid-way through its processing.

The other big refactor was to create (and test) a `getBindingInfo` function.  If you give it an attribute node, it will tell you everything about the binding behavior:

```js
// Testing the old mustache behavior
var info = can.bindings.getBindingInfo({name: "foo", value: "bar"},{foo: "@"},"legacy");
deepEqual(info,{
	parent: "attribute",
	child: "viewModel",
	parentToChild: true,
	childToParent: true,
	childName: "foo",
	parentName: "foo",
	bindingAttributeName: "foo"
}, "legacy with @");
```

There's still a potential memory leak as non-viewModel bindings aren't tearing themselves down.  I'm probably going to make `makeDataBinding` always return a "post view model" continuation regardless if there's a viewModel needed or not.

However, I do want to make sure that we aren't creating a view model with `{($value)}="name"`.  