### PR TITLE
Fix uppercase html parsing

### DIFF
--- a/view/parser/parser.js
+++ b/view/parser/parser.js
@@ -131,6 +131,7 @@ steal(function(){
 
 				// Find the closest opened tag of the same type
 			else {
+				tagName = tagName.toLowerCase();
 				for (pos = stack.length - 1; pos >= 0; pos--) {
 					if (stack[pos] === tagName) {
 						break;

--- a/view/parser/parser_test.js
+++ b/view/parser/parser_test.js
@@ -70,6 +70,28 @@ steal("can/view/parser", "steal-qunit", function(parser){
 		parser("<h1 id='foo' {{#if}}{{.}}{{/if}} class='a{{foo}}'>Hello {{message}}!</h1>",makeChecks(tests));
 
 	});
+	
+	test("uppercase html to html", function(){
+
+
+
+		var tests = [
+			['start', ['div', false]],
+			['end', ['div', false]],
+			["chars", ["sibling"]],
+			['close', ['div']],
+			['start', ['div', false]],
+			['end', ['div', false]],
+			["chars", ["sibling"]],
+			['close', ['div']],
+			['done', []]
+		];
+
+
+
+		parser("<DIV>sibling</DIV><DIV>sibling</DIV>", makeChecks(tests));
+
+	});
 
 	test("special in an attribute in an in-tag section", function(){
 


### PR DESCRIPTION
If a template uses uppercase HTML tags, can's parser fails to close nested tags properly.

JSBin: http://jsbin.com/zizotavesu/edit?html,css,js,output
_This will work if the first `</DIV>` is changed to `</div>`._

The parsing for end tags [does not](https://github.com/canjs/canjs/blob/master/view/parser/parser.js#L124) use `toLowerCase` on the tagName, whereas the parsing for start tags [does](https://github.com/canjs/canjs/blob/master/view/parser/parser.js#L94) which causes a mismatch in opening/closing tags.

In the JSBin example, the first `</DIV>` doesn't match the open `<div>` on the stack and is left open resulting in the second div nesting inside of it.