### PR TITLE
back porting define inheritance fix from can-map and can-map-define

### DIFF
--- a/map/define/define.js
+++ b/map/define/define.js
@@ -19,8 +19,14 @@ steal('can/util','can/map/map_helpers.js', 'can/map', 'can/compute', function (c
 		};
 
 		// This is called when the Map is defined
-		mapHelpers.define = function (Map) {
+		mapHelpers.define = function (Map, baseDefine) {
 			var definitions = Map.prototype.define;
+			
+			if (baseDefine) {
+				var defines = can.simpleExtend({}, baseDefine);
+				mapHelpers.twoLevelDeepExtend(defines, definitions);
+				can.simpleExtend(definitions, defines);
+			}
 			//!steal-remove-start
 			if(Map.define){
 				can.dev.warn("The define property should be on the map's prototype properties, "+

--- a/map/define/define_test.js
+++ b/map/define/define_test.js
@@ -1217,4 +1217,121 @@ steal("can/map/define", "can/route", "can/test", "steal-qunit", function () {
 		assert.equal(vmUndef.foo, undefined, "foo is undefined, no error thrown");
 	});
 
+	test("can inherit computes from another map (#1322)", 4, function(){
+		var string1 = 'a string';
+		var string2 = 'another string';
+
+		var MapA = can.Map.extend({
+			define: {
+				propA: {
+					get: function() {
+						return string1;
+					}
+				},
+				propB: {
+					get: function() {
+						return string1;
+					},
+					set: function(newVal) {
+						equal(newVal, string1, 'set was called');
+					}
+				}
+			}
+		});
+		var MapB = MapA.extend({
+			define: {
+				propC: {
+					get: function() {
+						return string2;
+					}
+				},
+				propB: {
+					get: function() {
+						return string2;
+					}
+				}
+			}
+		});
+
+		var map = new MapB();
+
+		equal(map.attr('propC'), string2, 'props only in the child have the correct values');
+		equal(map.attr('propB'), string2, 'props in both have the child values');
+		equal(map.attr('propA'), string1, 'props only in the parent have the correct values');
+		map.attr('propB', string1);
+
+	});
+
+	test("can inherit primitive values from another map (#1322)", function(){
+		var string1 = 'a';
+		var string2 = 'b';
+
+		var MapA = can.Map.extend({
+			define: {
+				propA: {
+					value: string1
+				},
+				propB: {
+					value: string1
+				}
+			}
+		});
+		var MapB = MapA.extend({
+			define: {
+				propC: {
+					value: string2
+				},
+				propB: {
+					value: string2
+				}
+			}
+		});
+
+		var map = new MapB();
+
+		equal(map.propC, string2, 'props only in the child have the correct values');
+		equal(map.propB, string2, 'props in both have the child values');
+		equal(map.propA, string1, 'props only in the parent have the correct values');
+
+	});
+
+	test("can inherit object values from another map (#1322)", function(){
+		var object1 = {a: 'a'};
+		var object2 = {b: 'b'};
+
+		var MapA = can.Map.extend({
+			define: {
+				propA: {
+					get: function() {
+						return object1;
+					}
+				},
+				propB: {
+					get: function() {
+						return object1;
+					}
+				}
+			}
+		});
+		var MapB = MapA.extend({
+			define: {
+				propB: {
+					get: function() {
+						return object2;
+					}
+				},
+				propC: {
+					get: function() {
+						return object2;
+					}
+				}
+			}
+		});
+
+		var map = new MapB();
+
+		equal(map.attr('propC'), object2, 'props only in the child have the correct values');
+		equal(map.attr('propB'), object2, 'props in both have the child values');
+		equal(map.attr('propA'), object1, 'props only in the parent have the correct values');
+	});
 });

--- a/map/define/doc/define.md
+++ b/map/define/doc/define.md
@@ -110,6 +110,54 @@ Here is the cliffnotes version of this plugin.  To define...
 * A custom converter method or a pre-defined standard converter called whenever a property is set - use [can.Map.prototype.define.type type]
 * That custom converter method as a constructor function - use [can.Map.prototype.define.TypeConstructor Type]
 
+## Inheritance
+ 
+[can.Map] constructors can inherit values from the [can.Map::define can.Map.define]
+plugin. If a parent [can.Map] constructor has a `define` property and a child
+constructor extends the parent and also has a `define` property, the two will
+be merged together so `define` properties from the parent are also available
+on instances of the child. For example:
+ 
+    var ParentMap = can.Map.extend({
+      define: {
+        inheritedProp: {
+          get: function() {
+            return 15;
+          },
+          set: function(newVal) {
+            return newVal;
+          }
+        },
+        parentProp: {
+          get: function() {
+            return 15;
+          }
+        }
+      }
+    });
+    var ChildMap = ParentMap.extend({
+      define: {
+        childProp: {
+          get: function() {
+            return 22;
+          }
+        },
+        inheritedProp: {
+          get: function() {
+            return 22;
+          }
+        }
+      }
+    });
+
+    var map = new ChildMap();
+
+    map.attr('childProp'); // -> 22
+    map.attr('inheritedProp'); // -> 22
+    map.attr('parentProp'); // -> 15
+
+    map.attr('inheritedProp', 13); // -> calls ParentMap’s setter for inheritedProp
+
 ## Demo
 
 The following shows picking cars by make / model / year:

--- a/map/map.js
+++ b/map/map.js
@@ -31,7 +31,7 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 			// Called when a Map constructor is defined/extended to
 			// perform any initialization behavior for the new constructor
 			// function.
-			setup: function () {
+			setup: function (baseMap) {
 
 				can.Construct.setup.apply(this, arguments);
 
@@ -79,7 +79,7 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 
 					// If define is a function, call it with this can.Map
 					if(mapHelpers.define) {
-						mapHelpers.define(this);
+						mapHelpers.define(this, baseMap.prototype.define);
 					}
 				}
 

--- a/map/map_helpers.js
+++ b/map/map_helpers.js
@@ -169,6 +169,12 @@ steal('can/util', 'can/util/object/isplain', function(can){
 		// `undefined` if nothing has been already created.
 		getMapFromObject: function (obj) {
 			return madeMap && madeMap[obj._cid] && madeMap[obj._cid].instance;
+		},
+		twoLevelDeepExtend: function (destination, source) {
+			for (var prop in source) {
+				destination[prop] = destination[prop] || {};
+				can.simpleExtend(destination[prop], source[prop]);
+			}
 		}
 	};
 	


### PR DESCRIPTION
fixes #1322 