### PR TITLE
Add index aliases to key iteration.

### DIFF
--- a/view/stache/mustache_core.js
+++ b/view/stache/mustache_core.js
@@ -32,20 +32,6 @@ steal("can/util",
 	// ## Helpers
 
 	var mustacheLineBreakRegExp = /(?:(?:^|(\r?)\n)(\s*)(\{\{([^\}]*)\}\}\}?)([^\S\n\r]*)($|\r?\n))|(\{\{([^\}]*)\}\}\}?)/g,
-		// A helper for calling the truthy subsection for each item in a list and putting them in a document Fragment.
-		getItemsFragContent = function(items, isObserveList, helperOptions, options){
-			var frag = (can.document || can.global.document).createDocumentFragment();
-			for (var i = 0, len = items.length; i < len; i++) {
-				append(frag, helperOptions.fn( isObserveList ? items.attr('' + i) : items[i], options) );
-			}
-			return frag;
-		},
-		// Appends some content to a document fragment.  If the content is a string, it puts it in a TextNode.
-		append = function(frag, content){
-			if(content) {
-				frag.appendChild(typeof content === "string" ? frag.ownerDocument.createTextNode(content) : content);
-			}
-		},
 		// A helper for calling the truthy subsection for each item in a list and returning them in a string.
 		getItemsStringContent = function(items, isObserveList, helperOptions, options){
 			var txt = "";
@@ -55,9 +41,6 @@ steal("can/util",
 			return txt;
 		},
 		k = function(){};
-
-
-
 
 
 	var core = {
@@ -161,8 +144,11 @@ steal("can/util",
 						var isObserveList = utils.isObserveLike(finalValue);
 
 						if(isObserveList ? finalValue.attr("length") : finalValue.length) {
-							return (stringOnly ? getItemsStringContent: getItemsFragContent  )
-								(finalValue, isObserveList, helperOptionArg, helperOptions );
+							if (stringOnly) {
+								return getItemsStringContent(finalValue, isObserveList, helperOptionArg, helperOptions);
+							} else {
+								return can.frag(utils.getItemsFragContent(finalValue, helperOptionArg, scope));
+							}
 						} else {
 							return helperOptionArg.inverse(scope, helperOptions);
 						}

--- a/view/stache/mustache_helpers.js
+++ b/view/stache/mustache_helpers.js
@@ -62,15 +62,8 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 			var expr = resolved;
 
 			if ( !! expr && utils.isArrayLike(expr)) {
-				var isCanList = expr instanceof can.List;
-				for (i = 0; i < (isCanList ? expr.attr('length') : expr.length); i++) {
-					var item = isCanList ? expr.attr(i) : expr[i];
-					result.push(options.fn(options.scope.add({
-							"%index": i,
-							"@index": i
-						},{notContext: true})
-						.add(item)));
-				}
+				var fragItems = utils.getItemsFragContent(expr, options, options.scope);
+				Array.prototype.push.apply(result, fragItems);
 			} else if (utils.isObserveLike(expr)) {
 				keys = can.Map.keys(expr);
 				// listen to keys changing so we can livebind lists of attributes.

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -4877,6 +4877,21 @@ steal("can/util/vdom/document", "can/util/vdom/build_fragment","can/view/stache"
 
 			assert.equal( className, 'one two three ' );
 		});
+
+		test("{{%index}} and {{@index}} work with {{#key}} iteration (#2361)", function () {
+			var template = can.stache('<p>{{#iter}}<span>{{@index}}</span>{{/iter}}</p> \
+					   <p>{{#iter}}<span>{{%index}}</span>{{/iter}}</p>');
+			var div = doc.createElement('div');
+			var dom = template({iter: new can.List(['hey', 'there'])});
+			div.appendChild(dom);
+
+			var span = div.getElementsByTagName('span');
+			equal((span[0].innerHTML), '0', 'iteration for @index');
+			equal((span[1].innerHTML), '1', 'iteration for %index');
+			equal((span[2].innerHTML), '0', 'iteration for %index');
+			equal((span[3].innerHTML), '1', 'iteration for %index');
+		});
+
 		// PUT NEW TESTS RIGHT BEFORE THIS!
 	}
 

--- a/view/stache/utils.js
+++ b/view/stache/utils.js
@@ -77,6 +77,22 @@ steal("can/util", "can/view/scope",function(can){
 			};
 			return observeObservables ? convertedRenderer : can.__notObserve(convertedRenderer);
 		},
+		// A helper for calling the truthy subsection for each item in a list and putting them in a document Fragment.
+		getItemsFragContent: function(items, helperOptions, scope){
+			var isObserveList = this.isObserveLike(items);
+			var result = [],
+				len = isObserveList ? items.attr('length') : items.length;
+
+			for (var i = 0; i < len; i++) {
+				var aliases = {
+					"%index": i,
+					"@index": i
+				};
+				var item = isObserveList ? items.attr('' + i) : items[i];
+				result.push(helperOptions.fn(scope.add(aliases, {notContext: true }).add(item)));
+			}
+			return result;
+		},
 		Options: Options
 	};
 });


### PR DESCRIPTION
For #2361

Add index aliases to key iteration.
Move `getItemsFragContent` helper function to utils and reuse in #each helper.