### PR TITLE
Add viewModel link to table of contents

### DIFF
--- a/util/util.md
+++ b/util/util.md
@@ -42,4 +42,5 @@ can.util adds the following utility functions to CanJS:
 - [can.unbind unbind] - stop listening for events on an Object
 - [can.undelegate undelegate] - stop listening for events from the children of an Element
 - [can.underscore underscore] - convert a CamelCase or mixedCase string and underscores the String on the capital letter
+- [can.viewModel viewModel] - read and write a component element's viewModel
 - [can.when when] - call a callback Function when a Deferred resolves


### PR DESCRIPTION
Linked to http://canjs.com/docs/can.viewModel.html on http://canjs.com/docs/can.util.html. 

Closes #2165. 