### PR TITLE
setting build # for ios safari tests so it will be associated with other browser tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "postversion": "git push --tags && git checkout master && git branch -D release && git push",
     "testee": "testee test/index.html --browsers firefox",
     "test": "npm run build && npm run testee",
-    "ci": "npm run build && grunt && node test-ios-safari.js",
+    "ci": "npm run build && node test-ios-safari.js && grunt",
     "release:pre": "npm version prerelease && npm run build && npm publish",
     "release:patch": "npm version patch && npm run build && npm publish",
     "release:minor": "npm version minor && npm run build && npm publish",

--- a/test-ios-safari.js
+++ b/test-ios-safari.js
@@ -52,7 +52,10 @@ var platforms = [{
 	// https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-MaximumTestDuration
 	maxDuration: 1800,// seconds, default 1800, max 10800
 	commandTimeout: 300,// seconds, default 300, max 600
-	idleTimeout: idleTimeout// seconds, default 90, max 1000
+	idleTimeout: idleTimeout,// seconds, default 90, max 1000
+
+	// https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-BuildNumbers
+	build: process.env.TRAVIS_JOB_ID
 }];
 
 // Main


### PR DESCRIPTION
Closes https://github.com/canjs/canjs/issues/2641.