### PR TITLE
Add the ability to inherit values through the define plugin

### DIFF
--- a/map/define/define_test.js
+++ b/map/define/define_test.js
@@ -1136,4 +1136,125 @@ steal("can/map/define", "can/route", "can/test", "steal-qunit", function () {
 			start();
 		}, 200);
 	});
+	
+	test("can inherit computes from another map (#1322)", 4, function(){
+		var string1 = 'a string';
+		var string2 = 'another string';
+
+		var ParentMap = can.Map.extend({
+			define: {
+				inheritedProp: {
+					get: function() {
+						return string1;
+					},
+					set: function(newVal) {
+						equal(newVal, string1, 'set was called');
+					}
+				},
+				parentProp: {
+					get: function() {
+						return string1;
+					}
+				}
+			}
+		});
+		var ChildMap = ParentMap.extend({
+			define: {
+				childProp: {
+					get: function() {
+						return string2;
+					}
+				},
+				inheritedProp: {
+					get: function() {
+						return string2;
+					}
+				}
+			}
+		});
+
+		var map = new ChildMap();
+
+		equal(map.attr('childProp'), string2, 'props only in the child have the correct values');
+		equal(map.attr('inheritedProp'), string2, 'props in both have the child values');
+		equal(map.attr('parentProp'), string1, 'props only in the parent have the correct values');
+
+		map.attr('inheritedProp', string1);
+	});
+	
+	test("can inherit primitive values from another map (#1322)", function(){
+		var string1 = 'a string';
+		var string2 = 'another string';
+
+		var ParentMap = can.Map.extend({
+			define: {
+				inheritedProp: {
+					value: string1
+				},
+				parentProp: {
+					value: string1
+				}
+			}
+		});
+		var ChildMap = ParentMap.extend({
+			define: {
+				childProp: {
+					value: string2
+				},
+				inheritedProp: {
+					value: string2
+				}
+			}
+		});
+
+		var map = new ChildMap();
+
+		equal(map.attr('childProp'), string2, 'props only in the child have the correct values');
+		equal(map.attr('inheritedProp'), string2, 'props in both have the child values');
+		equal(map.attr('parentProp'), string1, 'props only in the parent have the correct values');
+	});
+	
+	test("can inherit object values from another map (#1322)", function(){
+		var object1 = {a: 'a'};
+		var object2 = {b: 'b'};
+
+		var ParentMap = can.Map.extend({
+			define: {
+				inheritedProp: {
+					get: function() {
+						return object1;
+					}
+				},
+				parentProp: {
+					get: function() {
+						return object1;
+					}
+				}
+			}
+		});
+		var ChildMap = ParentMap.extend({
+			define: {
+				childProp: {
+					get: function() {
+						return object2;
+					}
+				},
+				inheritedProp: {
+					get: function() {
+						return object2;
+					}
+				}
+			}
+		});
+
+		var map = new ChildMap();
+
+		strictEqual(map.attr('childProp'), object2, 'props only in the child have the correct values');
+		strictEqual(map.attr('inheritedProp'), object2, 'props in both have the child values');
+		strictEqual(map.attr('parentProp'), object1, 'props only in the parent have the correct values');
+	});
+	
+	
+	
+	
 });

--- a/map/define/doc/define.md
+++ b/map/define/doc/define.md
@@ -110,6 +110,54 @@ Here is the cliffnotes version of this plugin.  To define...
 * A custom converter method or a pre-defined standard converter called whenever a property is set - use [can.Map.prototype.define.type type]
 * That custom converter method as a constructor function - use [can.Map.prototype.define.TypeConstructor Type]
 
+## Inheritance
+
+[can.Map] constructors can inherit values from the [can.Map::define can.Map.define]
+plugin. If a parent [can.Map] constructor has a `define` property and a child
+constructor extends the parent and also has a `define` property, the two will
+be merged together so `define` properties from the parent are also available
+on instances of the child. For example:
+
+    var ParentMap = can.Map.extend({
+      define: {
+        inheritedProp: {
+          get: function() {
+            return 15;
+          },
+          set: function(newVal) {
+            return newVal;
+          }
+        },
+        parentProp: {
+          get: function() {
+            return 15;
+          }
+        }
+      }
+    });
+    var ChildMap = ParentMap.extend({
+      define: {
+        childProp: {
+          get: function() {
+            return 22;
+          }
+        },
+        inheritedProp: {
+          get: function() {
+            return 22;
+          }
+        }
+      }
+    });
+
+    var map = new ChildMap();
+
+    map.attr('childProp'); // -> 22
+    map.attr('inheritedProp'); // -> 22
+    map.attr('parentProp'); // -> 15
+
+    map.attr('inheritedProp', 13); // -> calls ParentMap’s setter for inheritedProp
+
 ## Demo
 
 The following shows picking cars by make / model / year:

--- a/map/map.js
+++ b/map/map.js
@@ -24,7 +24,7 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 		"constructor": true
 	};
 
-	// Extend [can.Construct](../construct/construct.html) to make inherting a `can.Map` easier.
+	// Extend [can.Construct](../construct/construct.html) to make inheriting a `can.Map` easier.
 	var Map = can.Map = can.Construct.extend(
 		/**
 		 * @static
@@ -35,7 +35,7 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 			// Called when a Map constructor is defined/extended to
 			// perform any initialization behavior for the new constructor
 			// function.
-			setup: function () {
+			setup: function (baseMap) {
 
 				can.Construct.setup.apply(this, arguments);
 
@@ -84,6 +84,13 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 					// If define is a function, call it with this can.Map
 					if(mapHelpers.define) {
 						mapHelpers.define(this);
+					}
+
+					// Inherit define values
+					if (baseMap.prototype.define) {
+						var defines = can.simpleExtend({}, baseMap.prototype.define);
+						mapHelpers.twoLevelDeepExtend(defines, this.prototype.define);
+						this.prototype.define = defines;
 					}
 				}
 

--- a/map/map_helpers.js
+++ b/map/map_helpers.js
@@ -169,6 +169,16 @@ steal('can/util', 'can/util/object/isplain', function(can){
 		// `undefined` if nothing has been already created.
 		getMapFromObject: function (obj) {
 			return madeMap && madeMap[obj._cid] && madeMap[obj._cid].instance;
+		},
+		
+		// ### twoLevelDeepExtend
+		// Performs an object extend to each of the properties in the destination object
+		// with the values from the source object
+		twoLevelDeepExtend: function (destination, source) {
+			for (var prop in source) {
+				destination[prop] = destination[prop] || {};
+				can.simpleExtend(destination[prop], source[prop]);
+			}
 		}
 	};
 	


### PR DESCRIPTION
This adds the ability to have two maps, one inheriting from the other, that both use the define plugin.

Fixes #1322
