### PR TITLE
Makes can.compute.read always try .attr

### DIFF
--- a/compute/compute_test.js
+++ b/compute/compute_test.js
@@ -1,4 +1,4 @@
-steal("can/compute", "can/test", "can/map", "steal-qunit", function () {
+steal("can/compute", "can/test", "can/map", "steal-qunit", "./read_test", function () {
 	QUnit.module('can/compute');
 	test('single value compute', function () {
 		var num = can.compute(1);
@@ -259,28 +259,6 @@ steal("can/compute", "can/test", "can/map", "steal-qunit", function () {
 		
 		
 	});
-
-	test("can.Construct derived classes should be considered objects, not functions (#450)", function() {
-		var foostructor = can.Map({ text: "bar" }, {}),
-			obj = {
-				next_level: {
-					thing: foostructor,
-					text: "In the inner context"
-				}
-			},
-			read;
-		foostructor.self = foostructor;
-
-		read = can.compute.read(obj, can.compute.read.reads("next_level.thing.self.text") );
-		equal(read.value, "bar", "static properties on a can.Construct-based function");
-
-		read = can.compute.read(obj, can.compute.read.reads("next_level.thing.self"), { isArgument: true });
-		ok(read.value === foostructor, "arguments shouldn't be executed");
-
-		foostructor.self = function() { return foostructor; };
-		read = can.compute.read(obj, can.compute.read.reads("next_level.thing.self.text"), { });
-		equal(read.value, "bar", "anonymous functions in the middle of a read should be executed if requested");
-	});
 	
 	test("compute.async read without binding", function(){
 		
@@ -295,53 +273,6 @@ steal("can/compute", "can/test", "can/map", "steal-qunit", function () {
 		
 		
 		
-	});
-	
-
-	test("compute.read works with a Map wrapped in a compute", function() {
-		var parent = can.compute(new can.Map({map: {first: "Justin" }}));
-
-		var result = can.compute.read(parent, can.compute.read.reads("map.first"));
-		equal(result.value, "Justin", "The correct value is found.");
-	});
-
-	test('compute.read works with a Map wrapped in a compute', function() {
-		var parent = new can.Compute(new can.Map({map: {first: 'Justin' }}));
-
-		var result = can.Compute.read(parent, can.compute.read.reads("map.first"));
-		equal(result.value, 'Justin', 'The correct value is found.');
-	});
-
-	test("compute.read returns constructor functions instead of executing them (#1332)", function() {
-		var Todo = can.Map.extend({});
-		var parent = can.compute(new can.Map({map: { Test: Todo }}));
-
-		var result = can.compute.read(parent, can.compute.read.reads("map.Test"));
-		equal(result.value, Todo, 'Got the same Todo');
-	});
-	
-	test("compute.set with different values", 4, function() {
-		var comp = can.compute("David");
-		var parent = {
-			name: "David",
-			comp: comp
-		};
-		var map = new can.Map({
-			name: "David"
-		});
-
-		map.bind('change', function(ev, attr, how, value) {
-			equal(value, "Brian", "Got change event on map");
-		});
-		
-		can.compute.set(parent, "name", "Matthew");
-		equal(parent.name, "Matthew", "Name set");
-
-		can.compute.set(parent, "comp", "Justin");
-		equal(comp(), "Justin", "Name updated");
-
-		can.compute.set(map, "name", "Brian");
-		equal(map.attr("name"), "Brian", "Name updated in map");
 	});
 
 
@@ -726,34 +657,6 @@ steal("can/compute", "can/test", "can/map", "steal-qunit", function () {
 		equal(combined(), true);
 		//equal(other(), 2);
 	});
-	
-	test("can.Compute.read can read a promise (#179)", function(){
-		
-		var def = new can.Deferred();
-		var map = new can.Map();
-		
-		var c = can.compute(function(){
-			return can.Compute.read({map: map},can.compute.read.reads("map.data.value")).value;
-		});
-		
-		var calls = 0;
-		c.bind("change", function(ev, newVal, oldVal){
-			calls++;
-			equal(calls, 1, "only one call");
-			equal(newVal, "Something", "new value");
-			equal(oldVal, undefined, "oldVal");
-			start();
-		});
-		
-		map.attr("data", def);
-		
-		setTimeout(function(){
-			def.resolve("Something");
-		},2);
-		
-		stop();
-		
-	});
 
 	test('compute change handler context is set to the function not can.Compute', function() {
 		var comp = can.compute(null);
@@ -765,20 +668,7 @@ steal("can/compute", "can/test", "can/map", "steal-qunit", function () {
 		comp('test');
 	});
 	
-	test('can.compute.reads', function(){
-		deepEqual( can.compute.read.reads("@foo"),
-			[{key: "foo", at: true}]);
-			
-		deepEqual( can.compute.read.reads("@foo.bar"),
-			[{key: "foo", at: true}, {key: "bar", at: false}]);
-			
-		deepEqual( can.compute.read.reads("@foo\\.bar"),
-			[{key: "foo.bar", at: true}]);
-			
-		deepEqual( can.compute.read.reads("foo.bar@zed"),
-			[{key: "foo", at: false},{key: "bar", at: false},{key: "zed", at: true}]);
-		
-	});
+
 	
 
 	test('Calling .unbind() on un-bound compute does not throw an error', function () {
@@ -918,18 +808,6 @@ steal("can/compute", "can/test", "can/map", "steal-qunit", function () {
 		});
 		
 		outer.bind("change", function(){});
-	});
-	
-	test("prototype computes work (#2098)", function(){
-		var Map = can.Map.extend({
-			plusOne: can.compute(function(){
-				return this.attr("value")+1;
-			})
-		});
-		var root = new Map({value: 2}),
-			read;
-		read = can.compute.read(root, can.compute.read.reads("plusOne") );
-		equal(read.value, 3, "static properties on a can.Construct-based function");
 	});
 	
 	test("handles missing update order items (#2121)",function(){

--- a/compute/read.js
+++ b/compute/read.js
@@ -150,13 +150,11 @@ steal("can/util", function(can){
 					options.foundObservable(value, index);
 					state.foundObservable = true;
 				}
-				var val = value[prop.key];
-				if (typeof val === 'function' && value.constructor.prototype[prop.key] === val && !val.isComputed) {
-					// call that method
-					return val;
+				var res = value.attr(prop.key);
+				if(res !== undefined) {
+					return res;
 				} else {
-					// use attr to get that value
-					return value.attr(prop.key);
+					return value[prop.key];
 				}
 			}
 		},

--- a/map/map.js
+++ b/map/map.js
@@ -15,6 +15,11 @@
 // instantition of objects.
 steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/construct', 'can/util/batch', function (can, bind, bubble, mapHelpers) {
 
+	// properties that can't be observed on ... no matter what
+	var unobservable = {
+		"constructor": true
+	};
+
 	// Extend [can.Construct](../construct/construct.html) to make inherting a `can.Map` easier.
 	var Map = can.Map = can.Construct.extend(
 		/**
@@ -243,7 +248,9 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 			// Signals `can.compute` that an observable
 			// property is being read.
 			__get: function(attr){
-				can.__observe(this, attr);
+				if(!unobservable[attr]) {
+					can.__observe(this, attr);
+				}
 				return this.___get( attr );
 			},
 
@@ -257,7 +264,7 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 					if (computedAttr && computedAttr.compute) {
 						return computedAttr.compute();
 					} else {
-						return this._data[attr];
+						return this._data.hasOwnProperty(attr) ? this._data[attr] : undefined;
 					}
 				} else {
 					return this._data;
@@ -547,7 +554,7 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 			bind: function (eventName, handler) {
 
 				var computedBinding = this._computedAttrs && this._computedAttrs[eventName];
-				if (computedBinding) {
+				if (computedBinding && computedBinding.compute) {
 					if (!computedBinding.count) {
 						computedBinding.count = 1;
 						computedBinding.compute.bind("change", computedBinding.handler);


### PR DESCRIPTION
fixes #2199

This makes it so a map's `.attr()` is always called by `can.compute.read`.  If undefined is returned, it will fall back to directly reading from the map object.