### PR TITLE
Benchmark array diff utility

### DIFF
--- a/util/array/benchmark.html
+++ b/util/array/benchmark.html
@@ -1,0 +1,1 @@
+<script src="../../node_modules/steal/steal.js" main="can/util/array/diff_benchmark"></script>

--- a/util/array/diff_benchmark.js
+++ b/util/array/diff_benchmark.js
@@ -1,0 +1,86 @@
+steal(
+'steal-benchmark',
+'can/util/array/diff.js',
+function (Benchmarks, diff) {
+
+	new Benchmarks.suite('diff')
+		.on('cycle', function (ev) {
+			var benchmark = ev.target;
+			console.log('Average runtime:', benchmark.stats.mean * 1000);
+		})
+		.add({
+			name: '10k - same',
+			diffLib: diff,
+			setup: function () {
+				/* jshint ignore:start */
+				var oldList = [];
+				var newList = [];
+				var obj;
+
+				for (var i = 0; i <= 10000; i++) {
+					obj = { foo: 'bar-' + i };
+
+					oldList.push(obj);
+					newList.push(obj);
+				}
+				/* jshint ignore:end */
+			},
+			fn: function () {
+				/* jshint ignore:start */
+				var patch = this.diffLib(oldList, newList);
+				/* jshint ignore:end */
+			}
+		})
+		.add({
+			name: '10k - slightly different',
+			diffLib: diff,
+			setup: function () {
+				/* jshint ignore:start */
+				var oldList = [];
+				var newList = [];
+				var obj;
+
+				for (var i = 0; i <= 10000; i++) {
+					obj = { foo: 'bar-' + i };
+
+					oldList.push(obj);
+					newList.push(obj);
+				}
+
+				newList.splice(100, 1);
+				newList.splice(501, 1);
+				/* jshint ignore:end */
+			},
+			fn: function () {
+				/* jshint ignore:start */
+				var patch = this.diffLib(oldList, newList);
+				/* jshint ignore:end */
+			}
+		})
+		.add({
+			name: '10k - very different',
+			diffLib: diff,
+			setup: function () {
+				/* jshint ignore:start */
+				var oldList = [];
+				var newList = [];
+				var obj;
+
+				for (var i = 0; i <= 10000; i++) {
+					obj = { foo: 'bar-' + i };
+
+					oldList.push(obj);
+
+					if (i % 2 !== 0) {
+						newList.push(obj);
+					}
+				}
+				/* jshint ignore:end */
+			},
+			fn: function () {
+				/* jshint ignore:start */
+				var patch = this.diffLib(oldList, newList);
+				/* jshint ignore:end */
+			}
+		});
+});


### PR DESCRIPTION
I created some benchmarks of the current array diff utility in CanJS. I was pretty surprised to see that even with 10k items in the two compared lists, the runtime is still less than 1ms. Am I reading these results correctly? 

```
SUITE diff
  10k - same x 30,860 ops/sec ±1.26% (61 runs sampled) 
    [Average runtime: 0.032403886673781045]
  10k - slightly different x 21,544 ops/sec ±1.19% (58 runs sampled) 
    [Average runtime: 0.04641671862046386]
  10k - very different x 1,379 ops/sec ±1.77% (56 runs sampled) 
    [Average runtime: 0.7251001082251083]
```

Now, I will say it doesn't take much for it to defer to a complete replacement, but if all you've got is simple adds/removes this is pretty impressive.
