### PR TITLE
fix svg-use not displaying svg-image (#2384)

### DIFF
--- a/util/attr/attr.js
+++ b/util/attr/attr.js
@@ -192,6 +192,11 @@ steal("can/util/can.js", function (can) {
 								el.setAttributeNode(node);
 							} else {
 								el.setAttribute(attrName, val);
+
+								// fix svg-use not displaying svg-image (i.e. element is collapsed) because namespace-specific 'el.setAttributeNS()' must be used to set 'xlink:href'-attribute instead of 'el.setAttribute()' (#2384)
+								if(el.tagName === "use" && attrName === "xlink:href"){
+									el.setAttributeNS("http://www.w3.org/1999/xlink", "href", val);
+								}
 							}
 						};
 					}

--- a/util/attr/attr_test.js
+++ b/util/attr/attr_test.js
@@ -145,6 +145,13 @@ steal('can/util', 'can/view/stache', 'can/util/attr', 'steal-qunit', function ()
 		equal(svg.getAttribute('class'), 'my-class', 'you can pass an object to svg class');
 	});
 
+	test("set xlink:href attribute via setAttributeNS for svg-use (#2384)", function() {
+		var use = document.createElementNS("http://www.w3.org/2000/svg", "use");
+
+		can.attr.set(use, "xlink:href", "svgUri");
+		equal(use.getAttributeNS("http://www.w3.org/1999/xlink", "href"), "svgUri", "svg-use xlink:href was set with setAttributeNS");
+	});
+
 	if (window.jQuery || window.Zepto) {
 
 		test("zepto or jQuery - bind and unbind", function () {

--- a/view/stache/stache.js
+++ b/view/stache/stache.js
@@ -21,6 +21,8 @@ steal(
 	var svgNamespace = "http://www.w3.org/2000/svg";
 	var namespaces = {
 		"svg": svgNamespace,
+		// this allows svg-use to display svg-image which is need in 'attr.js' (via 'target.js') (#2384)
+		"use": svgNamespace,
 		// this allows a partial to start with g.
 		"g": svgNamespace
 	},

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -4832,6 +4832,17 @@ steal("can/util/vdom/document", "can/util/vdom/build_fragment","can/view/stache"
 			var template = can.stache('{{foo 1 2 3 4 5}}');
 			template({});
 		});
+
+		if(doc.createElementNS) {
+			test("svg namespace for svg-use elements (#2384)", function(){
+				var template = can.stache('<use xlink:href="svgUri" />');
+				var frag = template({});
+
+				equal(frag.firstChild.namespaceURI, "http://www.w3.org/2000/svg", "svg namespace for svg-use element");
+				equal(frag.firstChild.getAttributeNS("http://www.w3.org/1999/xlink", "href"), "svgUri", "svg-use xlink:href was set with setAttributeNS");
+			});
+		}
+
 		// PUT NEW TESTS RIGHT BEFORE THIS!
 	}
 


### PR DESCRIPTION
fix svg-use not displaying svg-image (i.e. element is collapsed) because namespace-specific 'el.setAttributeNS()' must be used to set 'xlink:href'-attribute instead of 'el.setAttribute() (#2384)