### PR TITLE
Allow setters to return undefined

### DIFF
--- a/map/define/define.js
+++ b/map/define/define.js
@@ -169,7 +169,7 @@ steal('can/util','can/map/map_helpers.js', 'can/map', 'can/compute', function (c
 					return;
 				}
 				// if it took a setter and returned nothing, don't set the value
-				else if (setValue === undefined && !setterCalled && setter.length >= 1) {
+				else if (setValue === undefined && !setterCalled && setter.length > 1) {
 					//!steal-remove-start
 					asyncTimer = setTimeout(function () {
 						can.dev.warn('can/map/setter.js: Setter "' + prop + '" did not return a value or call the setter callback.');

--- a/map/define/define_test.js
+++ b/map/define/define_test.js
@@ -1334,4 +1334,26 @@ steal("can/map/define", "can/route", "can/test", "steal-qunit", function () {
 		equal(map.attr('propB'), object2, 'props in both have the child values');
 		equal(map.attr('propA'), object1, 'props only in the parent have the correct values');
 	});
+
+	test("can set properties to undefined", function(){
+		var MyMap = can.Map.extend({
+			define: {
+				foo: {
+					set: function(newVal) {
+						return newVal;
+					}
+				}
+			}
+		});
+		var map = new MyMap();
+
+		map.attr('foo', 'bar');
+		equal(map.attr('foo'), 'bar', 'foo should be bar');
+
+		map.attr('foo', undefined);
+		equal(typeof map.attr('foo'), 'undefined', 'foo should be undefined');
+	});
+
 });
+
+


### PR DESCRIPTION
Fixes #2523

The previous behavior of ignoring returning undefined should only apply
to asynchronous setters, so checking for the correct argument length to
handle that scenario and otherwise allowing setting a property to
undefined.