### PR TITLE
changes the behavior of ""  to makes things consistent

### DIFF
--- a/util/attr/attr.js
+++ b/util/attr/attr.js
@@ -102,6 +102,20 @@ steal("can/util/can.js", function (can) {
 					this.set(el, attrName, val);
 				}
 			},
+			setSelectValue: function(el, val) {
+				// jshint eqeqeq: false
+				if(val != null) {
+					var options = el.getElementsByTagName('option');
+					for(var i  = 0; i < options.length; i++) {
+						if(val == options[i].value) {
+							options[i].selected = true;
+							return;
+						}
+					}
+				}
+				
+				el.selectedIndex = -1;
+			},
 			// ## attr.set
 			// Set the value an attribute on an element.
 			set: function (el, attrName, val) {

--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -590,7 +590,7 @@ steal("can/util",
 						can.bind.call(el,eventName, updater);
 					});
 					if(hasChildren) {
-						var onMuataion = function (mutations) {
+						var onMutation = function (mutations) {
 							if(stickyCompute) {
 								set(stickyCompute());
 							} else {
@@ -600,14 +600,14 @@ steal("can/util",
 							}
 						};
 						if(can.attr.MutationObserver) {
-							observer = new can.attr.MutationObserver(onMuataion);
+							observer = new can.attr.MutationObserver(onMutation);
 							observer.observe(el, {
 								childList: true,
 								subtree: true
 							});
 						} else {
-							// TODO: Remove in 3.0.
-							can.data(can.$(el), "canBindingCallback", onMuataion);
+							// TODO: Remove in 3.0. Can't store a function b/c Zepto doesn't support it.
+							can.data(can.$(el), "canBindingCallback", {onMutation: onMutation});
 						}
 					}
 					
@@ -926,7 +926,7 @@ steal("can/util",
 		var updateSelectValue = function(el){
 			var bindingCallback = can.data(can.$(el),"canBindingCallback");
 			if(bindingCallback) {
-				bindingCallback(el);
+				bindingCallback.onMutation(el);
 			}
 		};
 		live.registerChildMutationCallback("select",updateSelectValue);

--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -533,10 +533,12 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 							}
 						});
 					} else {
-						if(!bindingData.legacyBindings && hasChildren && ("selectedIndex" in el)) {
-							el.selectedIndex = -1;
+						if(!bindingData.legacyBindings && hasChildren && ("selectedIndex" in el) && prop === "value" ) {
+							can.attr.setSelectValue(el, newVal);
+						} else {
+							can.attr.setAttrOrProp(el, prop, newVal == null ? "" : newVal);
 						}
-						can.attr.setAttrOrProp(el, prop, newVal == null ? "" : newVal);
+						
 					}
 					return newVal;
 	
@@ -555,6 +557,8 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 						});
 	
 						return isStringValue ? values.join(";"): values;
+					} else if(hasChildren && ("selectedIndex" in el) && el.selectedIndex === -1) {
+						return undefined;
 					}
 	
 					return can.attr.get(el, prop);
