### PR TITLE
Fixes problem with @index

### DIFF
--- a/component/component_test.js
+++ b/component/component_test.js
@@ -1531,6 +1531,38 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can", "can/map/define", 
 			});
 		});
 		
+		test("wrong context inside <content> tags (#2092)", function(){
+
+			can.Component.extend({
+				tag: 'some-context',
+				viewModel: {
+					items: [{value: "A", name: "X"}, {value: "B", name: "Y"}]
+				},
+				template: can.stache("{{#each items}}<content><span>{{name}}</span></content>{{/each}}")
+			});
+			
+			var templateA = can.stache("<some-context><span>{{value}}</span></some-context>");
+			
+			var frag = templateA({});
+			
+			var spans = frag.firstChild.getElementsByTagName("span");
+			
+			equal(spans[0].firstChild.nodeValue, "A", "context is right");
+			equal(spans[1].firstChild.nodeValue, "B", "context is right");
+			
+			var templateB = can.stache("<some-context/>");
+			
+			frag = templateB({});
+			
+			spans = frag.firstChild.getElementsByTagName("span");
+			
+			equal(spans[0].firstChild.nodeValue, "X", "context is right X");
+			equal(spans[1].firstChild.nodeValue, "Y", "context is right");
+			
+		});
+		
+		
+		
 		// PUT NEW TESTS ABOVE THIS LINE
 	}
 

--- a/component/component_test.js
+++ b/component/component_test.js
@@ -1536,6 +1536,7 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can", "can/map/define", 
 			can.Component.extend({
 				tag: 'some-context',
 				viewModel: {
+					value: "WRONG",
 					items: [{value: "A", name: "X"}, {value: "B", name: "Y"}]
 				},
 				template: can.stache("{{#each items}}<content><span>{{name}}</span></content>{{/each}}")

--- a/compute/read.js
+++ b/compute/read.js
@@ -211,7 +211,7 @@ steal("can/util", function(can){
 			read: function(value, prop){
 				if(value == null) {
 					return undefined;
-				} else {					
+				} else {
 					if(prop.key in value) {
 						return value[prop.key];
 					}

--- a/compute/read.js
+++ b/compute/read.js
@@ -92,6 +92,7 @@ steal("can/util", function(can){
 		
 		return value;
 	};
+	
 	// value readers check the current value
 	// and get a new value from it
 	// ideally they would keep calling until 
@@ -210,7 +211,7 @@ steal("can/util", function(can){
 			read: function(value, prop){
 				if(value == null) {
 					return undefined;
-				} else {
+				} else {					
 					if(prop.key in value) {
 						return value[prop.key];
 					}
@@ -220,6 +221,8 @@ steal("can/util", function(can){
 						can.dev.warn("Use %"+prop.key+" in place of @"+prop.key+".");
 						
 						//!steal-remove-end
+						
+						prop.at = false;
 						return value["@"+prop.key];
 					}
 					

--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -478,13 +478,14 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 				isStringValue,
 				lastSet,
 				scheduledAsyncSet = false,
+				timer,
 				// Sets the element property or attribute.
 				set = function(newVal){
 					// Templates write parent's out before children.  This should probably change.
 					// But it means we don't do a set immediately.
 					if(hasChildren && !scheduledAsyncSet) {
-						scheduledAsyncSet = true;
-						setTimeout(function(){
+						clearTimeout(timer);
+						timer = setTimeout(function(){
 							set(newVal);
 						},1);
 					}

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -1770,7 +1770,7 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 	
 	test("dynamic attribute bindings (#2016)", function(){
 
-		var template = can.view.stache("<input {($value)}='{{propName}}'/>");
+		var template = can.stache("<input {($value)}='{{propName}}'/>");
 
 		var map = new can.Map({propName: 'first', first: "Justin", last: "Meyer"});
 
@@ -1797,6 +1797,64 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 			start();
 		},10);
 
+	});
+	
+	test("select bindings respond to changes immediately or during insert (#2134)", function(){
+		var countries = [{code: 'MX', countryName:'MEXICO'},
+			{code: 'US', countryName:'USA'},
+			{code: 'IND', countryName:'INDIA'},
+			{code: 'RUS', countryName:'RUSSIA'}
+		];
+		
+		var template = can.stache('<select {($value)}="countryCode">'+
+			'{{#each countries}}'+
+				'<option value="{{code}}">{{countryName}}</option>'+
+			'{{/each}}'+
+		'</select>');
+		
+		var data = new can.Map({
+			countryCode: 'US',
+			countries: countries
+		});
+		
+		var frag = template(data);
+		data.attr('countryCode', 'IND');
+		
+		stop();
+		setTimeout(function(){
+			start();
+			equal(frag.firstChild.value, "IND", "got last updated value");
+		},10);
+		
+	});
+	
+	test("select bindings respond to changes immediately or during insert using can-value (#2134)", function(){
+		var countries = [{code: 'MX', countryName:'MEXICO'},
+			{code: 'US', countryName:'USA'},
+			{code: 'IND', countryName:'INDIA'},
+			{code: 'RUS', countryName:'RUSSIA'}
+		];
+		
+		var template = can.stache('<select can-value="{countryCode}">'+
+			'{{#each countries}}'+
+				'<option value="{{code}}">{{countryName}}</option>'+
+			'{{/each}}'+
+		'</select>');
+		
+		var data = new can.Map({
+			countryCode: 'US',
+			countries: countries
+		});
+		
+		var frag = template(data);
+		data.attr('countryCode', 'IND');
+		
+		stop();
+		setTimeout(function(){
+			start();
+			equal(frag.firstChild.value, "IND", "got last updated value");
+		},10);
+		
 	});
 
 });

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -1856,5 +1856,45 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		},10);
 		
 	});
+	
+	test("select bindings work if options are replaced (#1762)", function(){
+		var countries = [{code: 'MX', countryName:'MEXICO'},
+			{code: 'US', countryName:'USA'}
+		];
+		
+		var data = new can.Map({
+			countryCode: 'US',
+			countries: countries
+		});
+		data.bind("countryCode", function(ev, newVal){
+			ok(false, "countryCode changed to "+newVal);
+		});
+		
+		var template = can.stache('<select {($value)}="countryCode">'+
+			'{{#countries}}'+
+				'<option value="{{code}}">{{countryName}}</option>'+
+			'{{/countries}}'+
+		'</select>');
+		
+		var frag = template(data);
+		stop();
+		setTimeout(function(){
+			data.attr("countries").replace([
+				{code: 'IND', countryName:'INDIA'},
+				{code: 'RUS', countryName:'RUSSIA'},
+				{code: 'US', countryName:'USA'}
+			]);
+			
+			setTimeout(function(){
+				equal(data.attr("countryCode"), "US", "country set to USA");
+				
+				start();
+			},10);
+			
+		},10);
+		
+		
+			
+	});
 
 });

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -1981,5 +1981,30 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		equal(typeof vm.attr("vmMethod"), "function", "parent export function");
 
 	});
+	
+	test("backtrack path in to-parent bindings (#2132)", function(){
+		can.Component.extend({
+			tag: "parent-export",
+			viewModel: {
+				value: "VALUE"
+			}
+		});
+		
+		var template = can.stache("{{#innerMap}}<parent-export {^value}='../parentValue'/>{{/innerMap}}");
+		
+		var data = new can.Map({
+			innerMap: {}
+		});
+		
+		template(data);
+		
+		equal(data.attr("parentValue"), "VALUE", "set on correct context");
+		equal(data.attr("innerMap.parentValue"), undefined, "nothing on innerMap");
+		
+	});
+	
+	
+	
+	
 
 });

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -1876,7 +1876,7 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 			'{{/countries}}'+
 		'</select>');
 		
