### PR TITLE
fix #1541 can.Component should show a warning if tag name is missing a hyphen

### DIFF
--- a/view/callbacks/callbacks.js
+++ b/view/callbacks/callbacks.js
@@ -38,7 +38,7 @@ steal("can/util", "can/view",function(can){
 				can.dev.warn("Custom tag: " + tagName.toLowerCase() + " is already defined");
 			}
 			if (!automaticCustomElementCharacters.test(tagName)) {
-				can.dev.warn("Custom tag: " + tagName.toLowerCase() + " not hyphanited");
+				can.dev.warn("Custom tag: " + tagName.toLowerCase() + " is missing a hyphen");
 			}
 			//!steal-remove-end
 			// if we have html5shive ... re-generate

--- a/view/callbacks/callbacks.js
+++ b/view/callbacks/callbacks.js
@@ -37,7 +37,7 @@ steal("can/util", "can/view",function(can){
 			if (typeof tags[tagName.toLowerCase()] !== 'undefined') {
 				can.dev.warn("Custom tag: " + tagName.toLowerCase() + " is already defined");
 			}
-			if (!automaticCustomElementCharacters.test(tagName)) {
+			if (!automaticCustomElementCharacters.test(tagName) && tagName !== "content") {
 				can.dev.warn("Custom tag: " + tagName.toLowerCase() + " is missing a hyphen");
 			}
 			//!steal-remove-end

--- a/view/callbacks/callbacks.js
+++ b/view/callbacks/callbacks.js
@@ -37,6 +37,9 @@ steal("can/util", "can/view",function(can){
 			if (typeof tags[tagName.toLowerCase()] !== 'undefined') {
 				can.dev.warn("Custom tag: " + tagName.toLowerCase() + " is already defined");
 			}
+			if (!automaticCustomElementCharacters.test(tagName)) {
+				can.dev.warn("Custom tag: " + tagName.toLowerCase() + " not hyphanited");
+			}
 			//!steal-remove-end
 			// if we have html5shive ... re-generate
 			if (can.global.html5) {

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -3604,6 +3604,18 @@ steal("can/util/vdom/document", "can/util/vdom/build_fragment","can/view/stache"
 
 				can.dev.warn = oldlog;
 			});
+
+			test("logging: warning if tag name is missing a hyphen (#1541)", function() {
+				var oldlog = can.dev.warn;
+				can.dev.warn = function(text) {
+					ok(text, "got a message");
+					can.dev.warn = oldlog;
+				};
+
+				can.view.tag('nohyphen', function(tag, tagHandler) {});
+				var template = can.stache('<nohyphen></nohyphen>');
+				template();
+			});
 		}
 		//!steal-remove-end
 		test("Calling .fn without arguments should forward scope by default (#658)", function(){
@@ -4811,18 +4823,6 @@ steal("can/util/vdom/document", "can/util/vdom/build_fragment","can/view/stache"
             }));
 
             equal(frag.firstChild.getAttribute("f"),"f", "able to set f");
-		});
-
-		test("warning if tag name is missing a hyphen (#1541)", function() {
-				var oldlog = can.dev.warn;
-				can.dev.warn = function(text) {
-					ok(text, "got a message");
-					can.dev.warn = oldlog;
-				};
-
-				can.view.tag('nohyphen', function(tag, tagHandler) {});
-				var template = can.stache('<nohyphen></nohyphen>');
-				template();
 		});
 		
 		// PUT NEW TESTS RIGHT BEFORE THIS!

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -4821,9 +4821,7 @@ steal("can/util/vdom/document", "can/util/vdom/build_fragment","can/view/stache"
 				};
 
 				can.view.tag('nohyphen', function(tag, tagHandler) {});
-
 				var template = can.stache('<nohyphen></nohyphen>');
-				console.log(template());
 				template();
 		});
 		

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -3605,13 +3605,12 @@ steal("can/util/vdom/document", "can/util/vdom/build_fragment","can/view/stache"
 				can.dev.warn = oldlog;
 			});
 
-			test("logging: warning if tag name is missing a hyphen (#1541)", function() {
+			test("Logging: warning if tag name is missing a hyphen (#1541)", function() {
 				var oldlog = can.dev.warn;
 				can.dev.warn = function(text) {
 					ok(text, "got a message");
 					can.dev.warn = oldlog;
 				};
-
 				can.view.tag('nohyphen', function(tag, tagHandler) {});
 				var template = can.stache('<nohyphen></nohyphen>');
 				template();

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -4812,6 +4812,20 @@ steal("can/util/vdom/document", "can/util/vdom/build_fragment","can/view/stache"
 
             equal(frag.firstChild.getAttribute("f"),"f", "able to set f");
 		});
+
+		test("warning if tag name is missing a hyphen (#1541)", function() {
+				var oldlog = can.dev.warn;
+				can.dev.warn = function(text) {
+					ok(text, "got a message");
+					can.dev.warn = oldlog;
+				};
+
+				can.view.tag('nohyphen', function(tag, tagHandler) {});
+
+				var template = can.stache('<nohyphen></nohyphen>');
+				console.log(template());
+				template();
+		});
 		
 		// PUT NEW TESTS RIGHT BEFORE THIS!
 	}


### PR DESCRIPTION
fix #1541 