### PR TITLE
Fixes the hyperlink for canjs.com homepage

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -105,7 +105,7 @@ CanJS supports the following browsers:
 
 ## Documentation
 
-If your changes affect the public API, please make relevant changes to the documentation. Documentation is found either inline or in markdown files in the respective directory. In order to view your changes in documentation you will need to run the [CanJS.com site](https://github.com/canjs/canjs.com) locally and regenerate the docs.
+If your changes affect the public API, please make relevant changes to the documentation. Documentation is found either inline or in markdown files in the respective directory. In order to view your changes in documentation you will need to run the [CanJS.com site](https://github.com/bitovi/canjs.com) locally and regenerate the docs.
 
 Follow the instructions on [CanJS.com gh-pages branch](https://github.com/bitovi/canjs.com/tree/gh-pages#setup) to generate documentation from your local copy of canjs.
 


### PR DESCRIPTION
No more page not found, Fixed hyperlink to canjs.com github