### PR TITLE
binding issue with Mustache and EJS templating engine

### DIFF
--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -2192,4 +2192,39 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		equal(logCalls, 1, "input rendered the right number of times");
 	});
 
+	test("dropdown does not pick the selected value for mustache and EJS (#2245)", function(){
+		var nameObj = new can.Map({
+			selected : "name3",
+			students : [
+				{name : "name1"},
+				{name : "name2"},
+				{name : "name3"},
+				{name : "name4"}
+			],
+			fn: function(obj){
+				return obj.attr('name') === this.attr('selected');
+			}
+		});
+
+		var template = can.mustache('<select>'+
+				'{{#students}}'+
+					'<option value="{{name}}" {{#fn}} selected="selected"{{/fn name}}>{{name}}</option>'+
+				'{{/students}}'+
+				'</select>');
+
+		var frag = template(nameObj);
+		ok(frag.firstChild.value, "name3");
+		// the value is set asynchronously
+		setTimeout(function(){
+			nameObj.attr('students').push({
+				name : "name4"
+			});
+			nameObj.attr('selected',"name2");
+			ok(frag.firstChild.value, "name2");
+			start();
+		},20);
+		stop();
+
+	});
+
 });

--- a/view/elements.js
+++ b/view/elements.js
@@ -138,6 +138,11 @@ steal('can/util', "can/view",function (can) {
 				
 			if(parentNode.nodeName.toUpperCase() === "SELECT" && parentNode.selectedIndex >= 0) {
 				selectedValue = parentNode.value;
+				can.each(newFrag.childNodes, function (el) {
+					if(el.nodeName.toUpperCase() === 'OPTION' && !!el.hasAttribute('selected')) {
+						selectedValue = el.value;
+					}
+				});
 			}
 			
 			


### PR DESCRIPTION
Dropdown does not set value event if option is selected. This issue exists both for EJS and Mustache templating engine, bug #2245(https://github.com/canjs/canjs/issues/2245) 
