### PR TITLE
Port dynamic depth changes over from 3.0

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -33,7 +33,7 @@
 	"undef": true,
 	"unused": "vars",
 	"trailing": true,
-	"maxdepth": 4,
+	"maxdepth": 5,
 	"boss" : true,
 	"eqnull": true,
 	"evil": true,

--- a/compute/compute_test.js
+++ b/compute/compute_test.js
@@ -877,5 +877,36 @@ steal("can/compute", "can/test", "can/map", "steal-qunit", "./read_test", functi
 		can.batch.stop();
 	});
 
+	test("Change propagation in a batch with late bindings (#2412)", function(){
+		var rootA = new can.Compute('a');
+		var rootB = new can.Compute('b');
 
+		var childA = new can.Compute(function() {
+			return "childA"+rootA.get();
+		});
+
+		var grandChild = new can.Compute(function() {
+
+			var b = rootB.get();
+			if (b === "b") {
+				return "grandChild->b";
+			}
+
+			var a = childA.get();
+			return "grandChild->" + a;
+		});
+
+
+		childA.bind('change', function(ev, newVal, oldVal) {});
+
+		grandChild.bind('change', function(ev, newVal, oldVal) {
+			equal(newVal, "grandChild->childAA");
+		});
+
+		can.batch.start();
+		rootA.set('A');
+		rootB.set('B');
+		can.batch.stop();
+
+	});
 });

--- a/compute/proto_compute.js
+++ b/compute/proto_compute.js
@@ -296,9 +296,12 @@ steal('can/util', 'can/util/bind', 'can/compute/read.js','can/compute/get_value_
 		// Returns the cached value if `bound`, otherwise, returns
 		// the _get value.
 		get: function() {
+
+			var recordingObservation = can.__isRecordingObserves();
+
 			// If an external compute is tracking observables and
 			// this compute can be listened to by "function" based computes ....
-			if(can.__isRecordingObserves() && this._canObserve !== false) {
+			if(recordingObservation && this._canObserve !== false) {
 
 				// ... tell the tracking compute to listen to change on this computed.
 				can.__observe(this, 'change');
@@ -310,6 +313,9 @@ steal('can/util', 'can/util/bind', 'can/compute/read.js','can/compute/get_value_
 			}
 			// If computed is bound, use the cached value.
 			if (this.bound) {
+				if(recordingObservation && this.getDepth && this.getDepth() >= recordingObservation.getDepth()) {
+					ObservedInfo.updateUntil(this.readInfo);
+				}
 				return this.value;
 			} else {
 				return this._get();
@@ -405,6 +411,7 @@ steal('can/util', 'can/util/bind', 'can/compute/read.js','can/compute/get_value_
 		var readInfo = new ObservedInfo(func, context, compute);
 
 		return {
+			readInfo: readInfo,
 			// Call `onchanged` when any source observables change.
 			_on: function() {
 				readInfo.getValueAndBind();


### PR DESCRIPTION
Overview:

When a compute reads another compute with a depth greater than its own, continue to evaluate computes in the stack until the initial (deeper) dependency, and all its dependencies, have been evaluated, before returning a value. 

Sources: 

- canjs/can-observation@c337c67 
- canjs/can-compute@5d1cd72 

Closes #2421