### PR TITLE
Enable comparator set via sort method (#2159)

### DIFF
--- a/list/sort/sort.md
+++ b/list/sort/sort.md
@@ -96,8 +96,7 @@ table  // -> [1, 8, 2],
 The default sort order for string comparators is ascending. To sort
 items in descending order use a function comparator.
 
-
-## Move events
+## Move Events
 
 Whenever there are changes to items in the [can.List], the
 [can.List.plugins.sort] plugin moves the item to the correct
@@ -118,3 +117,9 @@ cart.bind('move', function (ev, item, newIndex, oldIndex) {
 cart.attr('0.price', 4.00); // Moved: Bread, from: 0, to: 3
 							// -> [Juice, Butter, Bread]
 ```
+
+## Changing Comparators
+
+A comparator can be set explicitly with [can.Map::attr attr], or implicitly
+with the more familiar `list.sort(newComparator)`. Both have the same
+effect.

--- a/list/sort/sort.md
+++ b/list/sort/sort.md
@@ -20,7 +20,7 @@ var cart = new can.List([
 	{ title: 'Butter', price: 3.50 },
 	{ title: 'Juice', price: 3.05 }
 ]);
-cart.attr("comparator",'price');
+cart.attr("comparator", 'price');
 cart; // -> [Juice, Butter, Bread]
 ```
 
@@ -34,9 +34,9 @@ var cart = new can.List([
 	{ title: 'Butter', price: 3.50 },
 	{ title: 'Bread', price: 4.00 }
 ]);
-cart.attr("comparator",'price');
+cart.attr("comparator", 'price');
 cart.bind("length", function(){});
-cart.attr("0.price",5);
+cart.attr("0.price", 5);
 cart; // -> [Butter, Bread, Juice]
 ```
 
@@ -48,12 +48,13 @@ var cart = new can.List([
 	{ title: 'Butter', price: 3.50 },
 	{ title: 'Bread', price: 4.00 }
 ]);
+cart.attr('comparator', 'price');
 cart.bind("length", function(){});
-cart.push({title: 'Apple', 3.25});
+cart.push({ title: 'Apple', price: 3.25 });
 cart; // -> [Juice, Apple, Butter, Bread]
 ```
 
-If you are using a `can.List` in a template, it will be bound to 
+If you are using a `can.List` in a template, it will be bound to
 automatically.  Check out this demo that lets you change the sort order
 and a person's name:
 
@@ -73,7 +74,6 @@ stockPrices.attr("comparator", function (a, b) {
 	return a === b ? 0 : a < b ? 1 : -1; // Descending
 })
 stockPrices // -> [0.98, 0.75, 0.16, 0.12, 0.05, 0.01];
-
 ```
 
 ## String Comparators
@@ -87,11 +87,14 @@ var table = new can.List([
 	[1, 8, 2],
 	[7, 9, 5]
 ]);
-table.attr('comparator', '2')
+table.attr('comparator', '2') // Translates to: row.attr('2')
 table  // -> [1, 8, 2],
              [6, 3, 4],
              [7, 9, 5]
 ```
+
+The default sort order for string comparators is ascending. To sort
+items in descending order use a function comparator.
 
 
 ## Move events
@@ -106,7 +109,7 @@ var cart = new can.List([
 	{ title: 'Butter', price: 3.50 },
 	{ title: 'Juice', price: 3.25 }
 ]);
-cart.attr('comparator','price');
+cart.attr('comparator', 'price');
 
 cart.bind('move', function (ev, item, newIndex, oldIndex) {
 	console.log('Moved:', item.title + ', from:', oldIndex + ', to:', newIndex);

--- a/list/sort/sort_test.js
+++ b/list/sort/sort_test.js
@@ -689,4 +689,30 @@ steal("can/list/sort", "can/test", "can/view/mustache", "can/view/stache", "can/
 		expected = [300, 200, 100];
 		evaluate();
 	});
+
+	test('Setting comparator with .sort() (#2159)', function () {
+		var list = new can.List([
+			{ letter: 'x', number: 3 },
+			{ letter: 'y', number: 2 },
+			{ letter: 'z', number: 1 },
+		]);
+
+		list.attr('comparator', 'number');
+
+		equal(list.attr('0.number'), 1, 'First value is correct');
+		equal(list.attr('1.number'), 2, 'Second value is correct');
+		equal(list.attr('2.number'), 3, 'Third value is correct');
+
+		list.sort('letter');
+
+		equal(list.attr('0.letter'), 'x', 'First value is correct after comparator set');
+		equal(list.attr('1.letter'), 'y', 'Second value is correct after comparator set');
+		equal(list.attr('2.letter'), 'z', 'Third value is correct after comparator set');
+
+		list.push({ letter: 'w', number: 4 });
+
+		equal(list.attr('0.letter'), 'w', 'First value is correct after insert');
+		equal(list.attr('0.number'), 4, 'First value is correct after insert');
+
+	});
 });


### PR DESCRIPTION
Makes `list.attr('comparator', newComparator)` and `list.sort(newComparator)` work the same. 

Depends on PR #2251. Closes https://github.com/canjs/canjs/issues/2159.