### PR TITLE
Always set and update select bindings

### DIFF
--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -512,6 +512,7 @@ steal("can/util",
 					}
 					
 					lastSet = newVal;
+					
 					if(isMultiselectValue) {
 						if (newVal && typeof newVal === 'string') {
 							newVal = newVal.split(";");
@@ -543,8 +544,8 @@ steal("can/util",
 						} else {
 							can.attr.setAttrOrProp(el, prop, newVal == null ? "" : newVal);
 						}
-						
 					}
+					
 					return newVal;
 	
 				},
@@ -593,11 +594,9 @@ steal("can/util",
 						var onMutation = function (mutations) {
 							if(stickyCompute) {
 								set(stickyCompute());
-							} else {
-								if(scheduledAsyncSet) {
-									updater();
-								}
 							}
+							
+							updater();
 						};
 						if(can.attr.MutationObserver) {
 							observer = new can.attr.MutationObserver(onMutation);
@@ -775,7 +774,7 @@ steal("can/util",
 				parentName: attributeValue,
 				initializeValues: true
 			};
-			if(tagName === "select" && !childToParent) {
+			if(tagName === "select") {
 				bindingInfo.stickyParentToChild = true;
 			}
 			return bindingInfo;

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -1923,6 +1923,45 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		
 	});
 	
+	test('previously non-existing select value gets selected from a list when it is added (#1762)', function() {
+	  var template = can.view.stache('<select {($value)}="{person}">' +
+	      '<option></option>' +
+	      '{{#each people}}<option value="{{.}}">{{.}}</option>{{/each}}' +
+	    '</select>' +
+	    '<input type="text" size="5" {($value)}="person">'
+	  );
+
+	  var people = new can.List([
+	    "Alexis",
+	    "Mihael",
+	    "Curtis",
+	    "David"
+	  ]);
+
+	  var vm = new can.Map({
+	    person: 'Brian',
+	    people: people
+	  });
+
+	  stop();
+	  vm.bind('person', function(ev, newVal, oldVal) {
+	    ok(false, 'person attribute should not change');
+	  });
+
+	  var frag = template(vm);
+
+	  equal(vm.attr('person'), 'Brian', 'Person is still set');
+
+	  setTimeout(function() {
+	    people.push('Brian');
+	    setTimeout(function() {
+	      var select = frag.firstChild;
+	      ok(select.lastChild.selected, 'New child should be selected');
+	      start();
+	    }, 20);
+	  }, 20);
+	});
+	
 	test("one-way <select> bindings keep value if options are replaced (#1762)", function(){
 		var countries = [{code: 'MX', countryName:'MEXICO'},
 			{code: 'US', countryName:'USA'}


### PR DESCRIPTION
This pull request should cover all cases and closes #1762 
The solution was to always set select fields and call the mutation observer updater in every case.