### PR TITLE
Bugfix: elems must be an array for can.inserted()

### DIFF
--- a/util/jquery/jquery.js
+++ b/util/jquery/jquery.js
@@ -164,7 +164,7 @@ steal('jquery', 'can/util/can.js', 'can/util/attr', "can/event", "can/util/fragm
 		can.each(['after', 'prepend', 'before', 'append','replaceWith'], function (name) {
 			var original = $.fn[name];
 			$.fn[name] = function () {
-				var elems,
+				var elems = [],
 					args = can.makeArray(arguments);
 
 				if (args[0] != null) {


### PR DESCRIPTION
Without this fix, `canjs/util/inserted/inserted.js` can fail at line 7...
```
if(!elems.length) {
  return;
}
```
...since length is undefined:
```
TypeError: Cannot read property 'length' of undefined
```