### PR TITLE
Firefox debugging functions conflicting with can.Map

### DIFF
--- a/map/map.js
+++ b/map/map.js
@@ -252,9 +252,9 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 			// property is represented by a computed attribute, return the value of that compute.  
 			// If no argument is provided, return the raw data.
 			___get: function (attr) {
-				var computedAttr = this._computedAttrs[attr];
 				if (attr) {
-					if (this.___isComputedAttr(attr)) {
+					var computedAttr = this._computedAttrs[attr];
+					if (computedAttr && computedAttr.compute) {
 						return computedAttr.compute();
 					} else {
 						return this._data[attr];
@@ -262,17 +262,6 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 				} else {
 					return this._data;
 				}
-			},
-
-			___isComputedAttr: function (attr) {
-				var computedAttrs = this._computedAttrs;
-				var result = computedAttrs[attr] || false;
-				if (Object.prototype.watch || Object.prototype.unwatch) {
-					if (attr === 'watch' || attr === 'unwatch') {
-						result = computedAttrs.hasOwnProperty(attr);
-					}
-				}
-				return result;
 			},
 
 			// ### _set

--- a/map/map.js
+++ b/map/map.js
@@ -252,9 +252,9 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 			// property is represented by a computed attribute, return the value of that compute.  
 			// If no argument is provided, return the raw data.
 			___get: function (attr) {
+				var computedAttr = this._computedAttrs[attr];
 				if (attr) {
-					var computedAttr = this._computedAttrs[attr];
-					if (computedAttr) {
+					if (this.___isComputedAttr(attr)) {
 						return computedAttr.compute();
 					} else {
 						return this._data[attr];
@@ -262,6 +262,17 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 				} else {
 					return this._data;
 				}
+			},
+
+			___isComputedAttr: function (attr) {
+				var computedAttrs = this._computedAttrs;
+				var result = computedAttrs[attr] || false;
+				if (Object.prototype.watch || Object.prototype.unwatch) {
+					if (attr === 'watch' || attr === 'unwatch') {
+						result = computedAttrs.hasOwnProperty(attr);
+					}
+				}
+				return result;
 			},
 
 			// ### _set

--- a/map/map_test.js
+++ b/map/map_test.js
@@ -303,6 +303,18 @@ steal("can/map", "can/compute", "can/test", "can/list", "steal-qunit", function(
 
 		equal(map._bindings, 1, 'The number of bindings is still correct');
 	});
+	
+	test("Should be able to get and set attribute named 'watch' on can.Map in Firefox", function() {
+		var map = new can.Map({});
+		map.attr("watch");
+		ok(true, "can have attribute named 'watch' on a can.Map instance");
+	});
+
+	test("Should be able to get and set attribute named 'unwatch' on can.Map in Firefox", function() {
+		var map = new can.Map({});
+		map.attr("unwatch");
+		ok(true, "can have attribute named 'unwatch' on a can.Map instance");
+	});
 
 	test('Creating map in compute dispatches all events properly', function() {
 		expect(2);


### PR DESCRIPTION
Gecko exposes methods named "watch" and "unwatch" on Object.prototype. If a can.Map doesn't define these attributes, the ___get method in map.js incorrectly treats these as computed attributes. Fix it by ignoring these properties before invoking the compute function on the attribute.

Fixes #2069