### PR TITLE
double get

### DIFF
--- a/compute/get_value_and_bind.js
+++ b/compute/get_value_and_bind.js
@@ -230,19 +230,19 @@ steal("can/util", function(can){
 	// Updates the top of the stack with the observable being read.
 	can.__observe = function (obj, event) {
 		var top = observedInfoStack[observedInfoStack.length-1];
-		if (top) {
+		if (top && !top.ignore) {
 			var evStr = event + "",
 				name = obj._cid + '|' + evStr;
+				
 			if(top.traps) {
 				top.traps.push({obj: obj, event: evStr, name: name});
 			}
-			else if(!top.ignore && !top.newObserved[name]) {
+			else if(!top.newObserved[name]) {
 				top.newObserved[name] = {
 					obj: obj,
 					event: evStr
 				};
 			}
-
 		}
 	};
 

--- a/map/define/define_test.js
+++ b/map/define/define_test.js
@@ -1100,40 +1100,68 @@ steal("can/map/define", "can/route", "can/test", "steal-qunit", function () {
 	});
 
 	test("Asynchronous virtual properties cause extra recomputes (#1915)", function() {
+
 		stop();
 
 		var ran = false;
 		var VM = can.Map.extend({
-		  define: {
-		    foo: {
-		      get: function(lastVal, setVal) {
-		        setTimeout(function() {
-							if(setVal) {
+			define : {
+				foo : {
+					get : function(lastVal, setVal) {
+						setTimeout(function() {
+							if (setVal) {
 								setVal(5);
 							}
-		        }, 10);
-		      }
-		    },
-		    bar: {
-		      get: function() {
-		        var foo = this.attr('foo');
-		        if (foo) {
-							if(ran) {
+						}, 10);
+					}
+				},
+				bar : {
+					get : function() {
+						var foo = this.attr('foo');
+						if (foo) {
+							if (ran) {
 								ok(false, 'Getter ran twice');
 							}
 							ran = true;
-		          return foo * 2;
-		        }
-		      }
-		    }
-		  }
+							return foo * 2;
+						}
+					}
+				}
+			}
 		});
 
 		var vm = new VM();
 		vm.bind('bar', function() {});
+		
 		setTimeout(function() {
 			equal(vm.attr('bar'), 10);
 			start();
 		}, 200);
+
 	});
+	
+
+	test("double get in a compute (#2230)", function() {
+		var VM = can.Map.extend({
+			define : {
+				names : {
+					get : function(val, setVal) {
+						ok(setVal, "setVal passed");
+						return 'Hi!';
+					}
+				}
+			}
+		});
+
+		var vm = new VM();
+		
+		var c = can.compute(function(){
+			return vm.attr("names");
+		});
+
+		c.bind("change", function(){});
+
+	});
+
+	
 });

--- a/map/map.js
+++ b/map/map.js
@@ -15,10 +15,6 @@
 // instantition of objects.
 steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/construct', 'can/util/batch', 'can/compute/get_value_and_bind.js', function (can, bind, bubble, mapHelpers) {
 
-	var readButDontObserveCompute = can.__notObserve(function(compute){
-		return compute();
-	});
-
 	// properties that can't be observed on ... no matter what
 	var unobservable = {
 		"constructor": true
@@ -252,7 +248,7 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 			// Signals `can.compute` that an observable
 			// property is being read.
 			__get: function(attr){
-				if(!unobservable[attr]) {
+				if(!unobservable[attr] && !this._computedAttrs[attr]) {
 					can.__observe(this, attr);
 				}
 				return this.___get( attr );
@@ -267,7 +263,7 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 					var computedAttr = this._computedAttrs[attr];
 					if (computedAttr && computedAttr.compute) {
 						// return computedAttr.compute();
-						return readButDontObserveCompute(computedAttr.compute);
+						return computedAttr.compute();
 					} else {
 						return this._data.hasOwnProperty(attr) ? this._data[attr] : undefined;
 					}

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -2169,7 +2169,7 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 	});
 	
 	test("double render with batched / unbatched events (#2223)", function(){
-		var template = can.stache("{{#page}}{{doLog}}<input {($value)}='foo'/>{{/page}}");
+		var template = can.stache("{{#page}}{{doLog}}<input {($value)}='notAHelper'/>{{/page}}");
 		
 		var appVM = new can.Map();
 
@@ -2186,7 +2186,7 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		can.batch.stop();
 		
 		// logs 'child' a 2nd time
-		appVM.attr('foo', 'bar');
+		appVM.attr('notAHelper', 'bar');
 		
 		
 		equal(logCalls, 1, "input rendered the right number of times");

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -2168,5 +2168,28 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		stop();
 	});
 	
+	test("double render with batched / unbatched events (#2223)", function(){
+		var template = can.stache("{{#page}}{{doLog}}<input {($value)}='foo'/>{{/page}}");
+		
+		var appVM = new can.Map();
+
+		var logCalls = 0;
+		can.stache.registerHelper('doLog', function(){
+			logCalls++;
+		});
+		
+		template(appVM);
+		
+		
+		can.batch.start();
+		appVM.attr('page', true);
+		can.batch.stop();
+		
+		// logs 'child' a 2nd time
+		appVM.attr('foo', 'bar');
+		
+		
+		equal(logCalls, 1, "input rendered the right number of times");
+	});
 
 });


### PR DESCRIPTION
Closes #2230.  The can.__notObserve was preventing auto-binding on the compute.  This fixes it.