### PR TITLE
Allows function bindings again

### DIFF
--- a/component/examples/name_editor.html
+++ b/component/examples/name_editor.html
@@ -5,45 +5,36 @@
 
 
 <script type='text/mustache' id='app-template'>
-<h1>{{#me}}{{first}} {{last}}{{/me}}</h1>
-<name-editor first="me.first" last="me.last">
-	Editing {{honorific}}
-</name-editor>
+<foo-bar {foo}="foo" {bar}="bar"></foo-bar>
 </script>
 <script type='text/javascript'> 
-steal("can/component", function() {
+steal("can/component", "can/map/define","can/view/stache"
+	,function() {
 
-	can.Component.extend({
-		tag: "name-editor",
-		viewModel: {
-			firstPH: "first",
-			lastPH: "last",
-			honorific: function(){
-				if( this.attr('first') == "Justin" ) {
-					return "Mr."
-				} else {
-					return "Mrs."
+		can.Component.extend({
+			tag : 'foo-bar',
+			leakScope : false,
+			viewModel : {
+				define : {
+					foo : {
+						set : function(newVal) {
+							console.log('foo set to ' + newVal);
+						}
+					},
+					bar : {
+						set : function(newVal) {
+							console.log('bar set to ' + newVal);
+						}
+					}
 				}
 			}
-		},
-		template: 
-			"<form><content/>"+
-				"<input can-value='first'/>"+
-				"<input can-value='last'/>"+
-			"</form>"	
+		});
+
+		var vm = new can.Map({
+			bar : 'test'
+		});
+
+		$('#out').html(can.view('app-template')(vm));
 	});
-
-	var me = new can.Map({
-		first: "Justin",
-		last: "Meyer"
-	})
-
-    $("#out").html(can.view("app-template",{
-    	me: new can.Map({
-			first: "Justin",
-			last: "Meyer"
-		})
-    }))
-})
 </script>
 </body>

--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -445,10 +445,11 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 		// Returns a compute that's two-way bound to the `viewModel` returned by 
 		// `options.getViewModel()`.
 		viewModel: function(el, scope, vmName, options) {
+			var setName = vmName.replace(/@/g,"");
 			return can.compute(function(newVal){
 				var viewModel = options.getViewModel();
 				if(arguments.length) {
-					viewModel.attr(vmName,newVal);
+					viewModel.attr(setName,newVal);
 				} else {
 					return vmName === "." ? viewModel : can.compute.read(viewModel, can.compute.read.reads(vmName), {}).value;
 				}

--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -56,14 +56,15 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 					getViewModel: function(){
 						return viewModel;
 					},
-					attributeViewModelBindings: attributeViewModelBindings
+					attributeViewModelBindings: attributeViewModelBindings,
+					alreadyUpdatedChild: true
 				});
 				if(dataBinding) {
 					// For bindings that change the viewModel,
 					if(dataBinding.onCompleteBinding) {
 						// save the initial value on the viewModel.
 						if(dataBinding.bindingInfo.parentToChild && dataBinding.value !== undefined) {
-							initialViewModelData[dataBinding.bindingInfo.childName] = dataBinding.value;
+							initialViewModelData[cleanVMName(dataBinding.bindingInfo.childName)] = dataBinding.value;
 						}
 						// Save what needs to happen after the `viewModel` is created.
 						onCompleteBindings.push(dataBinding.onCompleteBinding);
@@ -337,7 +338,7 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 	
 			if (el.nodeName.toLowerCase() === "input" && ( el.type === "checkbox" || el.type === "radio" ) ) {
 	
-				var property = getComputeFrom.scope(el, data.scope, attrValue, {});
+				var property = getComputeFrom.scope(el, data.scope, attrValue, {}, true);
 				if (el.type === "checkbox") {
 	
 					var trueValue = can.attr.has(el, "can-true-value") ? el.getAttribute("can-true-value") : true,
@@ -432,33 +433,47 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 	var getComputeFrom = {
 		// ### getComputeFrom.scope
 		// Returns a compute from the scope.  This handles expressions like `someMethod(.,1)`.
-		scope: function(el, scope, scopeProp, options){
+		scope: function(el, scope, scopeProp, bindingData, mustBeACompute){
 			if(!scopeProp) {
 				return can.compute();
 			} else {
-				var parentExpression = expression.parse(scopeProp,{baseMethodType: "Call"});
-				return parentExpression.value(scope, new can.view.Options({}));
+				if(mustBeACompute) {
+					var parentExpression = expression.parse(scopeProp,{baseMethodType: "Call"});
+					return parentExpression.value(scope, new can.view.Options({}));
+				} else {
+					return function(newVal){
+						scope.attr(cleanVMName(scopeProp), newVal);
+					};
+				}
+				
 			}
 			
 		},
 		// ### getComputeFrom.viewModel
 		// Returns a compute that's two-way bound to the `viewModel` returned by 
 		// `options.getViewModel()`.
-		viewModel: function(el, scope, vmName, options) {
-			var setName = vmName.replace(/@/g,"");
-			return can.compute(function(newVal){
-				var viewModel = options.getViewModel();
-				if(arguments.length) {
-					viewModel.attr(setName,newVal);
-				} else {
-					return vmName === "." ? viewModel : can.compute.read(viewModel, can.compute.read.reads(vmName), {}).value;
-				}
-				
-			});
+		viewModel: function(el, scope, vmName, bindingData, mustBeACompute) {
+			var setName = cleanVMName(vmName);
+			if(mustBeACompute) {
+				return can.compute(function(newVal){
+					var viewModel = bindingData.getViewModel();
+					if(arguments.length) {
+						viewModel.attr(setName,newVal);
+					} else {
+						return vmName === "." ? viewModel : can.compute.read(viewModel, can.compute.read.reads(vmName), {}).value;
+					}
+				});
+			} else {
+				return function(newVal){
+					bindingData.getViewModel().attr(setName,newVal);
+				};
+			}
+			
+			
 		},
 		// ### getComputeFrom.attribute
 		// Returns a compute that is two-way bound to an attribute or property on the element.
-		attribute: function(el, scope, prop, options, event){
+		attribute: function(el, scope, prop, bindingData, mustBeACompute, event){
 			// Determine the event or events we need to listen to 
 			// when this value changes.
 			if(!event) {
@@ -517,7 +532,7 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 							}
 						});
 					} else {
-						if(!options.legacyBindings && hasChildren && ("selectedIndex" in el)) {
+						if(!bindingData.legacyBindings && hasChildren && ("selectedIndex" in el)) {
 							el.selectedIndex = -1;
 						}
 						can.attr.setAttrOrProp(el, prop, newVal == null ? "" : newVal);
@@ -764,15 +779,23 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 		if(!bindingInfo) {
 			return;
 		}
-		// Get computes for the parent and child binding
-		var parentCompute = getComputeFrom[bindingInfo.parent](el, bindingData.scope, bindingInfo.parentName, bindingData);
-		var childCompute = getComputeFrom[bindingInfo.child](el, bindingData.scope, bindingInfo.childName, bindingData);
-		var updateParent;
+		// assign some bindingData props to the bindingInfo
+		bindingInfo.alreadyUpdatedChild = bindingData.alreadyUpdatedChild;
+		if( bindingData.initializeValues) {
+			bindingInfo.initializeValues = true;
+		}
 		
+		// Get computes for the parent and child binding
+		var parentCompute = getComputeFrom[bindingInfo.parent](el, bindingData.scope, bindingInfo.parentName, bindingData, bindingInfo.parentToChild),
+			childCompute = getComputeFrom[bindingInfo.child](el, bindingData.scope, bindingInfo.childName, bindingData, bindingInfo.childToParent),
+			
+			// these are the functions bound to one compute that update the other.
+			updateParent,
+			updateChild;
 		
 		// Only bind to the parent if it will update the child.
 		if(bindingInfo.parentToChild){
-			var updateChild = bind.parentToChild(el, parentCompute, childCompute, bindingData.semaphore, bindingInfo.bindingAttributeName);
+			updateChild = bind.parentToChild(el, parentCompute, childCompute, bindingData.semaphore, bindingInfo.bindingAttributeName);
 		}
 		
 		// This completes the binding.  We can't call it right away because
@@ -783,7 +806,7 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 				updateParent = bind.childToParent(el, parentCompute, childCompute, bindingData.semaphore, bindingInfo.bindingAttributeName,
 					bindingData.syncChildWithParent);
 			}
-			if(bindingData.initializeValues || bindingInfo.initializeValues) {
+			if(bindingInfo.initializeValues) {
 				initializeValues(bindingInfo, childCompute, parentCompute, updateChild, updateParent);
 			}
 			
@@ -816,23 +839,29 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 	// ## initializeValues
 	// Updates the parent or child value depending on the direction of the binding
 	// or if the child or parent is `undefined`.
-	var initializeValues = function(options, childCompute, parentCompute, updateChild, updateParent){
-
-		if(options.parentToChild && !options.childToParent) {
-			updateChild({}, getValue(parentCompute) );
+	var initializeValues = function(bindingInfo, childCompute, parentCompute, updateChild, updateParent){
+		var doUpdateParent = false;
+		if(bindingInfo.parentToChild && !bindingInfo.childToParent) {
+			// updateChild
 		}
-		else if(!options.parentToChild && options.childToParent) {
-			updateParent({}, getValue(childCompute) );
+		else if(!bindingInfo.parentToChild && bindingInfo.childToParent) {
+			doUpdateParent = true;
 		}
 		// Two way
 		// Update child or parent depending on who has a value.
 		// If both have a value, update the child.
 		else if( getValue(childCompute) === undefined) {
-			updateChild({}, getValue(parentCompute) );
+			// updateChild
 		} else if(getValue(parentCompute) === undefined) {
+			doUpdateParent = true;
+		}
+		
+		if(doUpdateParent) {
 			updateParent({}, getValue(childCompute) );
 		} else {
-			updateChild({}, getValue(parentCompute) );
+			if(!bindingInfo.alreadyUpdatedChild) {
+				updateChild({}, getValue(parentCompute) );
+			}
 		}
 	};
 	
@@ -889,6 +918,9 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 			if(compute && compute.isComputed && typeof updateOther === "function") {
 				compute.unbind("change", updateOther);
 			}
+		},
+		cleanVMName = function(name){
+			return name.replace(/@/g,"");
 		};
 
 	

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -1798,5 +1798,36 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		},10);
 
 	});
+	
+	test("@function reference to child (#2116)", function(){
+		expect(2);
+		var template = can.stache('<foo-bar {@child}="@parent"></foo-bar>');
+		can.Component.extend({
+			tag : 'foo-bar',
+			viewModel : {
+				method: function(){
+					ok(false, "should not be called");
+				}
+			}
+		});
+
+		var VM = can.Map.extend({
+			parent : function() {
+				ok(false, "should not be called");
+			}
+		});
+
+		var vm = new VM({});
+		var frag = template(vm);
+
+		ok( typeof can.viewModel(frag.firstChild).attr("child") === "function", "to child binding");
+		
+		
+		template = can.stache('<foo-bar {^@method}="@vmMethod"></foo-bar>');
+		vm = new VM({});
+		template(vm);
+		
+		ok(typeof vm.attr("vmMethod") === "function", "parent export function");
+	});
 
 });

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -1820,7 +1820,7 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		var vm = new VM({});
 		var frag = template(vm);
 
-		ok( typeof can.viewModel(frag.firstChild).attr("child") === "function", "to child binding");
+		equal( typeof can.viewModel(frag.firstChild).attr("child"), "function", "to child binding");
 		
 		
 		template = can.stache('<foo-bar {^@method}="@vmMethod"></foo-bar>');
@@ -1828,6 +1828,60 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		template(vm);
 		
 		ok(typeof vm.attr("vmMethod") === "function", "parent export function");
+	});
+	
+	test("setter only gets called once (#2117)", function(){
+		expect(1);
+		var VM = can.Map.extend({
+			_set: function(prop, val){
+				if(prop === "bar") {
+					equal(val, "BAR");
+				}
+				return can.Map.prototype._set.apply(this, arguments);
+			}
+		});
+		
+		can.Component.extend({
+			tag : 'foo-bar',
+			viewModel : VM
+		});
+		
+		var template = can.stache('<foo-bar {bar}="bar"/>');
+		
+		template(new can.Map({bar: "BAR"}));
+		
+	});
+	
+	test("function reference to child binding (#2116)", function(){
+		expect(2);
+		var template = can.stache('<foo-bar {child}="@parent"></foo-bar>');
+		can.Component.extend({
+			tag : 'foo-bar',
+			viewModel : {
+				
+			}
+		});
+
+		var VM = can.Map.extend({
+		});
+
+		var vm = new VM({});
+		var frag = template(vm);
+		
+		vm.attr("parent", function(){ ok(false, "should not be called"); });
+
+		equal( typeof can.viewModel(frag.firstChild).attr("child"), "function", "to child binding");
+		
+		
+		template = can.stache('<foo-bar {^@method}="vmMethod"></foo-bar>');
+		vm = new VM({});
+		frag = template(vm);
+		
+		can.viewModel(frag.firstChild).attr("method",function(){
+			ok(false, "method should not be called");
+		});
+		
+		equal(typeof vm.attr("vmMethod"), "function", "parent export function");
 	});
 
 });

--- a/view/scope/scope.js
+++ b/view/scope/scope.js
@@ -321,8 +321,12 @@ steal(
 						// Get the last part of the key which is what we want to set
 						key = key.substring(lastIndex + 1, key.length);
 					}
-
-					can.compute.set(obj, key, value, options);
+					if(key.charAt(0) === "*") {
+						can.compute.set(this.getRefs()._context, key, value, options);
+					} else {
+						can.compute.set(obj, key, value, options);
+					}
+					
 				} else {
 					return this.get(key, options);
 				}


### PR DESCRIPTION
fixes #2116.  It's currently required to use `@` on both sides of a function binding.  However, this makes it work by removing `@` characters when setting a view model.