### PR TITLE
Add exclusive mapping to map/define

### DIFF
--- a/map/define/define.js
+++ b/map/define/define.js
@@ -260,13 +260,23 @@ steal('can/util','can/map/map_helpers.js', 'can/map', 'can/compute', function (c
 		}
 		var baseObj = oldRemapObject(obj);
 		var newObj = {};
-		if (baseObj.hasOwnProperty('_cid')) {
-			newObj._cid = baseObj._cid;
+		for (var prop in baseObj) {
+			if (prop.substr(0, 1) === '%' || prop.substr(0, 1) === '_') {
+				newObj[prop] = baseObj[prop];
+			}
 		}
 
 		for (var prop in this.define) {
 			if (baseObj.hasOwnProperty(prop)) {
 				newObj[prop] = baseObj[prop];
+			}
+		}
+
+		if (!this.exclusiveMapping) {
+			for (var prop in baseObj) {
+				if (!newObj.hasOwnProperty(prop)) {
+					newObj[prop] = baseObj[prop];
+				}
 			}
 		}
 

--- a/map/define/define.js
+++ b/map/define/define.js
@@ -292,6 +292,9 @@ steal('can/util','can/map/map_helpers.js', 'can/map', 'can/compute', function (c
 			}
 			// If there's a Type create a new instance of it
 			if (Type && !(newValue instanceof Type)) {
+				if (Type.shortName === 'Map' && typeof newValue === 'object') {
+					newValue.parent = this;
+				}
 				newValue = new Type(newValue);
 			}
 			// If the newValue is a Map, we need to hook it up

--- a/map/map.js
+++ b/map/map.js
@@ -214,7 +214,7 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 					return this._get(attr+"");
 				} else {
 					// Set an attribute.
-					this._set(attr + '', this._remapObject(val));
+					this._set(attr + '', val);
 					return this;
 				}
 			},

--- a/map/map.js
+++ b/map/map.js
@@ -151,13 +151,18 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 				var teardownMapping = obj && mapHelpers.addToMap(obj, this);
 
 				var defaultValues = this._setupDefaults(obj);
-				var data = can.extend(can.extend(true, {}, defaultValues), obj);
+				var data = can.extend(can.extend(true, {}, defaultValues), this._remapObject(obj));
 
 				this.attr(data);
 
 				if (teardownMapping) {
 					teardownMapping();
 				}
+			},
+
+			// this will be over ridden by define
+			_remapObject:function (obj) {
+				return obj;
 			},
 
 			// ### _setupComputes
@@ -209,7 +214,7 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 					return this._get(attr+"");
 				} else {
 					// Set an attribute.
-					this._set(attr+"", val);
+					this._set(attr + '', this._remapObject(val));
 					return this;
 				}
 			},
@@ -462,7 +467,7 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 				// Merge current properties with the new ones.
 				this._each(function (curVal, prop) {
 					// You can not have a _cid property; abort.
-					if (prop === "_cid") {
+					if (prop === "_cid" || prop === "exclusiveMapping") {
 						return;
 					}
 					newVal = props[prop];
@@ -492,7 +497,7 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 				// Add remaining props.
 				for (prop in props) {
 					// Ignore _cid.
-					if (prop !== "_cid") {
+					if (prop !== "_cid" && prop !== "exclusiveMapping") {
 						newVal = props[prop];
 						this._set(prop, newVal, true);
 					}


### PR DESCRIPTION
When using map.define I added an option to specify ```exclusiveMapping: true```. If set the code will only use the attributes defined in the map when building the local copy of the object. Useful when the server based object has hundreds of properties, but the UI only uses a few of them.