### PR TITLE
Removing CNAME file

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-canjs.com

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ publish-docs:
 	git add -f node_modules/funcunit
 	git add -f node_modules/syn
 	git add -f node_modules/socket.io-client
+	git checkout origin/gh-pages -- CNAME
 	git checkout origin/gh-pages -- release/
 	git commit -m "Publish docs"
 	git push -f origin gh-pages


### PR DESCRIPTION
The CNAME file is only used for Github Pages, so it does not need to be
in master. This change removes it from master and adds it back when
pushing to gh-pages.