### PR TITLE
Use YouTube embed link to avoid cross origin errors

### DIFF
--- a/util/fixture/doc/fixture.md
+++ b/util/fixture/doc/fixture.md
@@ -9,7 +9,7 @@
 
 In the following CanJS community hangout we also talk about CanJS models and fixtures:
 
-<iframe width="662" height="372" src="https://www.youtube.com/watch?v=Tyr_087p8CQ" frameborder="0" allowfullscreen></iframe>
+<iframe width="662" height="372" src="https://www.youtube.com/embed/Tyr_087p8CQ" frameborder="0" allowfullscreen></iframe>
 
 @signature `can.fixture( url, toUrl )`
 

--- a/view/doc/tag.md
+++ b/view/doc/tag.md
@@ -8,7 +8,7 @@ Register custom behavior for a given tag.
 Registers the `tagHandler` callback when `tagName` is found 
 in a template. Check out this video where we talk about different possiblities to use can.view.tag:
 
-<iframe width="662" height="372" src="https://www.youtube.com/watch?v=ahjd5OQcs7c" frameborder="0" allowfullscreen></iframe>
+<iframe width="662" height="372" src="https://www.youtube.com/embed/ahjd5OQcs7c" frameborder="0" allowfullscreen></iframe>
 
 @release 2.1
 


### PR DESCRIPTION
Getting domain issues with a couple of the YouTube videos in the docs, so I can't view them directly:

<img width="467" alt="canjs_-_can_fixture" src="https://cloud.githubusercontent.com/assets/4423365/14068766/8184dd12-f442-11e5-9f84-160a7386bb7e.png">

The rest use the embed link and work great. They are very helpful!