### PR TITLE
Allow anchor tags to be children of inline elements and contain block elements

### DIFF
--- a/view/parser/parser.js
+++ b/view/parser/parser.js
@@ -51,11 +51,11 @@ steal(function(){
 	var empty = makeMap("area,base,basefont,br,col,frame,hr,img,input,isindex,link,meta,param,embed");
 
 	// Block Elements - HTML 5
-	// a is traditionally inline, but should allow block-level elments inside it, so it should be treated like a block-level element when parsed
+	// For an INLINE element which can have BLOCK children, include that element in BOTH lists
 	var block = makeMap("a,address,article,applet,aside,audio,blockquote,button,canvas,center,dd,del,dir,div,dl,dt,fieldset,figcaption,figure,footer,form,frameset,h1,h2,h3,h4,h5,h6,header,hgroup,hr,iframe,ins,isindex,li,map,menu,noframes,noscript,object,ol,output,p,pre,section,script,table,tbody,td,tfoot,th,thead,tr,ul,video");
 
 	// Inline Elements - HTML 5
-	var inline = makeMap("abbr,acronym,applet,b,basefont,bdo,big,br,button,cite,code,del,dfn,em,font,i,iframe,img,input,ins,kbd,label,map,object,q,s,samp,script,select,small,span,strike,strong,sub,sup,textarea,tt,u,var");
+	var inline = makeMap("a,abbr,acronym,applet,b,basefont,bdo,big,br,button,cite,code,del,dfn,em,font,i,iframe,img,input,ins,kbd,label,map,object,q,s,samp,script,select,small,span,strike,strong,sub,sup,textarea,tt,u,var");
 
 	// Elements that you can, intentionally, leave open
 	// (and which close themselves)
@@ -94,9 +94,11 @@ steal(function(){
 		function parseStartTag(tag, tagName, rest, unary) {
 			tagName = tagName.toLowerCase();
 
-			if (block[tagName]) {
-				while (stack.last() && inline[stack.last()]) {
-					parseEndTag("", stack.last());
+			if (block[tagName] && !inline[tagName]) {
+				var last = stack.last();
+				while (last && inline[last] && !block[last]) {
+					parseEndTag("", last);
+					last = stack.last();
 				}
 			}
 

--- a/view/parser/parser_test.js
+++ b/view/parser/parser_test.js
@@ -138,6 +138,33 @@ steal("can/view/parser", "steal-qunit", function(parser){
 		]));
 	});
 
+	test("anchors are allowed as children of inline elements - #2169", function(){
+		parser("<span><a></a></span>", makeChecks([
+			['start', ['span', false]],
+			['end', ['span', false]],
+			['start', ['a', false]],
+			['end', ['a', false]],
+			['close', ['a']],
+			['close', ['span']],
+			['done', []]
+		]));
+	});
+
+	test("inline tags are closed when a block element is encountered", function(){
+		parser("<span><span><div></div></span></span>", makeChecks([
+			['start', ['span', false]],
+			['end', ['span', false]],
+			['start', ['span', false]],
+			['end', ['span', false]],
+			['close', ['span']],
+			['close', ['span']],
+			['start', ['div', false]],
+			['end', ['div', false]],
+			['close', ['div']],
+			['done', []]
+		]));
+	});
+
 	test("supports single character attributes (#1132)", function(){
 		parser('<circle r="25"></circle>', makeChecks([
 			["start", ["circle", false]],


### PR DESCRIPTION
Fixes #2169 

This also preserves the ability to have block elements as children of an anchor - there is still a test for that still passes.