### PR TITLE
making sure release folder doesn't get blown away by publishing the docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ publish-docs:
 	git add -f node_modules/funcunit
 	git add -f node_modules/syn
 	git add -f node_modules/socket.io-client
+	git checkout origin/gh-pages -- release/
 	git commit -m "Publish docs"
 	git push -f origin gh-pages
 	git rm -q -r --cached node_modules


### PR DESCRIPTION
I think this is the simplest solution to keep the `release` folder in the gh-pages branch without having it on the master branch.

Closes https://github.com/canjs/canjs/issues/2853.