### PR TITLE
Prevents %index from being passed as a "double" wrapped compute.

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -360,7 +360,10 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 
 							// Remove `viewModel.` from the start of the key and read the value from the `viewModel`.
 							key = key.replace(/^(scope|^viewModel)\./,"");
-							value = can.compute.read(options.viewModel, can.compute.read.reads(key), {isArgument: true}).value;
+							value = can.compute.read(options.viewModel, can.compute.read.reads(key), {
+								// if we find a compute, we should bind on that and not read it
+								readCompute: false
+							}).value;
 
 							// If `value` is undefined use `can.getObject` to get the value.
 							if(value === undefined) {
@@ -392,7 +395,9 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 
 					// Create a handler function that we'll use to handle the `change` event on the `readyCompute`.
 					var handler = function(ev, ready){
+						// unbinds the old binding
 						controlInstance._bindings.control[methodName](controlInstance.element);
+						// binds the new
 						controlInstance._bindings.control[methodName] = ready.processor(
 							ready.delegate || controlInstance.element,
 							ready.parts[2], ready.parts[1], methodName, controlInstance);

--- a/compute/read.js
+++ b/compute/read.js
@@ -6,6 +6,8 @@ steal("can/util", function(can){
 	// actually check
 	// - isArgument - should be renamed to something like "onLastPropertyReadReturnFunctionInsteadOfCallingIt".
 	//   This is used to make a compute out of that function if necessary.
+	// - readCompute - can be set to `false` to prevent reading an ending compute.  This is used by component to get a
+	//   compute as a delegate.  In 3.0, this should be removed and force people to write "{@prop} change"
 	// - callMethodsOnObservables - this is an overwrite ... so normal methods won't be called, but observable ones will.
 	// - executeAnonymousFunctions - call a function if it's found, defaults to true
 	// - proxyMethods - if the last read is a method, return a function so `this` will be correct.
@@ -105,7 +107,7 @@ steal("can/util", function(can){
 			return value && value.isComputed && !isAt(i, reads);
 		},
 		read: function(value, i, reads, options, state){
-			if(options.isArgument && i === reads.length ) {
+			if(options.readCompute === false && i === reads.length ) {
 				return value;
 			}
 			

--- a/view/mustache/mustache.js
+++ b/view/mustache/mustache.js
@@ -2238,7 +2238,7 @@ steal('can/util',
 					options = offset;
 					offset = 0;
 				}
-				var index = options.scope.attr("@index");
+				var index = options.scope.read("@index",{isArgument: true}).value;
 				return ""+((can.isFunction(index) ? index() : index) + offset);
 			}
 			/**

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -4760,6 +4760,25 @@ steal("can/util/vdom/document", "can/util/vdom/build_fragment","can/view/stache"
 
 			equal(counter, 2, 'Counter incremented twice');
 		});
+		
+		test("%index is double wrapped compute in helper (#2179)", function(){
+			var appState = new can.Map({
+				todos: [
+					{ description: "Foo" },
+					{ description: "Bar" },
+				]
+			});
+			
+			var template =  can.stache('{{#each todos}}<div>{{indexPlusOne %index}}</div>{{/each}}');
+			
+			can.stache.registerHelper("indexPlusOne", function(val, options) {
+				var resolved = val();
+				equal(typeof resolved,"number", "should be a number");
+				return resolved + 2;
+			});
+			
+			template(appState);
+		});
 
 		// PUT NEW TESTS RIGHT BEFORE THIS!
 	}


### PR DESCRIPTION
fixes #2179.

This makes can.compute.read's `isArgument` option still call computes, but adds another `computeRead` that can be set to false.  The `computeRead` is needed by a component test that really should be rewritten in 3.0.