### PR TITLE
Makes bindings happen after parent node list

### DIFF
--- a/component/component_test.js
+++ b/component/component_test.js
@@ -1782,7 +1782,7 @@ steal("can/util/vdom/document", "can/util/vdom/build_fragment","can", "can/map/d
 
 			// Dispatches async
 			setTimeout(function() {
-				equal(count, 4, '2 items unbound, but unbinding the temporary unbind and the actual unbind');
+				equal(count, 2, '2 items unbound. Previously, this would unbind 4 times because of switching to fast path');
 				can.unbindAndTeardown = old;
 
 				start();
@@ -1823,8 +1823,15 @@ steal("can/util/vdom/document", "can/util/vdom/build_fragment","can", "can/map/d
 			map.attr("show", false);
 			map.attr("show", true);
 			map.attr("show", false);
-			equal(map._bindings,1, "only one binding");
-			can.remove(can.$("#qunit-fixture>*"));
+			map.attr("show", true);
+			map.attr("show", false);
+			stop();
+			setTimeout(function(){
+				equal(map._bindings,1, "only one binding");
+				can.remove(can.$("#qunit-fixture>*"));
+				start();
+			},10);
+			
 		});
 		
 		// PUT NEW TESTS THAT NEED TO TEST AGAINST MUSTACHE JUST ABOVE THIS LINE

--- a/compute/get_value_and_bind.js
+++ b/compute/get_value_and_bind.js
@@ -67,7 +67,7 @@ steal("can/util", function(can){
 				this.depth = null;
 			}
 		},
-		onDependencyChange: function(ev){
+		dependencyChange: function(ev){
 			if(this.bound && this.ready) {
 				if(ev.batchNum !== undefined) {
 					// Only need to register once per batchNum
@@ -79,6 +79,9 @@ steal("can/util", function(can){
 					this.updateCompute(ev.batchNum);
 				}
 			}
+		},
+		onDependencyChange: function(ev, newVal, oldVal){
+			this.dependencyChange(ev, newVal, oldVal);
 		},
 		updateCompute: function(batchNum){
 			// It's possible this became unbound since it was registered to update

--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -62,7 +62,8 @@ steal("can/util",
 						return viewModel;
 					},
 					attributeViewModelBindings: attributeViewModelBindings,
-					alreadyUpdatedChild: true
+					alreadyUpdatedChild: true,
+					nodeList: tagData.parentNodeList
 				});
 				if(dataBinding) {
 					// For bindings that change the viewModel,
@@ -110,7 +111,8 @@ steal("can/util",
 						},
 						attributeViewModelBindings: attributeViewModelBindings,
 						// always update the viewModel accordingly.
-						initializeValues: true
+						initializeValues: true,
+						nodeList: tagData.parentNodeList
 					});
 					if(dataBinding) {
 						// The viewModel is created, so call callback immediately.
@@ -143,7 +145,8 @@ steal("can/util",
 			// Setup binding
 			var dataBinding = makeDataBinding({
 				name: attrData.attributeName,
-				value: el.getAttribute(attrData.attributeName)
+				value: el.getAttribute(attrData.attributeName),
+				nodeList: attrData.nodeList
 			}, el, {
 				templateType: attrData.templateType,
 				scope: attrData.scope,
@@ -183,7 +186,8 @@ steal("can/util",
 								return viewModel;
 							},
 							// always update the viewModel accordingly.
-							initializeValues: true
+							initializeValues: true,
+							nodeList: attrData.nodeList
 						});
 						if(dataBinding) {
 							// The viewModel is created, so call callback immediately.
@@ -833,12 +837,20 @@ steal("can/util",
 		// Get computes for the parent and child binding
 		var parentCompute = getComputeFrom[bindingInfo.parent](el, bindingData.scope, bindingInfo.parentName, bindingData, bindingInfo.parentToChild),
 			childCompute = getComputeFrom[bindingInfo.child](el, bindingData.scope, bindingInfo.childName, bindingData, bindingInfo.childToParent, bindingInfo.stickyParentToChild && parentCompute),
-			
 			// these are the functions bound to one compute that update the other.
 			updateParent,
 			updateChild,
 			childLifecycle;
 		
+		if(bindingData.nodeList) {
+			if(parentCompute && parentCompute.isComputed){
+				parentCompute.computeInstance.setPrimaryDepth(bindingData.nodeList.nesting+1);
+			}
+			if(childCompute && childCompute.isComputed){
+				childCompute.computeInstance.setPrimaryDepth(bindingData.nodeList.nesting+1);
+			}
+		}
+
 		// Only bind to the parent if it will update the child.
 		if(bindingInfo.parentToChild){
 			updateChild = bind.parentToChild(el, parentCompute, childCompute, bindingData.semaphore, bindingInfo.bindingAttributeName);

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -2191,5 +2191,33 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		
 		equal(logCalls, 1, "input rendered the right number of times");
 	});
+	
+
+	test("Child bindings updated before parent (#2252)", function(){
+		var template = can.stache("{{#eq page 'view'}}<child-binder {page}='page'/>{{/eq}}");
+		can.Component.extend({
+			tag: 'child-binder',
+			template: can.stache('<span/>'),
+			viewModel: {
+				_set: function(prop, val){
+					if(prop === "page"){
+						equal(val,"view", "value should not be edit");
+					}
+					
+					return can.Map.prototype._set.apply(this, arguments);
+				}
+			}
+		});
+		
+		var vm = new can.Map({
+			page : 'view'
+		});
+		template(vm);
+		
+		can.batch.start();
+		vm.attr('page', 'edit');
+		can.batch.stop();
+	});
+
 
 });

--- a/view/mustache/mustache_test.js
+++ b/view/mustache/mustache_test.js
@@ -3314,7 +3314,7 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 			if (eventType === "visible") {
 				ok(true, "unbound visible");
 				unbindCount++;
-				if(unbindCount >= 2) {
+				if(unbindCount >= 1) {
 					start();
 				}
 			}

--- a/view/stache/mustache_core.js
+++ b/view/stache/mustache_core.js
@@ -53,7 +53,8 @@ steal("can/util",
 				txt += helperOptions.fn( isObserveList ? items.attr('' + i) : items[i], options);
 			}
 			return txt;
-		};
+		},
+		k = function(){};
 
 
 
@@ -321,7 +322,7 @@ steal("can/util",
 
 				// Bind on the compute to set the cached value. This helps performance
 				// so live binding can read a cached value instead of re-calculating.
-				compute.computeInstance.bind("change", can.k);
+				compute.computeInstance.bind("change", k);
 
 				var value = compute();
 
@@ -370,7 +371,7 @@ steal("can/util",
 					}
 				}
 				// Unbind the compute.
-				compute.computeInstance.unbind("change", can.k);
+				compute.computeInstance.unbind("change", k);
 			};
 		},
 		// ## mustacheCore.splitModeFromExpression

--- a/view/stache/stache.js
+++ b/view/stache/stache.js
@@ -234,11 +234,12 @@ steal(
 						if( !state.node.attributes ) {
 							state.node.attributes = [];
 						}
-						state.node.attributes.push(function(scope, options){
+						state.node.attributes.push(function(scope, options, nodeList){
 							attrCallback(this,{
 								attributeName: attrName,
 								scope: scope,
-								options: options
+								options: options,
+								nodeList: nodeList
 							});
 						});
 					}

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -3972,7 +3972,7 @@ steal("can/util/vdom/document", "can/util/vdom/build_fragment","can/view/stache"
 		});
 
 		test("possible to teardown immediate nodeList (#1593)", function(){
-			expect(5);
+			expect(3);
 			var map = new can.Map({show: true});
 			var oldBind = map.bind,
 				oldUnbind = map.unbind;


### PR DESCRIPTION
Uses the depth trick.  However, I had to make some changes to can/view/scopeData so it could actually make use of component depth and be registered to update in the right order.

Fixes #2252 