### PR TITLE
Adding PhantomJS from NPM for a newer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"bower": "~1.3.8",
 		"browserify": "~8.1.0",
 		"connect": "^2.14.4",
+		"documentjs": "~0.3.2",
 		"grunt": "~0.4.0",
 		"grunt-banner": "^0.3.1",
 		"grunt-cli": "~0.1.7",
@@ -44,14 +45,14 @@
 		"jquery-ui": "^1.10.5",
 		"jquerypp": "^2.0.0",
 		"lodash": "2.4.1",
+		"phantomjs-prebuilt": "^2.1.12",
 		"rimraf": "2.1",
 		"steal": "^0.13.0-pre.7",
 		"steal-benchmark": "~0.0.1",
 		"steal-qunit": "0.0.2",
 		"steal-tools": "^0.13.3",
 		"testee": "^0.2.4",
-		"zombie": "3.1.1",
-		"documentjs": "~0.3.2"
+		"zombie": "3.1.1"
 	},
 	"scripts": {
 		"test": "grunt test"


### PR DESCRIPTION
Because of https://github.com/daffl/launchpad/pull/68 we can now use a locally installed PhantomJS which will get us a newer version and should fix some of the current test timeouts.