### PR TITLE
Deprecate can.isDeferred. More accurate can.isPromise.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -21,7 +21,8 @@
 		"raises": true,
 		"start": true,
 		"stop": true,
-		"global": true
+		"global": true,
+	  	"Promise": true
 	},
 	"curly": true,
 	"eqeqeq": true,

--- a/component/component_bindings_test.js
+++ b/component/component_bindings_test.js
@@ -521,7 +521,7 @@ steal("can", "can/map/define", "can/component", "can/view/stache" ,"can/route", 
 						var deferred = this.viewModel.attr('deferreddata'),
 							viewModel = this.viewModel;
 
-						if (can.isDeferred(deferred)) {
+						if (can.isPromise(deferred)) {
 							this.viewModel.attr("waiting", true);
 							deferred.then(function (items) {
 								viewModel.attr('items')

--- a/component/component_test.js
+++ b/component/component_test.js
@@ -525,7 +525,7 @@ steal("can/util/vdom/document", "can/util/vdom/build_fragment","can", "can/map/d
 						var deferred = this.viewModel.attr('deferreddata'),
 							viewModel = this.viewModel;
 
-						if (can.isDeferred(deferred)) {
+						if (can.isPromise(deferred)) {
 							this.viewModel.attr("waiting", true);
 							deferred.then(function (items) {
 								viewModel.attr('items')

--- a/component/examples/grid.js
+++ b/component/examples/grid.js
@@ -12,7 +12,7 @@ can.Component.extend({
 		update: function () {
 			var deferred = this.viewModel.attr('deferreddata'),
 				viewModel = this.viewModel;
-			if (can.isDeferred(deferred)) {
+			if (can.isPromise(deferred)) {
 				this.element.find('tbody')
 					.css('opacity', 0.5);
 				deferred.then(function (items) {

--- a/list/list.js
+++ b/list/list.js
@@ -91,7 +91,7 @@ steal("can/util", "can/map", "can/map/bubble.js","can/map/map_helpers.js",functi
 				instances = instances || [];
 				var teardownMapping;
 
-				if (can.isDeferred(instances)) {
+				if (can.isPromise(instances)) {
 					this.replace(instances);
 				} else {
 					teardownMapping = instances.length && mapHelpers.addToMap(instances, this);
@@ -836,7 +836,7 @@ steal("can/util", "can/map", "can/map/bubble.js","can/map/map_helpers.js",functi
 		 * ```
 		 */
 		replace: function (newList) {
-			if (can.isDeferred(newList)) {
+			if (can.isPromise(newList)) {
 				if(this._promise) {
 					this._promise.__isCurrentPromise = false;
 				}

--- a/list/promise/promise.js
+++ b/list/promise/promise.js
@@ -6,9 +6,9 @@ steal("can/util/can.js", "can/list", function (can) {
 		// First call the old replace so its
 		// deferred callbacks will be called first
 		var result = oldReplace.apply(this, arguments);
-
-		// If there is a deferred:
-		if (can.isDeferred(data)) {
+		
+		// If there is a promise, that is not a can.List instance or other collection with promise-like methods
+		if (can.isPromise(data)) {
 			if(this._deferred) {
 				this._deferred.__cancelState = true;
 			}

--- a/list/promise/promise.js
+++ b/list/promise/promise.js
@@ -7,7 +7,7 @@ steal("can/util/can.js", "can/list", function (can) {
 		// deferred callbacks will be called first
 		var result = oldReplace.apply(this, arguments);
 		
-		// If there is a promise, that is not a can.List instance or other collection with promise-like methods
+		// If there is a promise:
 		if (can.isPromise(data)) {
 			if(this._deferred) {
 				this._deferred.__cancelState = true;

--- a/map/app/app.js
+++ b/map/app/app.js
@@ -52,7 +52,7 @@ steal("can/util", "can/map", "can/compute",function(can){
 					data.serialize() : data;
 			}
 
-			if(can.isDeferred(inst)){
+			if(can.isPromise(inst)){
 				this.waitFor(inst);
 				inst.then(function(data){
 					store(data);

--- a/map/lazy/observe_test.js
+++ b/map/lazy/observe_test.js
@@ -826,7 +826,7 @@ steal('can/util', 'can/observe', 'can/map/lazy', 'can/test', 'steal-qunit', func
 			ob = new can.LazyMap({
 				test: dfd
 			});
-		ok(can.isDeferred(ob.attr('test')), 'Attribute is a deferred');
+		ok(can.isPromise(ob.attr('test')), 'Attribute is a deferred');
 		ok(!ob.attr('test')
 			._cid, 'Does not have a _cid');
 	});

--- a/map/map_helpers.js
+++ b/map/map_helpers.js
@@ -21,7 +21,7 @@ steal('can/util', 'can/util/object/isplain', function(can){
 		// ### can.mapHelpers.canMakeObserve
 		// Determines if an object can be made into an observable.
 		canMakeObserve: function (obj) {
-			return obj && !can.isDeferred(obj) && (can.isArray(obj) || can.isPlainObject(obj) );
+			return obj && !can.isPromise(obj) && (can.isArray(obj) || can.isPlainObject(obj) );
 		},
 		
 		// ### mapHelpers.serialize

--- a/model/model.js
+++ b/model/model.js
@@ -662,7 +662,7 @@ steal('can/util', 'can/map', 'can/list', function (can) {
 			// we use those as parameters for an initial findAll.
 			if (can.isPlainObject(params) && !can.isArray(params)) {
 				can.List.prototype.setup.apply(this);
-				this.replace(can.isDeferred(params) ? params : this.constructor.Map.findAll(params));
+				this.replace(can.isPromise(params) ? params : this.constructor.Map.findAll(params));
 			} else {
 				// Otherwise, set up the list like normal.
 				can.List.prototype.setup.apply(this, arguments);

--- a/observe/observe_test.js
+++ b/observe/observe_test.js
@@ -828,7 +828,7 @@ steal('can/util', "can/observe", 'can/map', 'can/list', "can/test", "steal-qunit
 			ob = new can.Map({
 				test: dfd
 			});
-		ok(can.isDeferred(ob.attr('test')), 'Attribute is a deferred');
+		ok(can.isPromise(ob.attr('test')), 'Attribute is a deferred');
 		ok(!ob.attr('test')
 			._cid, 'Does not have a _cid');
 	});

--- a/test/pluginified/2.0.5.test.js
+++ b/test/pluginified/2.0.5.test.js
@@ -316,7 +316,7 @@ var __m1 = (function () {
 				update: function () {
 					var deferred = this.scope.attr('deferreddata'),
 						scope = this.scope;
-					if (can.isDeferred(deferred)) {
+					if (can.isPromise(deferred)) {
 						this.scope.attr('waiting', true);
 						deferred.then(function (items) {
 							scope.attr('items')
@@ -2105,7 +2105,7 @@ var __m32 = (function () {
 			ob = new can.Map({
 				test: dfd
 			});
-		ok(can.isDeferred(ob.attr('test')), 'Attribute is a deferred');
+		ok(can.isPromise(ob.attr('test')), 'Attribute is a deferred');
 		ok(!ob.attr('test')
 			._cid, 'Does not have a _cid');
 	});
@@ -4044,13 +4044,13 @@ var __m39 = (function () {
 			bar: bar
 		};
 		stop();
-		ok(can.isDeferred(original.foo), 'Original foo property is a Deferred');
+		ok(can.isPromise(original.foo), 'Original foo property is a Deferred');
 		can.view(can.test.path('view/test//deferred.ejs'), original)
 			.then(function (result, data) {
 				ok(data, 'Data exists');
 				equal(data.foo, 'FOO', 'Foo is resolved');
 				equal(data.bar, 'BAR', 'Bar is resolved');
-				ok(can.isDeferred(original.foo), 'Original property did not get modified');
+				ok(can.isPromise(original.foo), 'Original property did not get modified');
 				start();
 			});
 		setTimeout(function () {

--- a/test/pluginified/2.0.5.test.js
+++ b/test/pluginified/2.0.5.test.js
@@ -316,7 +316,7 @@ var __m1 = (function () {
 				update: function () {
 					var deferred = this.scope.attr('deferreddata'),
 						scope = this.scope;
-					if (can.isPromise(deferred)) {
+					if (can.isDeferred(deferred)) {
 						this.scope.attr('waiting', true);
 						deferred.then(function (items) {
 							scope.attr('items')

--- a/util/can.js
+++ b/util/can.js
@@ -17,7 +17,9 @@ steal(function () {
 
 	
 	can.isDeferred = function(obj) {
-		can.dev.warn('can.isDeferred: this function is deprecated and will be removed in a future release. can.isPromise replaces the functionality of can.isDeferred.');
+		if (!!can.dev) { // can.dev may not be defined yet
+			can.dev.warn('can.isDeferred: this function is deprecated and will be removed in a future release. can.isPromise replaces the functionality of can.isDeferred.');
+		}
 		return obj && typeof obj.then === "function" && typeof obj.pipe === "function";
 	};
 	can.isPromise = function(obj){

--- a/util/can.js
+++ b/util/can.js
@@ -16,7 +16,7 @@ steal(function () {
 	can.k = function(){};
 
 	
-	can.isDeferred = function() {
+	can.isDeferred = function(obj) {
 		can.dev.warn('can.isDeferred: this function is deprecated and will be removed in a future release. can.isPromise replaces the functionality of can.isDeferred.');
 		return obj && typeof obj.then === "function" && typeof obj.pipe === "function";
 	};

--- a/util/can.js
+++ b/util/can.js
@@ -15,9 +15,16 @@ steal(function () {
 	// An empty function useful for where you need a dummy callback.
 	can.k = function(){};
 
-	can.isDeferred = can.isPromise = function (obj) {
-		// Returns `true` if something looks like a deferred.
-		return obj && typeof obj.then === "function" && typeof obj.pipe === "function";
+	
+	can.isDeferred = function() {
+		can.dev.warn('can.isDeferred: this function is deprecated and will be removed in a future release. can.isPromise replaces the functionality of can.isDeferred.');
+		return can.isPromise.call(this, arguments);
+	};
+	can.isPromise = function(obj){
+		return obj && (
+			(window.Promise && (obj instanceof Promise)) ||
+			(can.isFunction(obj.then) && can.isFunction(obj.catch || obj.fail) && !(obj instanceof can.List))
+		);
 	};
 	can.isMapLike = function(obj){
 		return can.Map && (obj instanceof can.Map || obj && obj.___get);

--- a/util/can.js
+++ b/util/can.js
@@ -23,7 +23,7 @@ steal(function () {
 	can.isPromise = function(obj){
 		return !!obj && (
 			(window.Promise && (obj instanceof Promise)) ||
-			(can.isFunction(obj.then) && !(obj instanceof can.List))
+			(can.isFunction(obj.then) && (can.List === undefined || !(obj instanceof can.List)))
 		);
 	};
 	can.isMapLike = function(obj){

--- a/util/can.js
+++ b/util/can.js
@@ -18,12 +18,12 @@ steal(function () {
 	
 	can.isDeferred = function() {
 		can.dev.warn('can.isDeferred: this function is deprecated and will be removed in a future release. can.isPromise replaces the functionality of can.isDeferred.');
-		return can.isPromise.call(this, arguments);
+		return obj && typeof obj.then === "function" && typeof obj.pipe === "function";
 	};
 	can.isPromise = function(obj){
-		return obj && (
+		return !!obj && (
 			(window.Promise && (obj instanceof Promise)) ||
-			(can.isFunction(obj.then) && can.isFunction(obj.catch || obj.fail) && !(obj instanceof can.List))
+			(can.isFunction(obj.then) && !(obj instanceof can.List))
 		);
 	};
 	can.isMapLike = function(obj){

--- a/util/func.js
+++ b/util/func.js
@@ -1,5 +1,27 @@
 /**
+@description Check if an object is a Promise.
+@function can.isPromise
+@parent can.util
+@signature `can.isPromise(subject)`
+@param {*} subject The object to check.
+@return {Boolean} Whether __subject__ is a Promise.
+
+@body
+`can.isPromise` returns if an object has the methods expected of a Promise object.
+
+## Example
+Convert any value to a Promise:
+
+	function convertPromise(prm) {
+		return can.isPromise(prm) 
+			? prm 
+			: new Promise(function(resolve) { resolve(prm) });
+	}
+*/
+//
+/**
 @description Check if an object is a Deferred.
+@deprecated {2.3.16} This method has been replaced by [can.isPromise].
 @function can.isDeferred
 @parent can.util
 @signature `can.isDeferred(subject)`

--- a/view/modifiers/modifiers.js
+++ b/view/modifiers/modifiers.js
@@ -20,7 +20,7 @@ steal('jquery', 'can/util', 'can/view', function ($, can) {
 			// if the first arg is a deferred
 			// wait until it finishes, and call
 			// modify with the result
-			if (can.isDeferred(args[0])) {
+			if (can.isPromise(args[0])) {
 				args[0].done(function (res) {
 					modify.call(self, [res], old);
 				});
@@ -40,7 +40,7 @@ steal('jquery', 'can/util', 'can/view', function ($, can) {
 				// call view with args (there might be deferreds)
 				result = can.view.apply(can.view, args);
 				// if we got a string back
-				if (!can.isDeferred(result)) {
+				if (!can.isPromise(result)) {
 					// we are going to call the old method with that string
 					args = [result];
 				} else {

--- a/view/view.js
+++ b/view/view.js
@@ -159,11 +159,11 @@ steal('can/util', function (can) {
 		var deferreds = [];
 
 		// pull out deferreds
-		if (can.isDeferred(data)) {
+		if (can.isPromise(data)) {
 			return [data];
 		} else {
 			for (var prop in data) {
-				if (can.isDeferred(data[prop])) {
+				if (can.isPromise(data[prop])) {
 					deferreds.push(data[prop]);
 				}
 			}
@@ -621,13 +621,13 @@ steal('can/util', function (can) {
 							result;
 
 						// Make data look like the resolved deferreds.
-						if (can.isDeferred(data)) {
+						if (can.isPromise(data)) {
 							dataCopy = usefulPart(resolved);
 						} else {
 							// Go through each prop in data again and
 							// replace the defferreds with what they resolved to.
 							for (var prop in data) {
-								if (can.isDeferred(data[prop])) {
+								if (can.isPromise(data[prop])) {
 									dataCopy[prop] = usefulPart(objs.shift());
 								}
 							}

--- a/view/view_test.js
+++ b/view/view_test.js
@@ -295,13 +295,13 @@ steal("can/view/callbacks",
 			bar: bar
 		};
 		stop();
-		ok(can.isDeferred(original.foo), 'Original foo property is a Deferred');
+		ok(can.isPromise(original.foo), 'Original foo property is a Deferred');
 		can.view(can.test.path('view/test//deferred.ejs'), original)
 			.then(function (result, data) {
 				ok(data, 'Data exists');
 				equal(data.foo, 'FOO', 'Foo is resolved');
 				equal(data.bar, 'BAR', 'Bar is resolved');
-				ok(can.isDeferred(original.foo), 'Original property did not get modified');
+				ok(can.isPromise(original.foo), 'Original property did not get modified');
 				start();
 			});
 		setTimeout(function () {


### PR DESCRIPTION
Resolves #1747, closes #2359

isPromise needs to explicitly reject can.List as it shouldn't be handled as a promise and the can.List promise plugin is likely to be removed in a coming release.