### PR TITLE
skipping tests in CI for docs changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 sudo: false
 language: node_js
 node_js: node
+before_install:
+- |
+    if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^docs)/'
+    then
+      echo "Only docs were updated, skipping tests."
+      exit
+    fi
 script: npm run ci
 before_script:
   - npm run http-server &

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "can-component": "3.0.2",
     "can-compute": "3.0.3",
-    "can-connect": "1.0.10",
+    "can-connect": "1.0.11",
     "can-construct": "3.0.3",
     "can-construct-super": "3.0.0",
     "can-control": "3.0.3",


### PR DESCRIPTION
Closes https://github.com/canjs/canjs/issues/2716.

This will skip running tests if changes are only to the `docs/` folder or `.md` files.