-		var frag = template(data);
+		template(data);
 		stop();
 		setTimeout(function(){
 			data.attr("countries").replace([

--- a/view/scope/scope.js
+++ b/view/scope/scope.js
@@ -361,7 +361,7 @@ steal(
 						parent = scope._parent;
 						break;
 					}
-					contexts.push(context);
+					contexts.unshift(context);
 					scope = scope._parent;
 				}
 				if(parent) {

--- a/view/scope/scope_test.js
+++ b/view/scope/scope_test.js
@@ -403,4 +403,17 @@ steal("can/view/scope", "can/route", "can/test", "steal-qunit", function () {
 		equal(root, map, "The root is the map passed into the scope");
 	});
 
+	test("can set scope attributes with ../ (#2132)", function(){
+		
+		var map = new can.Map();
+		var scope = new can.view.Scope(map);
+		var top = scope.add(new can.Map());
+		
+		top.attr("../foo", "bar");
+		
+		equal(map.attr("foo"), "bar");
+		
+	});
+
+
 });

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -4609,6 +4609,21 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can/view/stache", "can/v
 			var frag = template({foo: true});
 			equal(frag.firstChild.getAttribute("disabled"),"","disabled set");
 		});
+		
+
+		test("keep @index working with multi-dimensional arrays (#2127)", function() {
+			var data = new can.Map({
+				array2 : [['asd'], ['sdf']]
+			});
+			
+			var template = can.stache('<div>{{#each array2}}<span>{{@index}}</span>{{/each}}</div>');
+			
+			var frag = template(data);
+			
+			var spans = frag.firstChild.getElementsByTagName("span");
+			equal( spans[0].firstChild.nodeValue, "0");
+		}); 
+
 		// PUT NEW TESTS RIGHT BEFORE THIS!
 	}
 

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -4622,7 +4622,7 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can/view/stache", "can/v
 			
 			var spans = frag.firstChild.getElementsByTagName("span");
 			equal( spans[0].firstChild.nodeValue, "0");
-		}); 
+		});
 
 		// PUT NEW TESTS RIGHT BEFORE THIS!
 	}


### PR DESCRIPTION
Fixes #2127.  This changes the key info data for `"@index"` from `{at: true, key: "index"}` to `{at: false, key: "index"}` only if there's actually a "@index" property.  

This makes it so if there's a compute or function value, it will be properly read.