### PR TITLE
using href attribute instead of xlink:href attribute

### DIFF
--- a/util/attr/attr.js
+++ b/util/attr/attr.js
@@ -191,6 +191,9 @@ steal("can/util/can.js", function (can) {
 								node.value = val;
 								el.setAttributeNode(node);
 							} else {
+								if(attrName === 'xlink:href'){
+									attrName = 'href';
+								}
 								el.setAttribute(attrName, val);
 							}
 						};

--- a/util/attr/attr_test.js
+++ b/util/attr/attr_test.js
@@ -161,6 +161,13 @@ steal('can/util', 'can/view/stache', 'can/util/attr', 'steal-qunit', function ()
 		equal(svg.getAttribute('class'), 'my-class', 'you can pass an object to svg class');
 	});
 
+	test("when setting xlink:href attribute, set as href (#2384)", function() {
+		var use = document.createElementNS("http://www.w3.org/2000/svg", "use");
+
+		can.attr.set(use, "xlink:href", "svgUri");
+		equal(use.getAttribute("href"), "svgUri", "svg-use xlink:href was set as href attribute");
+	});
+ 
 	if (window.jQuery || window.Zepto) {
 
 		test("zepto or jQuery - bind and unbind", function () {


### PR DESCRIPTION
fixes #2384 

**Before**
![screen shot 2016-09-22 at 2 25 13 pm](https://cloud.githubusercontent.com/assets/11162699/18761990/1abaefac-80d5-11e6-96ca-1f1610503528.png)
**After**
![screen shot 2016-09-22 at 2 23 50 pm](https://cloud.githubusercontent.com/assets/11162699/18761963/0214c0a4-80d5-11e6-9640-d37320a3448b.png)

reference: [MDN says use `href` instead of `xlink:href`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href)