### PR TITLE
Pass list items to .sort(fn) and don't set the comparator

### DIFF
--- a/list/sort/sort.js
+++ b/list/sort/sort.js
@@ -200,13 +200,10 @@ steal('can/util', 'can/list', function (can) {
 		/**
 		 * @returns {number} The value that should be passed to the comparator
 		 **/
-		_getComparatorValue: function (item, overwrittenComparator) {
+		_getComparatorValue: function (item, singleUseComparator) {
 
 			// Use the value passed to .sort() as the comparator value
-			// if it is a string
-			var comparator = typeof overwrittenComparator === 'string' ?
-				overwrittenComparator :
-				this.comparator;
+			var comparator = singleUseComparator || this.comparator;
 
 			// If the comparator is a string, use it to get the value of that
 			// property on the item. Example:
@@ -231,13 +228,13 @@ steal('can/util', 'can/list', function (can) {
 			return a;
 		},
 
-		sort: function (comparator, silent) {
+		sort: function (singleUseComparator) {
 			var a, b, c, isSorted;
 
 			// Use the value passed to .sort() as the comparator function
 			// if it is a function
-			var comparatorFn = can.isFunction(comparator) ?
-				comparator :
+			var comparatorFn = can.isFunction(singleUseComparator) ?
+				singleUseComparator :
 				this._comparator;
 
 			for (var i, iMin, j = 0, n = this.length; j < n-1; j++) {
@@ -248,8 +245,8 @@ steal('can/util', 'can/list', function (can) {
 
 				for (i = j+1; i < n; i++) {
 
-					a = this._getComparatorValue(this.attr(i), comparator);
-					b = this._getComparatorValue(this.attr(iMin), comparator);
+					a = this._getComparatorValue(this.attr(i), singleUseComparator);
+					b = this._getComparatorValue(this.attr(iMin), singleUseComparator);
 
 					// [1, 2, 3, 4(b), 9, 6, 3(a)]
 					if (comparatorFn.call(this, a, b) < 0) {
@@ -275,20 +272,17 @@ steal('can/util', 'can/list', function (can) {
 				}
 
 				if (iMin !== j) {
-					this._swapItems(iMin, j, silent);
+					this._swapItems(iMin, j);
 				}
 			}
 
-
-			if (! silent) {
-				// Trigger length change so that {{#block}} helper can re-render
-				can.batch.trigger(this, 'length', [this.length]);
-			}
+			// Trigger length change so that {{#block}} helper can re-render
+			can.batch.trigger(this, 'length', [this.length]);
 
 			return this;
 		},
 
-		_swapItems: function (oldIndex, newIndex, silent) {
+		_swapItems: function (oldIndex, newIndex) {
 
 			var temporaryItemReference = this[oldIndex];
 
@@ -298,14 +292,12 @@ steal('can/util', 'can/list', function (can) {
 			// Place the item at the correct index
 			[].splice.call(this, newIndex, 0, temporaryItemReference);
 
-			if (! silent) {
-				// Update the DOM via can.view.live.list
-				can.batch.trigger(this, 'move', [
-					temporaryItemReference,
-					newIndex,
-					oldIndex
-				]);
-			}
+			// Update the DOM via can.view.live.list
+			can.batch.trigger(this, 'move', [
+				temporaryItemReference,
+				newIndex,
+				oldIndex
+			]);
 		}
 
 	});

--- a/list/sort/sort.js
+++ b/list/sort/sort.js
@@ -200,10 +200,13 @@ steal('can/util', 'can/list', function (can) {
 		/**
 		 * @returns {number} The value that should be passed to the comparator
 		 **/
-		_getComparatorValue: function (item) {
+		_getComparatorValue: function (item, overwrittenComparator) {
 
-			// Get the user supplied comparator
-			var comparator = this.comparator;
+			// Use the value passed to .sort() as the comparator value
+			// if it is a string
+			var comparator = typeof overwrittenComparator === 'string' ?
+				overwrittenComparator :
+				this.comparator;
 
 			// If the comparator is a string, use it to get the value of that
 			// property on the item. Example:
@@ -228,23 +231,14 @@ steal('can/util', 'can/list', function (can) {
 			return a;
 		},
 
-		sort: function (comparator) {
-
-			if (arguments.length) {
-
-				// Set the comparator; Sort if the value changed
-				this.attr('comparator', comparator);
-			} else {
-
-				// Sort without a comparator
-				this._sort();
-			}
-
-			return this;
-		},
-
-		_sort: function () {
+		sort: function (comparator, silent) {
 			var a, b, c, isSorted;
+
+			// Use the value passed to .sort() as the comparator function
+			// if it is a function
+			var comparatorFn = can.isFunction(comparator) ?
+				comparator :
+				this._comparator;
 
 			for (var i, iMin, j = 0, n = this.length; j < n-1; j++) {
 				iMin = j;
@@ -254,11 +248,11 @@ steal('can/util', 'can/list', function (can) {
 
 				for (i = j+1; i < n; i++) {
 
-					a = this._getComparatorValue(this.attr(i));
-					b = this._getComparatorValue(this.attr(iMin));
+					a = this._getComparatorValue(this.attr(i), comparator);
+					b = this._getComparatorValue(this.attr(iMin), comparator);
 
 					// [1, 2, 3, 4(b), 9, 6, 3(a)]
-					if (this._comparator.call(this, a, b) < 0) {
+					if (comparatorFn.call(this, a, b) < 0) {
 						isSorted = false;
 						iMin = i;
 					}
@@ -269,7 +263,7 @@ steal('can/util', 'can/list', function (can) {
 					// that are improperly sorted.
 					// Note: This is not part of the original selection
 					// sort agortithm
-					if (c && this._comparator.call(this, a, c) < 0) {
+					if (c && comparatorFn.call(this, a, c) < 0) {
 						isSorted = false;
 					}
 
@@ -281,18 +275,20 @@ steal('can/util', 'can/list', function (can) {
 				}
 
 				if (iMin !== j) {
-					this._swapItems(iMin, j);
+					this._swapItems(iMin, j, silent);
 				}
 			}
 
 
-			// Trigger length change so that {{#block}} helper can re-render
-			can.batch.trigger(this, 'length', [this.length]);
+			if (! silent) {
+				// Trigger length change so that {{#block}} helper can re-render
+				can.batch.trigger(this, 'length', [this.length]);
+			}
 
 			return this;
 		},
 
-		_swapItems: function (oldIndex, newIndex) {
+		_swapItems: function (oldIndex, newIndex, silent) {
 
 			var temporaryItemReference = this[oldIndex];
 
@@ -302,12 +298,14 @@ steal('can/util', 'can/list', function (can) {
 			// Place the item at the correct index
 			[].splice.call(this, newIndex, 0, temporaryItemReference);
 
-			// Update the DOM via can.view.live.list
-			can.batch.trigger(this, 'move', [
-				temporaryItemReference,
-				newIndex,
-				oldIndex
-			]);
+			if (! silent) {
+				// Update the DOM via can.view.live.list
+				can.batch.trigger(this, 'move', [
+					temporaryItemReference,
+					newIndex,
+					oldIndex
+				]);
+			}
 		}
 
 	});

--- a/list/sort/sort_test.js
+++ b/list/sort/sort_test.js
@@ -690,7 +690,7 @@ steal("can/list/sort", "can/test", "can/view/mustache", "can/view/stache", "can/
 		evaluate();
 	});
 
-	test('Setting comparator with .sort() (#2159)', function () {
+	test(".sort(comparatorFn) is passed list items regardless of .attr('comparator') value (#2159)", function () {
 		var list = new can.List([
 			{ letter: 'x', number: 3 },
 			{ letter: 'y', number: 2 },
@@ -703,16 +703,48 @@ steal("can/list/sort", "can/test", "can/view/mustache", "can/view/stache", "can/
 		equal(list.attr('1.number'), 2, 'Second value is correct');
 		equal(list.attr('2.number'), 3, 'Third value is correct');
 
-		list.sort('letter');
+		list.sort(function (a, b) {
+			a = a.attr('letter');
+			b = b.attr('letter');
+			return (a === b) ? 0 : (a < b) ? -1 : 1;
+		});
 
-		equal(list.attr('0.letter'), 'x', 'First value is correct after comparator set');
-		equal(list.attr('1.letter'), 'y', 'Second value is correct after comparator set');
-		equal(list.attr('2.letter'), 'z', 'Third value is correct after comparator set');
+		equal(list.attr('0.letter'), 'x',
+			'First value is correct after sort with single use comparator');
+		equal(list.attr('1.letter'), 'y',
+			'Second value is correct after sort with single use comparator');
+		equal(list.attr('2.letter'), 'z',
+			'Third value is correct after sort with single use comparator');
+	});
 
-		list.push({ letter: 'w', number: 4 });
+	test("List is not sorted on change after calling .sort(fn)", function () {
+		var list = new can.List([
+			{ letter: 'x', number: 3 },
+			{ letter: 'y', number: 2 },
+			{ letter: 'z', number: 1 },
+		]);
 
-		equal(list.attr('0.letter'), 'w', 'First value is correct after insert');
-		equal(list.attr('0.number'), 4, 'First value is correct after insert');
+		list.sort(function (a, b) {
+			a = a.attr('letter');
+			b = b.attr('letter');
+			return (a === b) ? 0 : (a < b) ? -1 : 1;
+		});
 
+		equal(list.attr('0.letter'), 'x',
+			'First value is correct after sort with single use comparator');
+		equal(list.attr('1.letter'), 'y',
+			'Second value is correct after sort with single use comparator');
+		equal(list.attr('2.letter'), 'z',
+			'Third value is correct after sort with single use comparator');
+
+		list.sort = function () {
+			ok(false, 'The list is not sorted as a result of change');
+		};
+
+		list.attr('2.letter', 'a');
+
+		equal(list.attr('0.letter'), 'x','First value is still correct');
+		equal(list.attr('1.letter'), 'y', 'Second value is still correct');
+		equal(list.attr('2.letter'), 'a', 'Third value is correctly out of place');
 	});
 });


### PR DESCRIPTION
This PR does two things: 

- `list.comparator('prop'); list.sort(fn)` - `fn` will be passed the list items and **not** the item's `prop` value (#2159)
- `list.sort(fn)` - `fn` will **not** be set as `list.attr('comparator', fn)` under the hood thus preserving the ability to call `.sort()` at will without setting up sorting for every "change" event (#2398)

Closes #2159, and #2398.
