### PR TITLE
using steal-tools@0.16 instead of pre version

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "steal": "^0.16.4",
     "steal-qunit": "^0.1.1",
     "steal-stache": "^3.0.1",
-    "steal-tools": "pre",
+    "steal-tools": "^0.16.8",
     "testee": "^0.2.5",
     "wd": "^1.0.0"
   },


### PR DESCRIPTION
Closes https://github.com/canjs/canjs/issues/2776.