### PR TITLE
Fixed nested if-s and each helper in attributes

### DIFF
--- a/view/stache/expression.js
+++ b/view/stache/expression.js
@@ -316,7 +316,8 @@ steal("can/util",
 
 		var helperOptionArg = {
 			fn: function () {},
-			inverse: function () {}
+			inverse: function () {},
+			stringOnly: stringOnly
 		},
 			context = scope.attr("."),
 			args = this.args(scope, helperOptions, nodeList, truthyRenderer, falseyRenderer, stringOnly),

--- a/view/stache/expression.js
+++ b/view/stache/expression.js
@@ -323,7 +323,7 @@ steal("can/util",
 			hash = this.hash(scope, helperOptions, nodeList, truthyRenderer, falseyRenderer, stringOnly);
 
 		// Add additional data to be used by helper functions
-		utils.convertToScopes(helperOptionArg, scope,helperOptions, nodeList, truthyRenderer, falseyRenderer);
+		utils.convertToScopes(helperOptionArg, scope,helperOptions, nodeList, truthyRenderer, falseyRenderer, stringOnly);
 
 		can.simpleExtend(helperOptionArg, {
 			context: context,

--- a/view/stache/mustache_core.js
+++ b/view/stache/mustache_core.js
@@ -102,7 +102,7 @@ steal("can/util",
 					exprData: exprData,
 					helpersScope: helperOptions
 				};
-				utils.convertToScopes(helperOptionArg, scope,helperOptions, nodeList, truthyRenderer, falseyRenderer);
+				utils.convertToScopes(helperOptionArg, scope,helperOptions, nodeList, truthyRenderer, falseyRenderer, stringOnly);
 
 				value = exprData.value(scope, helperOptions, helperOptionArg);
 				if(exprData.isHelper) {
@@ -144,7 +144,7 @@ steal("can/util",
 					fn: function () {},
 					inverse: function () {}
 				};
-				utils.convertToScopes(helperOptionArg, scope, helperOptions, nodeList, truthyRenderer, falseyRenderer);
+				utils.convertToScopes(helperOptionArg, scope, helperOptions, nodeList, truthyRenderer, falseyRenderer, stringOnly);
 				return function(){
 					// Get the value
 					var finalValue;

--- a/view/stache/mustache_helpers.js
+++ b/view/stache/mustache_helpers.js
@@ -35,7 +35,7 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 				key,
 				i;
 
-			if( resolved instanceof can.List ) {
+			if( resolved instanceof can.List  && !options.stringOnly) {
 				return function(el){
 					// make a child nodeList inside the can.view.live.html nodeList
 					// so that if the html is re
@@ -62,12 +62,14 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 			var expr = resolved;
 
 			if ( !! expr && utils.isArrayLike(expr)) {
-				for (i = 0; i < expr.length; i++) {
+				var isCanList = expr instanceof can.List;
+				for (i = 0; i < (isCanList ? expr.attr('length') : expr.length); i++) {
+					var item = isCanList ? expr.attr(i) : expr[i];
 					result.push(options.fn(options.scope.add({
 							"%index": i,
 							"@index": i
 						},{notContext: true})
-						.add(expr[i])));
+						.add(item)));
 				}
 			} else if (utils.isObserveLike(expr)) {
 				keys = can.Map.keys(expr);
@@ -91,7 +93,7 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 				}
 
 			}
-			return result;
+			return !options.stringOnly ? result : result.join('');
 
 		},
 		"@index": function(offset, options) {

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -4843,6 +4843,24 @@ steal("can/util/vdom/document", "can/util/vdom/build_fragment","can/view/stache"
 			var template = can.stache('{{foo 1 2 3 4 5}}');
 			template({});
 		});
+
+		test('Nested if-s inside a text section (#9)', function(assert){
+			var template = can.stache('<div class="{{#if sorting}}sort{{#if ascending}}-ascend{{/if}}{{/if}}"></div>');
+
+			var vm = new can.Map({
+				sorting: true,
+				ascending: false
+			});
+			var frag = template(vm);
+			var className = frag.firstChild.className;
+
+			assert.equal( className, 'sort');
+
+			vm.attr('ascending', true);
+			className = frag.firstChild.className;
+
+			assert.equal( className, 'sort-ascend');
+		});
 		// PUT NEW TESTS RIGHT BEFORE THIS!
 	}
 

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -4861,6 +4861,22 @@ steal("can/util/vdom/document", "can/util/vdom/build_fragment","can/view/stache"
 
 			assert.equal( className, 'sort-ascend');
 		});
+		test('Helper each inside a text section (attribute) (#8)', function(assert){
+			var template = can.stache('<div class="{{#each list}}{{.}} {{/}}"></div>');
+
+			var vm = new can.Map({
+				list: new can.List(['one','two'])
+			});
+			var frag = template(vm);
+			var className = frag.firstChild.className;
+
+			assert.equal( className, 'one two ' );
+
+			vm.attr('list').push('three');
+			className = frag.firstChild.className;
+
+			assert.equal( className, 'one two three ' );
+		});
 		// PUT NEW TESTS RIGHT BEFORE THIS!
 	}
 

--- a/view/stache/utils.js
+++ b/view/stache/utils.js
@@ -74,7 +74,7 @@ steal("can/util", "can/view/scope",function(can){
 				}
 				var result = rendererWithScope(newScope, newOptions || parentOptions, parentNodeList|| nodeList );
 				return result;
-			}
+			};
 			return observeObservables ? convertedRenderer : can.__notObserve(convertedRenderer);
 		},
 		Options: Options

--- a/view/stache/utils.js
+++ b/view/stache/utils.js
@@ -48,22 +48,22 @@ steal("can/util", "can/view/scope",function(can){
 		},
 		// Sets .fn and .inverse on a helperOptions object and makes sure
 		// they can reference the current scope and options.
-		convertToScopes: function(helperOptions, scope, options, nodeList, truthyRenderer, falseyRenderer){
+		convertToScopes: function(helperOptions, scope, options, nodeList, truthyRenderer, falseyRenderer, isStringOnly){
 			// overwrite fn and inverse to always convert to scopes
 			if(truthyRenderer) {
-				helperOptions.fn = this.makeRendererConvertScopes(truthyRenderer, scope, options, nodeList);
+				helperOptions.fn = this.makeRendererConvertScopes(truthyRenderer, scope, options, nodeList, isStringOnly);
 			}
 			if(falseyRenderer) {
-				helperOptions.inverse = this.makeRendererConvertScopes(falseyRenderer, scope, options, nodeList);
+				helperOptions.inverse = this.makeRendererConvertScopes(falseyRenderer, scope, options, nodeList, isStringOnly);
 			}
 		},
 		// Returns a new renderer function that makes sure any data or helpers passed
 		// to it are converted to a can.view.Scope and a can.view.Options.
-		makeRendererConvertScopes: function (renderer, parentScope, parentOptions, nodeList) {
+		makeRendererConvertScopes: function (renderer, parentScope, parentOptions, nodeList, observeObservables) {
 			var rendererWithScope = function(ctx, opts, parentNodeList){
 				return renderer(ctx || parentScope, opts, parentNodeList);
 			};
-			return can.__notObserve(function (newScope, newOptions, parentNodeList) {
+			var convertedRenderer = function (newScope, newOptions, parentNodeList) {
 				// prevent binding on fn.
 				// If a non-scope value is passed, add that to the parent scope.
 				if (newScope !== undefined && !(newScope instanceof can.view.Scope)) {
@@ -74,7 +74,8 @@ steal("can/util", "can/view/scope",function(can){
 				}
 				var result = rendererWithScope(newScope, newOptions || parentOptions, parentNodeList|| nodeList );
 				return result;
-			});
+			}
+			return observeObservables ? convertedRenderer : can.__notObserve(convertedRenderer);
 		},
 		Options: Options
 	};


### PR DESCRIPTION
This fixes (the same as for can-stache [issue 8](https://github.com/canjs/can-stache/issues/8) and [issue 9](https://github.com/canjs/can-stache/issues/9)):
```
<div class="{{#if sorting}}sort{{#if ascending}}-ascend{{/if}}{{/if}}"></div>

<div class="{{#sorting}}sort{{#ascending}}-ascend{{/}}{{/}}"></div>

<div class="{{#each list}} {{.}} {{/}}"></div>
```