### PR TITLE
Handle vm event bindings with dashes ("-") in them

### DIFF
--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -229,7 +229,7 @@ steal("can/util",
 				legacyBinding = attributeName.indexOf('can-') === 0,
 				event = attributeName.indexOf('can-') === 0 ?
 					attributeName.substr("can-".length) :
-					removeBrackets(attributeName, '(', ')'),
+					can.camelize(removeBrackets(attributeName, '(', ')')),
 				onBindElement = legacyBinding;
 	
 			if(event.charAt(0) === "$") {
@@ -417,7 +417,7 @@ steal("can/util",
 	can.view.attr(/\*[\w\.\-_]+/, behaviors.reference);
 
 	// `(EVENT)` event bindings.
-	can.view.attr(/^\([\$?\w\.]+\)$/, behaviors.event);
+	can.view.attr(/^\([\$?\w\.\-]+\)$/, behaviors.event);
 	
 	
 	//!steal-remove-start

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -2340,6 +2340,25 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 
 		ok(true, "was able to show without breaking");
 	});
+
+
+	test("(event) bindings can have a dash (\"-\") (#2347)", function () {
+		var viewModel = new can.Map({});
+
+		can.Component.extend({
+			tag: "my-component",
+			viewModel: viewModel
+		});
+
+		can.$('#qunit-fixture').append(
+			can.stache('<my-component (foo-bar-event)="fooBarHandler" />')({
+				fooBarHandler: function () {
+					ok(true, 'Handler was called');
+				}
+			}));
+
+		viewModel.dispatch('fooBarEvent');
+	});
 	
 
 });

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -2350,12 +2350,11 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 			viewModel: viewModel
 		});
 
-		can.$('#qunit-fixture').append(
-			can.stache('<my-component (foo-bar-event)="fooBarHandler" />')({
-				fooBarHandler: function () {
-					ok(true, 'Handler was called');
-				}
-			}));
+		can.append(can.$('#qunit-fixture'), can.stache('<my-component (foo-bar-event)="fooBarHandler" />')({
+			fooBarHandler: function () {
+				ok(true, 'Handler was called');
+			}
+		}));
 
 		viewModel.dispatch('fooBarEvent');
 	});


### PR DESCRIPTION
- Fix regex so that `(event-name)="someHandler"` is regognized
- Convert `event-name` to `eventName`
- Create a test

Closes #2347.