### PR TITLE
Type coerce to string in backing can.Map instead of in can.route.

### DIFF
--- a/route/route.js
+++ b/route/route.js
@@ -116,7 +116,19 @@ steal('can/util', 'can/map', 'can/list','can/util/string/deparam', function (can
 			}, 10);
 		},
 		// A dummy events object used to dispatch url change events on.
-		eventsObject = can.extend({}, can.event);
+		eventsObject = can.extend({}, can.event),
+		// everything in the backing Map is a string
+		// change type coercion during Map setter to coerce all values to strings 
+		stringCoercingMapDecorator = function(map) {
+			var typeSuper = map.__type;
+			map.__type = function(val, prop) {
+				var newArguments = [stringify(val), prop];
+	
+				return typeSuper.apply(map, newArguments);
+			};
+	
+			return map;
+		};
 
 	can.route = function (url, defaults) {
 		// if route ends with a / and url starts with a /, remove the leading / of the url
@@ -355,7 +367,7 @@ steal('can/util', 'can/map', 'can/list','can/util/string/deparam', function (can
 		 * @hide
 		 * A can.Map that represents the state of the history.
 		 */
-		data: new can.Map({}),
+		data: stringCoercingMapDecorator(new can.Map({})),
 		map: function(data){
 			var appState;
 			// appState is a can.Map constructor function
@@ -366,7 +378,8 @@ steal('can/util', 'can/map', 'can/list','can/util/string/deparam', function (can
 			else {
 				appState = data;
 			}
-			can.route.data = appState;
+			
+			can.route.data = stringCoercingMapDecorator(appState);
 		},
 		/**
 		 * @property {Object} routes
@@ -621,29 +634,19 @@ steal('can/util', 'can/map', 'can/list','can/util/string/deparam', function (can
 			return can.route.data[name].apply(can.route.data, arguments);
 		};
 	});
-
-	// Because everything in hashbang is in fact a string this will automaticaly convert new values to string. Works with single value, or deep hashes.
-	// Main motivation for this is to prevent double route event call for same value.
-	// Example (the problem):
-	// When you load page with hashbang like #!&some_number=2 and bind 'some_number' on routes.
-	// It will fire event with adding of "2" (string) to 'some_number' property
-	// But when you after this set can.route.attr({some_number: 2}) or can.route.attr('some_number', 2). it fires another event with change of 'some_number' from "2" (string) to 2 (integer)
-	// This wont happen again with this normalization
+	
+	// everything in the backing Map is a string
+	// coerce attribute names to string or number
 	can.route.attr = function (attr, val) {
 		var type = typeof attr,
 			newArguments;
-
-		// Reading
-		if (val === undefined) {
-			newArguments = arguments;
-			// Sets object
-		} else if (type !== "string" && type !== "number") {
+		
+		if (type !== "string" && type !== "number" && val !== undefined) { // if setting non-str non-num attr
 			newArguments = [stringify(attr), val];
-			// Sets key - value
 		} else {
-			newArguments = [attr, stringify(val)];
+			newArguments = arguments;
 		}
-
+    
 		return can.route.data.attr.apply(can.route.data, newArguments);
 	};
 

--- a/route/route.js
+++ b/route/route.js
@@ -61,11 +61,10 @@ steal('can/util', 'can/map', 'can/list','can/util/string/deparam', function (can
 		stringify = function (obj) {
 			// Object is array, plain object, Map or List
 			if (obj && typeof obj === "object") {
-				// Get native object or array from Map or List
 				if (obj instanceof can.Map) {
-					obj = obj.attr();
-					// Clone object to prevent change original values
+					obj = obj;
 				} else {
+					// Get array from array-like or shallow-copy object
 					obj = can.isFunction(obj.slice) ? obj.slice() : can.extend({}, obj);
 				}
 				// Convert each object property or array item into stringified new
@@ -121,10 +120,8 @@ steal('can/util', 'can/map', 'can/list','can/util/string/deparam', function (can
 		// change type coercion during Map setter to coerce all values to strings 
 		stringCoercingMapDecorator = function(map) {
 			var typeSuper = map.__type;
-			map.__type = function(val, prop) {
-				var newArguments = [stringify(val), prop];
-	
-				return typeSuper.apply(map, newArguments);
+			map.__type = function() {
+				return stringify(typeSuper.apply(map, arguments));
 			};
 	
 			return map;

--- a/route/route_test.js
+++ b/route/route_test.js
@@ -905,5 +905,25 @@ steal("can/route", "can/test", "steal-qunit", function () {
 		appState.attr('name', 'Brian');
 	});
 
+	test("updating bound can.Map causes single update with a coerced string value", function() {
+		expect(1);
 
+		setupRouteTest(function (iframe, route) {
+			var appVM = new can.Map({});
+
+			route.map(appVM);
+			route.ready();
+
+			appVM.bind('action', function(ev, newVal) {
+				strictEqual(newVal, '10');
+			});
+
+			appVM.attr('action', 10);
+
+			// check after 30ms to see that we only have a single call
+			setTimeout(function() {
+				teardownRouteTest();
+			}, 30);
+		});
+	});
 });

--- a/route/route_test.js
+++ b/route/route_test.js
@@ -743,6 +743,28 @@ steal("can/route", "can/test", "steal-qunit", function () {
 			});
 		});
 
+		test("updating bound can.Map causes single update with a coerced string value", function() {
+			expect(1);
+
+			setupRouteTest(function (iframe, route) {
+				var appVM = new can.Map({});
+
+				route.map(appVM);
+				route.ready();
+
+				appVM.bind('action', function(ev, newVal) {
+					strictEqual(newVal, '10');
+				});
+
+				appVM.attr('action', 10);
+
+				// check after 30ms to see that we only have a single call
+				setTimeout(function() {
+					teardownRouteTest();
+				}, 30);
+			});
+		});
+
 		test("hash doesn't update to itself with a !", function() {
 			stop();
 			window.routeTestReady = function (iCanRoute, loc) {
@@ -903,27 +925,5 @@ steal("can/route", "can/test", "steal-qunit", function () {
 			appState.removeAttr('name');
 		});
 		appState.attr('name', 'Brian');
-	});
-
-	test("updating bound can.Map causes single update with a coerced string value", function() {
-		expect(1);
-
-		setupRouteTest(function (iframe, route) {
-			var appVM = new can.Map({});
-
-			route.map(appVM);
-			route.ready();
-
-			appVM.bind('action', function(ev, newVal) {
-				strictEqual(newVal, '10');
-			});
-
-			appVM.attr('action', 10);
-
-			// check after 30ms to see that we only have a single call
-			setTimeout(function() {
-				teardownRouteTest();
-			}, 30);
-		});
 	});
 });


### PR DESCRIPTION
Resolves #2206.

Monkey patches map.__type on can.Map backing can.route. 