### PR TITLE
Backporting stache binding fix for special values. #2370

### DIFF
--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -259,32 +259,6 @@ steal("can/util",
 						expr = new expression.Call(expr, defaultArgs, {} );
 					}
 	
-					// We grab the first item and treat it as a method that
-					// we'll call.
-					var scopeData = data.scope.read(expr.methodExpr.key, {
-						isArgument: true
-					});
-	
-					// We break out early if the first argument isn't available
-					// anywhere.
-	
-					if (!scopeData.value) {
-						scopeData = data.scope.read(expr.methodExpr.key, {
-							isArgument: true
-						});
-	
-						//!steal-remove-start
-						can.dev.warn("can/view/bindings: " + attributeName + " couldn't find method named " + expr.methodExpr.key, {
-							element: el,
-							scope: data.scope
-						});
-						//!steal-remove-end
-	
-						return null;
-					}
-	
-	
-	
 					// make a scope with these things just under
 	
 					var localScope = data.scope.add({
@@ -304,6 +278,30 @@ steal("can/util",
 						notContext: true
 					});
 	
+					// We grab the first item and treat it as a method that
+					// we'll call.
+					var scopeData = localScope.read(expr.methodExpr.key, {
+						isArgument: true
+					});
+	
+					// We break out early if the first argument isn't available
+					// anywhere.
+	
+					if (!scopeData.value) {
+						scopeData = localScope.read(expr.methodExpr.key, {
+							isArgument: true
+						});
+	
+						//!steal-remove-start
+						can.dev.warn("can/view/bindings: " + attributeName + " couldn't find method named " + expr.methodExpr.key, {
+							element: el,
+							scope: data.scope
+						});
+						//!steal-remove-end
+	
+						return null;
+					}
+
 					var args = expr.args(localScope, null)();
 					
 	

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -2359,7 +2359,6 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		viewModel.dispatch('fooBarEvent');
 	});
 	
-<<<<<<< c75da90585d423b6b7f3d83f7b960bb7225295cd
 	test("one-way pass computes to components with ~", function(assert) {
 		expect(7);
 		can.Component.extend({

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -1978,42 +1978,42 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 	});
 	
 	test('previously non-existing select value gets selected from a list when it is added (#1762)', function() {
-	  var template = can.view.stache('<select {($value)}="{person}">' +
-	      '<option></option>' +
-	      '{{#each people}}<option value="{{.}}">{{.}}</option>{{/each}}' +
-	    '</select>' +
-	    '<input type="text" size="5" {($value)}="person">'
-	  );
+		var template = can.view.stache('<select {($value)}="{person}">' +
+				'<option></option>' +
+				'{{#each people}}<option value="{{.}}">{{.}}</option>{{/each}}' +
+			'</select>' +
+			'<input type="text" size="5" {($value)}="person">'
+		);
 
-	  var people = new can.List([
-	    "Alexis",
-	    "Mihael",
-	    "Curtis",
-	    "David"
-	  ]);
+		var people = new can.List([
+			"Alexis",
+			"Mihael",
+			"Curtis",
+			"David"
+		]);
 
-	  var vm = new can.Map({
-	    person: 'Brian',
-	    people: people
-	  });
+		var vm = new can.Map({
+			person: 'Brian',
+			people: people
+		});
 
-	  stop();
-	  vm.bind('person', function(ev, newVal, oldVal) {
-	    ok(false, 'person attribute should not change');
-	  });
+		stop();
+		vm.bind('person', function(ev, newVal, oldVal) {
+			ok(false, 'person attribute should not change');
+		});
 
-	  var frag = template(vm);
+		var frag = template(vm);
 
-	  equal(vm.attr('person'), 'Brian', 'Person is still set');
+		equal(vm.attr('person'), 'Brian', 'Person is still set');
 
-	  setTimeout(function() {
-	    people.push('Brian');
-	    setTimeout(function() {
-	      var select = frag.firstChild;
-	      ok(select.lastChild.selected, 'New child should be selected');
-	      start();
-	    }, 20);
-	  }, 20);
+		setTimeout(function() {
+			people.push('Brian');
+			setTimeout(function() {
+				var select = frag.firstChild;
+				ok(select.lastChild.selected, 'New child should be selected');
+				start();
+			}, 20);
+		}, 20);
 	});
 	
 	test("one-way <select> bindings keep value if options are replaced (#1762)", function(){
@@ -2359,6 +2359,7 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		viewModel.dispatch('fooBarEvent');
 	});
 	
+<<<<<<< c75da90585d423b6b7f3d83f7b960bb7225295cd
 	test("one-way pass computes to components with ~", function(assert) {
 		expect(7);
 		can.Component.extend({
@@ -2395,4 +2396,24 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		ok(vm.attr("compute").isComputed, "Back to being a compute");
 	});
 
+	test("special values get called", function(assert) {
+		expect(1);
+		stop();
+	
+		can.Component.extend({
+			tag: 'ref-syntax',
+			viewModel: new can.Map({
+				method: function() {
+					assert.ok(true, "method called");
+					start();
+				}
+			})
+		});
+	
+		can.append(
+			can.$("#qunit-fixture"),
+			can.stache("<ref-syntax ($inserted)=\"%viewModel.method()\">" +
+							"</ref-syntax>")({})
+		);
+	});
 });


### PR DESCRIPTION
Backports https://github.com/canjs/can-stache-bindings/pull/56 to CanJS 2.3, fixes #2370 

Since there isn't a nice way to set values on inputs across all base libraries, the tests doing that have been removed.  The inserted event is still shown to call the method on the view model.