### PR TITLE
Create a CanSimpleDocument constructor

### DIFF
--- a/util/vdom/document/document.js
+++ b/util/vdom/document/document.js
@@ -1,9 +1,18 @@
 // A document made with can/view/parser
 steal("can/util/can.js", "can-simple-dom", "../build_fragment/make_parser", function(can, simpleDOM, makeParser){
-	var document = new simpleDOM.Document();
-	var serializer = new simpleDOM.HTMLSerializer(simpleDOM.voidMap);
-	var parser = makeParser(document);
-	document.__addSerializerAndParser(serializer, parser);
+
+	function CanSimpleDocument(){
+		simpleDOM.Document.apply(this, arguments);
+
+		var serializer = new simpleDOM.HTMLSerializer(simpleDOM.voidMap);
+		var parser = makeParser(this);
+		this.__addSerializerAndParser(serializer, parser);
+	}
+
+	CanSimpleDocument.prototype = new simpleDOM.Document();
+	CanSimpleDocument.prototype.constructor = CanSimpleDocument;
+
+	var document = new CanSimpleDocument();
 	can.simpleDocument = document;
 	return document;
 });


### PR DESCRIPTION
This is needed so you can do: `new document.constructor()` which will
set up both the parser and serializer behavior. Currently in can-ssr we
are setting this up ourselves, which is gross:
https://github.com/canjs/can-ssr/blob/c5e2ec1be5cc28e1d6482b986f67c068dc4cc5b9/lib/index.js#L58

Needed for https://github.com/canjs/can-ssr/issues/128