### PR TITLE
Fix `map.attr` with empty string.

### DIFF
--- a/map/map.js
+++ b/map/map.js
@@ -252,7 +252,7 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 			// property is represented by a computed attribute, return the value of that compute.  
 			// If no argument is provided, return the raw data.
 			___get: function (attr) {
-				if (attr) {
+				if (attr !== undefined) {
 					var computedAttr = this._computedAttrs[attr];
 					if (computedAttr && computedAttr.compute) {
 						return computedAttr.compute();

--- a/map/map_test.js
+++ b/map/map_test.js
@@ -338,4 +338,13 @@ steal("can/map", "can/compute", "can/test", "can/list", "steal-qunit", function(
 		source(1);
 		can.batch.stop();
 	});
+
+	test('should get an empty string property value correctly', function() {
+		var map = new can.Map({
+			foo: 'foo',
+			'': 'empty string'
+		});
+
+		equal(map.attr(''), 'empty string');
+	});
 });


### PR DESCRIPTION
It was returning the collection of all of the properties of the Map instance instead of the actual value set to the empty string key.

![failed](https://cloud.githubusercontent.com/assets/724877/12644162/aee05146-c59f-11e5-9155-4bdd025a3adb.png)