@@ -569,6 +573,9 @@ steal("can/util", "can/view/stache/expression.js", "can/view/callbacks", "can/co
 				setTimeout(function(){
 					scheduledAsyncSet = true;
 				},1);
+				// The following would allow a select's value
+				// to be undefined.
+				// el.selectedIndex = -1;
 			}
 	
 			return can.compute(get(),{

--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -922,7 +922,7 @@ steal("can/util",
 	// added or removed to a `<select>`.  If we don't have 
 	// MutationObserver, we need to setup can.view.live to
 	// callback when this happens.
-	if( can.attr.MutationObserver ) {
+	if( !can.attr.MutationObserver ) {
 		var updateSelectValue = function(el){
 			var bindingCallback = can.data(can.$(el),"canBindingCallback");
 			if(bindingCallback) {

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -1874,12 +1874,10 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 			'{{/countries}}'+
 		'</select>');
 		
-		var frag = template(data);
-		var select = frag.firstChild;
+		template(data);
+		
 		stop();
 		setTimeout(function(){
-			console.log("empting list",select.value, select.selectedIndex);
-			
 			data.attr("countries").replace([]);
 			
 		
@@ -1909,12 +1907,9 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 			'{{/each}}'+
 		'</select>');
 		
-		var frag = template(data);
-		var select = frag.firstChild;
+		template(data);
 		stop();
 		setTimeout(function(){
-			console.log("empting list",select.value, select.selectedIndex);
-			
 			data.attr("countries").replace([]);
 			
 		
@@ -1948,14 +1943,10 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		var select = frag.firstChild;
 		stop();
 		setTimeout(function(){
-			console.log("empting list",select.value, select.selectedIndex);
 			
 			data.attr("countries").replace([]);
 			
-			
-			console.log("emptied list",select.value, select.selectedIndex);
 			setTimeout(function(){
-				console.log("adding back",select.value, select.selectedIndex);
 				data.attr("countries").replace(countries);
 				
 				equal(data.attr("countryCode"), "US", "country kept as USA");
@@ -1991,14 +1982,10 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		var select = frag.firstChild;
 		stop();
 		setTimeout(function(){
-			console.log("empting list",select.value, select.selectedIndex);
 			
 			data.attr("countries").replace([]);
 			
-			
-			console.log("emptied list",select.value, select.selectedIndex);
 			setTimeout(function(){
-				console.log("adding back",select.value, select.selectedIndex);
 				data.attr("countries").replace(countries);
 				
 				equal(data.attr("countryCode"), "US", "country kept as USA");

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -1858,7 +1858,7 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		
 	});
 	
-	test("select bindings work if options are replaced (#1762)", function(){
+	test("two-way <select> bindings update to `undefined` if options are replaced (#1762)", function(){
 		var countries = [{code: 'MX', countryName:'MEXICO'},
 			{code: 'US', countryName:'USA'}
 		];
@@ -1867,9 +1867,6 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 			countryCode: 'US',
 			countries: countries
 		});
-		data.bind("countryCode", function(ev, newVal){
-			ok(false, "countryCode changed to "+newVal);
-		});
 		
 		var template = can.stache('<select {($value)}="countryCode">'+
 			'{{#countries}}'+
@@ -1877,17 +1874,17 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 			'{{/countries}}'+
 		'</select>');
 		
-		template(data);
+		var frag = template(data);
+		var select = frag.firstChild;
 		stop();
 		setTimeout(function(){
-			data.attr("countries").replace([
-				{code: 'IND', countryName:'INDIA'},
-				{code: 'RUS', countryName:'RUSSIA'},
-				{code: 'US', countryName:'USA'}
-			]);
+			console.log("empting list",select.value, select.selectedIndex);
 			
+			data.attr("countries").replace([]);
+			
+		
 			setTimeout(function(){
-				equal(data.attr("countryCode"), "US", "country set to USA");
+				equal(data.attr("countryCode"), undefined, "countryCode set to undefined");
 				
 				start();
 			},10);
@@ -1896,6 +1893,126 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		
 	});
 	
+	test("two-way <select> bindings update to `undefined` if options are replaced - each (#1762)", function(){
+		var countries = [{code: 'MX', countryName:'MEXICO'},
+			{code: 'US', countryName:'USA'}
+		];
+		
+		var data = new can.Map({
+			countryCode: 'US',
+			countries: countries
+		});
+		
+		var template = can.stache('<select {($value)}="countryCode">'+
+			'{{#each countries}}'+
+				'<option value="{{code}}">{{countryName}}</option>'+
+			'{{/each}}'+
+		'</select>');
+		
+		var frag = template(data);
+		var select = frag.firstChild;
+		stop();
+		setTimeout(function(){
+			console.log("empting list",select.value, select.selectedIndex);
+			
+			data.attr("countries").replace([]);
+			
+		
+			setTimeout(function(){
+				equal(data.attr("countryCode"), undefined, "countryCode set to undefined");
+				
+				start();
+			},10);
+			
+		},10);
+		
+	});
+	
+	test("one-way <select> bindings keep value if options are replaced (#1762)", function(){
+		var countries = [{code: 'MX', countryName:'MEXICO'},
+			{code: 'US', countryName:'USA'}
+		];
+		
+		var data = new can.Map({
+			countryCode: 'US',
+			countries: countries
+		});
+		
+		var template = can.stache('<select {$value}="countryCode">'+
+			'{{#countries}}'+
+				'<option value="{{code}}">{{countryName}}</option>'+
+			'{{/countries}}'+
+		'</select>');
+		
+		var frag = template(data);
+		var select = frag.firstChild;
+		stop();
+		setTimeout(function(){
+			console.log("empting list",select.value, select.selectedIndex);
+			
+			data.attr("countries").replace([]);
+			
+			
+			console.log("emptied list",select.value, select.selectedIndex);
+			setTimeout(function(){
+				console.log("adding back",select.value, select.selectedIndex);
+				data.attr("countries").replace(countries);
+				
+				equal(data.attr("countryCode"), "US", "country kept as USA");
+				
+				setTimeout(function(){
+					ok( select.getElementsByTagName("option")[1].selected, "USA still selected");
+				},10);
+				
+				start();
+			},10);
+			
+		},10);
+		
+	});
+	
+	test("one-way <select> bindings keep value if options are replaced - each (#1762)", function(){
+		var countries = [{code: 'MX', countryName:'MEXICO'},
+			{code: 'US', countryName:'USA'}
+		];
+		
+		var data = new can.Map({
+			countryCode: 'US',
+			countries: countries
+		});
+		
+		var template = can.stache('<select {$value}="countryCode">'+
+			'{{#each countries}}'+
+				'<option value="{{code}}">{{countryName}}</option>'+
+			'{{/each}}'+
+		'</select>');
+		
+		var frag = template(data);
+		var select = frag.firstChild;
+		stop();
+		setTimeout(function(){
+			console.log("empting list",select.value, select.selectedIndex);
+			
+			data.attr("countries").replace([]);
+			
+			
+			console.log("emptied list",select.value, select.selectedIndex);
+			setTimeout(function(){
+				console.log("adding back",select.value, select.selectedIndex);
+				data.attr("countries").replace(countries);
+				
+				equal(data.attr("countryCode"), "US", "country kept as USA");
+				
+				setTimeout(function(){
+					ok( select.getElementsByTagName("option")[1].selected, "USA still selected");
+				},10);
+				
+				start();
+			},10);
+			
+		},10);
+		
+	});
 	
 	test("@function reference to child (#2116)", function(){
 		expect(2);

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -1762,8 +1762,9 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		// wait for set to be called which will change the selects
 		setTimeout(function(){
 			ok(!nullInputOptions[0].selected, "default (null) value set");
-			ok(!undefinedInputOptions[0].selected, "default (undefined) value set");
-			ok(!stringInputOptions[0].selected, "default ('') value set");
+			// the first item is selected because "" is the value.
+			ok(undefinedInputOptions[0].selected, "default (undefined) value set");
+			ok(stringInputOptions[0].selected, "default ('') value set");
 			start();
 		}, 1);
 	});
@@ -2003,8 +2004,26 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		
 	});
 	
-	
-	
+	test("two-way binding with empty strings (#2147)", function(){
+		var template = can.stache("<select {($value)}='val'>"+
+			'<option value="">Loading...</option>'+
+			'<option>Empty...</option>'+
+			"</select>");
+			
+		var map = new can.Map({
+			foo: true,
+			val: ""
+		});
+		
+		var frag = template(map);
+		
+		setTimeout(function(){
+			//map.attr("foo", false);
+			equal( frag.firstChild.selectedIndex, 0, "empty strings are bound");
+			start();
+		},10);
+		stop();
+	});
 	
 
 });

--- a/view/live/live.js
+++ b/view/live/live.js
@@ -186,7 +186,7 @@ steal('can/util',
 			}
 		},
 		callChildMutationCallback: function(el) {
-			var callback = childMutationCallbacks[el.nodeName.toLowerCase()];
+			var callback = el && childMutationCallbacks[el.nodeName.toLowerCase()];
 			if(callback) {
 				callback(el);
 			}

--- a/view/live/live.js
+++ b/view/live/live.js
@@ -149,7 +149,8 @@ steal('can/util',
 				elements.after([masterNodeList[0]], falseyFrag);
 				masterNodeList.push(falseyNodeLists[0]);
 			}
-		};
+		},
+		childMutationCallbacks = {};
 	/**
 	 * @property {Object} can.view.live
 	 * @parent can.view.static
@@ -177,6 +178,19 @@ steal('can/util',
 	 *
 	 */
 	var live = {
+		registerChildMutationCallback: function(tag, callback){
+			if(callback) {
+				childMutationCallbacks[tag] = callback;
+			} else {
+				return childMutationCallbacks[tag];
+			}
+		},
+		callChildMutationCallback: function(el) {
+			var callback = childMutationCallbacks[el.nodeName.toLowerCase()];
+			if(callback) {
+				callback(el);
+			}
+		},
 		/**
 		 * @function can.view.live.list
 		 * @parent can.view.live
@@ -287,6 +301,10 @@ steal('can/util',
 					for (var i = index + newIndicies.length, len = indexMap.length; i < len; i++) {
 						indexMap[i](i);
 					}
+					if(ev.callChildMutationCallback !== false) {
+						live.callChildMutationCallback(text.parentNode);
+					}
+					
 				},
 				// Called when an item is set with .attr
 				set = function(ev, newVal, index) {
@@ -316,19 +334,17 @@ steal('can/util',
 						indexMap[i](i);
 					}
 					
-					
-					
-					
-					
 					// don't remove elements during teardown.  Something else will probably be doing that.
 					if(!fullTeardown) {
 						// adds the falsey section if the list is empty
 						addFalseyIfEmpty(list, falseyRender, masterNodeList, nodeList);
 						can.remove(can.$(itemsToRemove));
+						if(ev.callChildMutationCallback !== false) {
+							live.callChildMutationCallback(text.parentNode);
+						}
 					} else {
 						nodeLists.unregister(masterNodeList);
 					}
-
 				},
 				move = function (ev, item, newIndex, currentIndex) {
 					if (!afterPreviousEvents) {
@@ -389,6 +405,9 @@ steal('can/util',
 					for (i, len; i < len; i++) {
 						indexMap[i](i);
 					}
+					if(ev.callChildMutationCallback !== false) {
+						live.callChildMutationCallback(text.parentNode);
+					}
 				},
 				// A text node placeholder
 				text = el.ownerDocument.createTextNode(''),
@@ -405,7 +424,7 @@ steal('can/util',
 							.unbind('move', move);
 					}
 					// use remove to clean stuff up for us
-					remove({}, {
+					remove({callChildMutationCallback: !!fullTeardown}, {
 						length: masterNodeList.length - 1
 					}, 0, true, fullTeardown);
 				},
@@ -415,7 +434,6 @@ steal('can/util',
 					if(isTornDown) {
 						return;
 					}
-					
 					
 					afterPreviousEvents = true;
 					if(newList && oldList) {
@@ -431,23 +449,24 @@ steal('can/util',
 						for(var i = 0, patchLen = patches.length; i < patchLen; i++) {
 							var patch = patches[i];
 							if(patch.deleteCount) {
-								remove({}, {
+								remove({callChildMutationCallback: false}, {
 									length: patch.deleteCount
 								}, patch.index, true);
 							}
 							if(patch.insert.length) {
-								add({}, patch.insert, patch.index);
+								add({callChildMutationCallback: false}, patch.insert, patch.index);
 							}
 						}
 					} else {
 						if(oldList) {
 							teardownList();
 						}
-						
 						list = newList || [];
-						add({}, list, 0);
+						add({callChildMutationCallback: false}, list, 0);
 						addFalseyIfEmpty(list, falseyRender, masterNodeList, nodeList);
 					}
+					live.callChildMutationCallback(text.parentNode);
+					
 					afterPreviousEvents = false;
 					// list might be a plain array
 					if (list.bind) {
@@ -458,6 +477,7 @@ steal('can/util',
 					}
 					afterPreviousEvents = true;
 				};
+				
 			parentNode = elements.getParentNode(el, parentNode);
 			// Setup binding and teardown to add and remove events
 			var data = setup(parentNode, function () {
@@ -520,14 +540,15 @@ steal('can/util',
 			var data;
 			parentNode = elements.getParentNode(el, parentNode);
 			data = listen(parentNode, compute, function (ev, newVal, oldVal) {
-				
 				// TODO: remove teardownCheck in 2.1
 				var attached = nodeLists.first(nodes).parentNode;
 				// update the nodes in the DOM with the new rendered value
 				if (attached) {
 					makeAndPut(newVal);
 				}
-				data.teardownCheck(nodeLists.first(nodes).parentNode);
+				var pn = nodeLists.first(nodes).parentNode;
+				data.teardownCheck(pn);
+				live.callChildMutationCallback(pn);
 			});
 
 			var nodes = nodeList || [el],
@@ -550,7 +571,6 @@ steal('can/util',
 						val(frag.firstChild);
 					}
 					elements.replace(oldNodes, frag);
-					
 				};
 				
 			data.nodeList = nodes;


### PR DESCRIPTION
fixes #2147 and #1762 

This makes binding to an empty string `""` in the scope work.  But this changes the behavior of `undefined`.  `undefined` values will be overwritten because the select's value will be `""`.  

perhaps in a future release, we can support something like: `<option {value}="undefined"/>`