### PR TITLE
Don’t include %root in a component’s initial viewModel data

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -96,9 +96,7 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 			setup: function (el, componentTagData) {
 
 				// Setup values passed to component
-				var initialViewModelData = {
-						"%root": componentTagData.scope.attr("%root")
-					},
+				var initialViewModelData = {},
 					component = this,
 					// If a template is not provided, we fall back to
 					// dynamic scoping regardless of settings.

--- a/component/component.js
+++ b/component/component.js
@@ -96,7 +96,9 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 			setup: function (el, componentTagData) {
 
 				// Setup values passed to component
-				var initialViewModelData = {},
+				var initialViewModelData = {
+						"%root": componentTagData.scope.attr("%root")
+					},
 					component = this,
 					// If a template is not provided, we fall back to
 					// dynamic scoping regardless of settings.

--- a/component/component.js
+++ b/component/component.js
@@ -96,9 +96,7 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 			setup: function (el, componentTagData) {
 
 				// Setup values passed to component
-				var initialViewModelData = {
-						"%root": componentTagData.scope.attr("%root")
-					},
+				var initialViewModelData = {},
 					component = this,
 					// If a template is not provided, we fall back to
 					// dynamic scoping regardless of settings.
@@ -130,6 +128,9 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/view/bindings
 				if(setupBindings) {
 					teardownFunctions.push(bindings.behaviors.viewModel(el, componentTagData, function(initialViewModelData){
 						
+						// Make %root available on the viewModel.
+						initialViewModelData["%root"] = componentTagData.scope.attr("%root");
+
 						// Create the component's viewModel.
 						var protoViewModel = component.scope || component.viewModel;
 						if (component.constructor.Map) {

--- a/component/component_test.js
+++ b/component/component_test.js
@@ -1575,6 +1575,43 @@ steal("can/util/vdom/document", "can/util/vdom/build_fragment","can", "can/map/d
 
 			can.append(this.$fixture, template());
 		});
+
+		test('Type in a component’s viewModel doesn’t work correctly with lists (#2250)', function() {
+			var Item = can.Map.extend({
+				define: {
+					prop: {
+						value: true
+					}
+				}
+			});
+
+			var Collection = can.List.extend({
+				Map: Item
+			}, {});
+
+			can.Component.extend({
+				tag: "test-component",
+				viewModel: {
+					define: {
+						collection: {
+							Type: Collection
+						},
+						vmProp: {
+							get: function() {
+								return this.attr('collection.0.prop');
+							}
+						}
+					}
+				}
+			});
+
+			var frag = can.stache('<test-component collection="{collection}"></test-component>')({
+				collection: [{}]
+			});
+			var vmPropVal = can.viewModel(can.$(frag.firstChild)).attr('vmProp');
+			ok(vmPropVal, 'value is from defined prop');
+		});
+
 		// PUT NEW TESTS ABOVE THIS LINE
 	}
 

--- a/component/component_test.js
+++ b/component/component_test.js
@@ -1576,6 +1576,22 @@ steal("can/util/vdom/document", "can/util/vdom/build_fragment","can", "can/map/d
 			can.append(this.$fixture, template());
 		});
 
+		test("%root property is available in a viewModel", function () {
+			var viewModel = can.Map.extend({});
+
+			can.Component.extend({
+				tag: "foo",
+				viewModel: viewModel,
+				init: function () {
+					ok(this.viewModel.attr('%root'), "viewModel contains '%root' property");
+				}
+			});
+
+			var template = can.stache("<foo/>");
+
+			can.append(this.$fixture, template());
+		});
+
 		test('Type in a component’s viewModel doesn’t work correctly with lists (#2250)', function() {
 			var Item = can.Map.extend({
 				define: {


### PR DESCRIPTION
When a component is set up, `%root` was added to the initial `viewModel` data so it would be available in every scope. However, [`can.view.Scope` already has a special case for %root](https://github.com/canjs/canjs/blob/cee94ae7744ea6376e1f4bd7f6088b325db06555/view/scope/scope.js#L91-L94), so it’s not necessary for `can.Component` to do that.

Fixes #2250