### PR TITLE
Docs updates

### DIFF
--- a/docs/can-canjs/can-core.md
+++ b/docs/can-canjs/can-core.md
@@ -70,7 +70,7 @@ hobbies.pop();
 ## can-define
 
 [can-define/map/map] and [can-define/list/list] allow you to create observable
-maps and lists with well defined properties.  You can
+maps and lists with well-defined properties.  You can
 [can-define.types.propDefinition define a property’s type initial value, enumerability, getter-setters and much more].
 For example, you can define the behavior of a `Todo` type and a `TodoList` type as follows:
 

--- a/docs/can-guides/experiment/atm/10-deposit-info/html.html
+++ b/docs/can-guides/experiment/atm/10-deposit-info/html.html
@@ -66,7 +66,7 @@
             <div class='warn'>
                 <p>
                     <img src="http://v3.canjs.com/docs/images/loader.gif"/>
-                    Loading Accounts ...
+                    Loading Accounts…
                 </p>
             </div>
         {{else}}

--- a/docs/can-guides/experiment/atm/11-withdrawal-info/html.html
+++ b/docs/can-guides/experiment/atm/11-withdrawal-info/html.html
@@ -66,7 +66,7 @@
             <div class='warn'>
                 <p>
                     <img src="http://v3.canjs.com/docs/images/loader.gif"/>
-                    Loading Accounts ...
+                    Loading Accounts…
                 </p>
             </div>
         {{else}}

--- a/docs/can-guides/experiment/atm/12-transaction-success/html.html
+++ b/docs/can-guides/experiment/atm/12-transaction-success/html.html
@@ -66,7 +66,7 @@
             <div class='warn'>
                 <p>
                     <img src="http://v3.canjs.com/docs/images/loader.gif"/>
-                    Loading Accounts ...
+                    Loading Accounts…
                 </p>
             </div>
         {{else}}

--- a/docs/can-guides/experiment/atm/13-printing/html.html
+++ b/docs/can-guides/experiment/atm/13-printing/html.html
@@ -66,7 +66,7 @@
             <div class='warn'>
                 <p>
                     <img src="http://v3.canjs.com/docs/images/loader.gif"/>
-                    Loading Accounts ...
+                    Loading Accounts…
                 </p>
             </div>
         {{else}}

--- a/docs/can-guides/experiment/atm/9-picking-account/html.html
+++ b/docs/can-guides/experiment/atm/9-picking-account/html.html
@@ -66,7 +66,7 @@
             <div class='warn'>
                 <p>
                     <img src="http://v3.canjs.com/docs/images/loader.gif"/>
-                    Loading Accounts ...
+                    Loading Accounts…
                 </p>
             </div>
         {{else}}

--- a/docs/can-guides/experiment/atm/atm-stream.html
+++ b/docs/can-guides/experiment/atm/atm-stream.html
@@ -69,7 +69,7 @@
             <div class='warn'>
                 <p>
                     <img src="http://v3.canjs.com/docs/images/loader.gif"/>
-                    Loading Accounts ...
+                    Loading Accounts…
                 </p>
             </div>
         {{else}}

--- a/docs/can-guides/experiment/atm/atm.html
+++ b/docs/can-guides/experiment/atm/atm.html
@@ -72,7 +72,7 @@
             <div class='warn'>
                 <p>
                     <img src="http://v3.canjs.com/docs/images/loader.gif"/>
-                    Loading Accounts ...
+                    Loading Accounts…
                 </p>
             </div>
         {{else}}

--- a/docs/can-guides/experiment/atm/atm.md
+++ b/docs/can-guides/experiment/atm/atm.md
@@ -1,8 +1,8 @@
 @page guides/atm ATM Guide
 @parent guides/experiment 3
 
-This guide will walk you through building and __testing__ an ATM application with CanJS’s
-[can-core Core libraries].  It teaches how to do test driven development (TDD)
+This guide will walk you through __building__ and __testing__ an Automated Teller Machine (ATM) application with CanJS’s
+[can-core Core libraries].  You’ll learn how to do test driven development (TDD)
 and manage complex state.  It takes about 2 hours to complete.
 
 @body
@@ -14,10 +14,6 @@ Check out the final app:
 <a class="jsbin-embed" href="//jsbin.com/yayupo/10/embed?js,output">JS Bin on jsbin.com</a>
 
 Notice it has tests at the bottom of the `Output` tab.
-
-Watch the following video to see it in action:
-
-> TODO: VIDEO OF IT IN ACTION
 
 ## Setup
 
@@ -38,19 +34,19 @@ tab.  To set this up, the `HTML` tab:
    should import things directly with a module loader like [StealJS](http://stealjs.com),
    WebPack or Browserify.  Read [guides/setup] for instructions on how to set up CanJS in a real app.
 
- - Includes the content for a `app-template` [can-stache] template. This template
-   provides the title for the ATM app, and uses the `<atm-machine>` custom [can-component]
+ - Includes the content for an `app-template` [can-stache] template. This template
+   provides the title for the ATM app and uses the `<atm-machine>` custom [can-component]
    element that will eventually provide the ATM functionality.
 
-The `JS` tab is split into two sections:
+The `JavaScript` tab is split into two sections:
 
  - `CODE` - The ATM’s models, view-models and component code will go here.
  - `TESTS` - The ATM’s tests will go here.
 
-Normally, your application’s code and test will be in separate files and loaded
-by different html pages.  But we combine them here to fit within JS&nbsp;Bin’s limitations.
+Normally, your application’s code and tests will be in separate files and loaded
+by different html pages, but we combine them here to fit within JS&nbsp;Bin’s limitations.
 
-The `CODE` section is rendering the `app-template` with:
+The `CODE` section renders the `app-template` with:
 
 ```js
 document.body.insertBefore(
@@ -59,7 +55,7 @@ document.body.insertBefore(
 );
 ```
 
-The `TESTS` section is labeling which module will be tested:
+The `TESTS` section labels which module will be tested:
 
 ```js
 QUnit.module("ATM system", {});
@@ -86,10 +82,10 @@ Update the `JavaScript` tab to:
 @sourceref ./1-pages-template/js.js
 @highlight 5-13,only
 
-When complete, you should see the __"Reading Card"__ title.
+When complete, you should see the __“Reading Card”__ title.
 
-This step outlines the page transitions we’re going to make the `state`
-property transition between:
+This step includes all the potential pages the `state`
+property can transition between:
 
 - readingCard
 - readingPin
@@ -100,7 +96,7 @@ property transition between:
 - successfulTransaction
 - printingReceipt
 
-Each of those states are present in the following state diagram.
+Each of those states are present in the following state diagram:
 
 <img src="../../docs/can-guides/experiment/atm/1-pages-template/state-diagram.png">
 
@@ -115,10 +111,10 @@ In this section, we will:
 
 An ATM `Card` will take a card `number` and `pin`. It will start out as
 having a `state` of  `"unverified"`. It will have a `verify` method
-that will change the `state` to `"verifying"` and if the response is successful,
+that will change the `state` to `"verifying"`, and if the response is successful,
 `state` will change to `"verified"`.
 
-Update the `JS` tab to:
+Update the `JavaScript` tab to:
 
 - Make the fake data request delay `1ms` by setting [can-fixture.delay] to `1` before every test and
   restoring it to `2s` after every test runs.
@@ -128,20 +124,20 @@ Update the `JS` tab to:
 @sourceref ./2-card-tests/js.js
 @highlight 24-70,only
 
-When complete you should have a breaking test.  Now lets make it pass.
+When complete, you should have a breaking test.  Now let’s make it pass.
 
 ## Card model
 
 In this section, we will:
 
-- Implement the `Card` model so that all tests pass.
+- Implement the `Card` model so that all the tests pass.
 
 Update the `JavaScript` tab to:
 
-- Simulate the `/verifyCard` with [can-fixture]. It return a successful response if
-  the request body has a `number` and `pin` and a 400 if not.
+- Simulate the `/verifyCard` with [can-fixture]. It will return a successful response if
+  the request body has a `number` and `pin`, or a `400` if not.
 - Use [can-define/map/map] to define the `Card` model, including:
-  - a `number` and  `pin` property.
+  - a `number` and a `pin` property.
   - a `state` property initialized to `unverified` that is not part of the card’s [can-define.types.serialize]d  data.
   - a `verify` method that posts the card’s data to `/verifyCard` and updates the `state`
     accordingly.
@@ -170,7 +166,7 @@ a `state` of `"invalid"`.  When the deposit has a `card`, `amount` and `account`
 will change to `"ready"`.  Once the deposit is ready, the `.execute()` method will change the state
 to `"executing"` and then to `"executed"` once the transaction completes.
 
-Update the `JS` tab to:
+Update the `JavaScript` tab to:
 
 - Create a `deposit` with an `amount` and a `card`.
 - Check that the `state` is `"invalid"` because there is no `account`.
@@ -193,8 +189,8 @@ When complete, the __Deposit__ test should run, but error because _Deposit is no
 In this section, we will:
 
 - Implement the `Account` model.
-- Implement a base `Transaction` model and extend it into a `Deposit` and
-`Withdrawal` model.
+- Implement a base `Transaction` model and extend it into `Deposit` and
+`Withdrawal` models.
 - Get the __Deposit__ test to pass.
 
 Update the `JavaScript` tab to:
@@ -203,24 +199,23 @@ Update the `JavaScript` tab to:
 - Simulate `/deposit` to always return a successful result.
 - Simulate `/withdrawal` to always return a successful result.
 - Define the `Account` model to:
-	- have an `id` property
-	- have a `balance` property
-	- have a `name` property
-- Define an `Account.List` type with [can-define/list/list]
-- Connect `Account` and `Account.List` types to the RESTful `"/accounts"` endpoint using [can-connect/can/base-map/base-map].
+	- have an `id` property.
+	- have a `balance` property.
+	- have a `name` property.
+- Define an `Account.List` type with [can-define/list/list].
+- Connect `Account` and `Account.List` types to the RESTful `/accounts` endpoint using [can-connect/can/base-map/base-map].
 - Define the `Transaction` model to:
-  - have an `account` and `card` property.
-  - have an `executing` and `executed` property that track if the transaction is executing or has executed.
+  - have `account` and `card` properties.
+  - have `executing` and `executed` properties that track if the transaction is executing or has executed.
   - have a `rejected` property that stores the error given for a failed transaction.
   - have an __abstract__ `ready` property that `Deposit` and `Withdrawal` will implement to return `true`
-    when the transaction is in a state able to be executed.
+    when the transaction is in an executable state.
   - have a `state` property that reads other stateful properties and returns a string representation
     of the state.
   - have an __abstract__ `executeStart` method that `Deposit` and `Withdrawal` will implement to
-    execute the transaction and return a `Promise` the resolves when the transaction completes.
+    execute the transaction and return a `Promise` that resolves when the transaction is complete.
   - have an __abstract__ `executeEnd` method that `Deposit` and `Withdrawal` will implement to
-    update the transactions values (typically the `account` balance) if the transaction completed
-    successfully.
+    update the transactions values (typically the `account` balance) if the transaction is successfully completed.
   - have an `execute` method that calls `.executeStart()` and `executeEnd()` and keeps the stateful
     properties updated correctly.
 - Define the `Deposit` model to:
@@ -242,7 +237,7 @@ When complete, the __Deposit__ tests will pass.
 In this section, we will:
 
  - Allow the user to enter a card number and go to the __Reading Pin__ page.
- - Add tests to __ATM Basics__ test.
+ - Add tests to the __ATM Basics__ test.
 
 Update the `HTML` tab to:
 
@@ -255,7 +250,7 @@ Update the `JavaScript` tab to:
 
 - Declare a `card` property.
 - Derive a `state` property that changes to `"readingPin"` when `card` is defined.
-- Add a `cardNumber` that creates a `card` with the `number` provided.
+- Add a `cardNumber` that creates a `card` with the provided `number`.
 
 @sourceref ./6-reading-card/js.js
 @highlight 190-205,313-325,only
@@ -268,7 +263,7 @@ page.
 In this section, we will:
 
 - Allow the user to enter a pin number and go to the __Choosing Transaction__ page.
-- Add tests to __ATM Basics__ test.
+- Add tests to the __ATM Basics__ test.
 
 Update the `HTML` tab to:
 
@@ -285,11 +280,11 @@ Update the `ATM` view model in the `CODE` section of the `JavaScript` tab to:
 - Define a `transactions` property that will contain a list of transactions for this session.
 - Update `state` to be in the `"choosingTransaction"` state when the `card` is verified.
 - Define a `pinNumber` method that updates the `card`’s `pin`, calls `.verify()`,
-  and then initializes the `accountsPromise` and `transactions` property.
+  and initializes the `accountsPromise` and `transactions` properties.
 
 Update the `TESTS` section of the `JavaScript` tab to:
 
-- Test calling `pinNumber` moves the `state` to `"choosingTransaction"`.
+- Test whether calling `pinNumber` moves the `state` to `"choosingTransaction"`.
 
 @sourceref ./7-reading-pin/js.js
 @highlight 192-193,198-200,212-228,346-356,only
@@ -302,7 +297,7 @@ page.
 In this section, we will:
 
 - Allow the user to pick a transaction type and go to the __Picking Account__ page.
-- Add tests to __ATM Basics__ test.
+- Add tests to the __ATM Basics__ test.
 
 Update the `HTML` tab to:
 
@@ -322,13 +317,13 @@ Update the `ATM` view model in the `CODE` section of the `JavaScript` tab to:
 
 Update the `TESTS` section of the `JavaScript` tab to:
 
-- Call `.chooseDeposit()` and verify the state moves to `"pickingAccount"`.
+- Call `.chooseDeposit()` and verify that the state moves to `"pickingAccount"`.
 
 @sourceref ./8-choosing-transaction/js.js
 @highlight 194-204,209-211,243,246-255,363,382-389,only
 
 
-> We will define `printReceiptAndExit` later!
+> __Note:__ We will define `printReceiptAndExit` later!
 
 ## Picking Account page and test
 
@@ -336,11 +331,11 @@ In this section, we will:
 
 - Allow the user to pick an account and go to either the  __Deposit Info__ or
   __Withdrawal Info__ page.
-- Add tests to __ATM Basics__ test.
+- Add tests to the __ATM Basics__ test.
 
 Update the `HTML` tab to:
 
-- Write out a _"Loading Accounts  ..."_ message while the accounts are loading.
+- Write out a _“Loading Accounts…”_ message while the accounts are loading.
 - Write out the accounts when loaded.
 - Call `chooseAccount()` when an account is clicked.
 
@@ -350,7 +345,7 @@ Update the `HTML` tab to:
 Update the `ATM` view model in the `CODE` section of the `JavaScript` tab to:
 
 - Change `state` to check if the `currentTransaction` has an `account` and update the
-  value to `"depositInfo"` or `"withdrawalInfo"` depending on the type of the `currentTransaction`.
+  value to `"depositInfo"` or `"withdrawalInfo"`, depending on the `currentTransaction`’s type.
 - Add a `chooseAccount` method that sets the `currentTransaction`’s `account`.
 
 Update the `TESTS` section of the `JavaScript` tab to:
@@ -366,7 +361,7 @@ Update the `TESTS` section of the `JavaScript` tab to:
 In this section, we will:
 
 - Allow the user to enter the amount of a deposit and go to the __Successful Transaction__ page.
-- Add tests to __ATM Basics__ test.
+- Add tests to the __ATM Basics__ test.
 
 Update the `HTML` tab to:
 
@@ -417,7 +412,7 @@ Update the `HTML` tab to:
 When complete, you should be able to enter a withdrawal amount and see that
 the transaction was successful.
 
-> __Optional:__ Challenge yourself by adding a test for the `withdrawalInfo` state of an atm instance.  Consider the progression of states needed to make it to the `withdrawalInfo` state.  How is it different from the __ATM basics__ test we already have?
+> __Optional:__ Challenge yourself by adding a test for the `withdrawalInfo` state of an `atm` instance.  Consider the progression of states needed to make it to the `withdrawalInfo` state.  How is it different from the __ATM basics__ test we already have?
 
 ## Transaction Successful page
 
@@ -430,19 +425,20 @@ Update the `HTML` tab to:
 - List out the account balance.
 - Add buttons to:
   - start another transaction, or
-  - print a receipt and exit the ATM. (`printReceiptAndExit` will be implemented in the next section)
+  - print a receipt and exit the ATM (`printReceiptAndExit` will be implemented in the next section).
 
 @sourceref ./12-transaction-success/html.html
 @highlight 134-144,only
 
-When complete, you should be able to make a deposit or withdrawal, see the updated account balance
-and then start another transaction.
+When complete, you should be able to make a deposit or withdrawal, see the updated account balance,
+then start another transaction.
 
 ## Printing Recipe page and test
 
-In this section, we will:
+In this section, we will make it possible to:
 
- - Make it possible to see a receipt of all transactions and exit the ATM.  
+ - See a receipt of all transactions
+ - Exit the ATM.  
 
 Update the `HTML` tab to:
 
@@ -466,7 +462,7 @@ Update the `ATM basics` test in the `JavaScript` tab to:
 
 - Shorten the default `receiptTime` so the tests move quickly.
 - Call `printReceiptAndExit` and make sure that the `state` changes to `"printingReceipt"` and
-  then to `"readingCard"` and ensure that sensitive information is cleared from the atm.
+  then to `"readingCard"` and ensure that sensitive information is cleared from the ATM.
 
 @sourceref ./13-printing/js.js
 @highlight 189,205-209,213-215,263,266-273,397,437-451,only

--- a/docs/can-guides/experiment/chat/chat.md
+++ b/docs/can-guides/experiment/chat/chat.md
@@ -136,7 +136,7 @@ Update the `HTML` tab to:
 Update the `JavaScript` tab to:
 
  - Add a `page` property that will be updated when the browser’s URL changes.
- - Prevent the `message` property from becoming part of the URL changes.
+ - Prevent the `message` property from becoming part of the URL changes by using `serialize: false`.
  - Connect changes in the url to changes in the `appVM` with [can-route.data].
  - Create a pretty routing rule so if the url looks like `"#!chat"`, the `page` property of
    `appVM` will be set to `chat` with [can-route].  If there is nothing in the hash, `page`
@@ -165,8 +165,8 @@ and initialized that connection with [can-route.ready can-route.ready].
 This makes it so if the `page` property changes, the browser’s url will change.  If the
 browser’s url changes, the `page` property changes.  
 
-> __Key take-away:__  [can-route] connects changes in the browser’s url to
-changes in the application view model and vice versa.  Use changes in
+> __Key take-away:__  [can-route] two-way binds changes in the browser’s url to
+the application view model and vice versa.  Use changes in
 the application view model to control which content is shown.
 
 
@@ -238,9 +238,9 @@ into many bite-sized custom elements.
 
 In this section, we will:
 
- - Display messages from [http://chat.donejs.com/api/messages](http://chat.donejs.com/api/messages)
- - Show a “Loading…” message while the messages are loading.
- - Show an error if those messages fail to load.
+ - Display messages from [http://chat.donejs.com/api/messages](http://chat.donejs.com/api/messages) when `messagesPromise.isResolved`.
+ - Show a “Loading…” message while the messages are loading (`messagesPromise.isPending`).
+ - Show an error if those messages fail to load (`messagesPromise.isRejected`).
 
 Update the `HTML` tab to:
 
@@ -268,9 +268,12 @@ Update the `JavaScript` tab to:
 
 When complete, you should see a list of messages in the __chat messages page__.
 
-This step creates a `Message` model, by first creating the `Message` type
-and then connecting it to a messages service at `http://chat.donejs.com/api/messages`. This
-adds [can-connect/can/map/map methods] to the `Message` type that let you:
+This step creates a `Message` model by first creating the `Message` type
+and then connecting it to a messages service at `http://chat.donejs.com/api/messages`.
+
+### Explanation
+
+The [can-connect/can/super-map/super-map super-map module] adds [can-connect/can/map/map methods] to the `Message` type that let you:
 
  - Get a list of messages:
    ```js
@@ -304,7 +307,7 @@ There are also methods to let you know when a message
 With the message model created, it’s used to load and list messages on the server.
 
 
-> __Key take-away:__ Create a model to connect to backend data.
+> __Key take-away:__ Create a model for your data’s schema and use it to communicate with a backend server.
 
 ## Create Messages
 

--- a/docs/can-guides/experiment/chat/chat.md
+++ b/docs/can-guides/experiment/chat/chat.md
@@ -27,15 +27,15 @@ WebPack or Browserify.  In a real app, your code will look like:
 var DefineMap = require("can-define/map/map");
 var DefineList = require("can-define/list/list");
 
-var Todo = DefineMap.extend({ ... });
-Todo.List = DefineList.extend({ ... });
+var Message = DefineMap.extend({ ... });
+Message.List = DefineList.extend({ ... });
 ```
 
 Not:
 
 ```js
-var Todo = can.DefineMap.extend({ ... });
-Todo.List = can.DefineList.extend({ ... });
+var Message = can.DefineMap.extend({ ... });
+Message.List = can.DefineList.extend({ ... });
 ```
 
 Read [guides/setup] for instructions on how to set up CanJS in a real app.

--- a/docs/can-guides/experiment/chat/chat.md
+++ b/docs/can-guides/experiment/chat/chat.md
@@ -225,9 +225,10 @@ to work together like:
 Breaking down an application into many isolated and potentially reusable components
 is a critical piece of CanJS software architecture.
 
-Custom elements are defined with [can-component].  Components render their `view` within
-the element with an instance of their `ViewModel`.  By default their `view` only
-has access to that data in the `ViewModel`.  You can use [can-stache-bindings event and data bindings] like [can-stache-bindings.toChild] and [can-stache-bindings.twoWay] to pass data
+Custom elements are defined with [can-component].  Components render their `view`
+with a `ViewModel` instance.  By default, their `view` only
+has access to the data in the `ViewModel`.  You can use [can-stache-bindings event and data bindings]
+like [can-stache-bindings.toChild] and [can-stache-bindings.twoWay] to pass data
 between custom elements.
 
 > __Key take-away:__  [can-component] makes custom elements. Break down your application

--- a/docs/can-guides/experiment/todomvc/2-items-left/js.js
+++ b/docs/can-guides/experiment/todomvc/2-items-left/js.js
@@ -1,5 +1,5 @@
 var Todo = can.DefineMap.extend({
-  id: "string",
+  id: "number",
   name: "string",
   complete: {type: "boolean", value: false}
 });

--- a/docs/can-guides/experiment/todomvc/3-models/js.js
+++ b/docs/can-guides/experiment/todomvc/3-models/js.js
@@ -15,7 +15,7 @@ can.fixture.delay = 1000;
 
 
 var Todo = can.DefineMap.extend({
-  id: "string",
+  id: "number",
   name: "string",
   complete: {type: "boolean", value: false}
 });

--- a/docs/can-guides/experiment/todomvc/5-create/js.js
+++ b/docs/can-guides/experiment/todomvc/5-create/js.js
@@ -16,7 +16,7 @@ can.fixture.delay = 1000;
 
 
 var Todo = can.DefineMap.extend({
-  id: "string",
+  id: "number",
   name: "string",
   complete: {type: "boolean", value: false}
 });

--- a/docs/can-guides/experiment/todomvc/6-list/js.js
+++ b/docs/can-guides/experiment/todomvc/6-list/js.js
@@ -15,7 +15,7 @@ can.fixture.delay = 1000;
 
 
 var Todo = can.DefineMap.extend({
-  id: "string",
+  id: "number",
   name: "string",
   complete: {type: "boolean", value: false}
 });

--- a/docs/can-guides/experiment/todomvc/7-edit/js.js
+++ b/docs/can-guides/experiment/todomvc/7-edit/js.js
@@ -15,7 +15,7 @@ can.fixture.delay = 1000;
 
 
 var Todo = can.DefineMap.extend({
-  id: "string",
+  id: "number",
   name: "string",
   complete: {type: "boolean", value: false}
 });

--- a/docs/can-guides/experiment/todomvc/8-routing/js.js
+++ b/docs/can-guides/experiment/todomvc/8-routing/js.js
@@ -15,7 +15,7 @@ can.fixture.delay = 1000;
 
 
 var Todo = can.DefineMap.extend({
-  id: "string",
+  id: "number",
   name: "string",
   complete: {type: "boolean", value: false}
 });

--- a/docs/can-guides/experiment/todomvc/9-toggle/js.js
+++ b/docs/can-guides/experiment/todomvc/9-toggle/js.js
@@ -15,7 +15,7 @@ can.fixture.delay = 1000;
 
 
 var Todo = can.DefineMap.extend({
-  id: "string",
+  id: "number",
   name: "string",
   complete: {type: "boolean", value: false}
 });

--- a/docs/can-guides/experiment/todomvc/todomvc.html
+++ b/docs/can-guides/experiment/todomvc/todomvc.html
@@ -105,7 +105,7 @@ can.fixture.delay = 1000;
 
 
 var Todo = can.DefineMap.extend({
-  id: "string",
+  id: "number",
   name: "string",
   complete: {type: "boolean", value: false}
 });

--- a/docs/can-guides/experiment/todomvc/todomvc.md
+++ b/docs/can-guides/experiment/todomvc/todomvc.md
@@ -179,7 +179,7 @@ The deleted todo is automatically removed from the page because [can-connect/can
 are created, updated or destroyed.  If you’ve created the right [can-set.Algebra], you
 shouldn’t have to manage lists yourself.
 
-Finally, if you refresh the page after deleting, you’ll notice the page temporarily shows fewer items.
+Finally, if you click “Run with JS” after deleting a todo, you’ll notice the page temporarily shows fewer items.
 This is because the fall through cache’s data is shown before the response from fixtured data store
 is used.
 

--- a/docs/can-guides/experiment/todomvc/todomvc.md
+++ b/docs/can-guides/experiment/todomvc/todomvc.md
@@ -58,7 +58,7 @@ Update the `JavaScript` tab to:
  - Render the template with an empty object into a [document fragment](https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment).
  - Insert the fragment into the document’s `<body>` element.
 
- To load and render this template, and add the result to the
+To load, render, and add this template to the
 body, add the following to the `JavaScript` tab:
 
 @sourceref ./1-create-template/js.js
@@ -75,7 +75,7 @@ that in the next step.
 
 In this section, we will:
 
- - List todos from a list of todos.
+ - Create a list of todos and show them.
  - Show the number of active (`complete === true`) and complete todos.
  - Connect a todo’s `complete` property to a checkbox so that when
    we toggle the checkbox the number of active and complete todos changes.
@@ -296,7 +296,7 @@ When complete, you should be able to edit a todo’s name.
 
 In this section, we will:
 
- - Make it possible to use the forward and backwards button to change
+ - Make it possible to use the browser’s forwards and backwards buttons to change
  between showing all todos, only active todos, or only completed todos.
  - Add links to change between showing all todos, only active todos, or only completed todos.
  - Make those links bold when the site is currently showing that link.

--- a/docs/can-guides/experiment/todomvc/todomvc.md
+++ b/docs/can-guides/experiment/todomvc/todomvc.md
@@ -92,10 +92,10 @@ Update the `JavaScript` tab to:
 
 Update the `HTML` tab to:
 
-- Use [can-stache.helpers.each] to loop through every todo.
+- Use [can-stache.helpers.each `{{#each todos}}`] to loop through every todo.
 - Add `completed` to the `<li>`’s `className` if the `<li>`’s todo is complete.
-- Use [can-stache-bindings.twoWay] to two-way bind the checkbox’s `checked` property to its todo’s `complete` property.  
-- Use [can-stache.tags.escaped] to insert the value todo’s `name` as the content of the `<label>` and
+- Use [can-stache-bindings.twoWay `{($checked)}`] to two-way bind the checkbox’s `checked` property to its todo’s `complete` property.  
+- Use [can-stache.tags.escaped `{{name}}`] to insert the value todo’s `name` as the content of the `<label>` and
   `value` of the text `<input/>`.
 - Insert the active and complete number of todos.
 
@@ -123,7 +123,7 @@ In this section, we will:
 
 Update the `JavaScript` tab to:
 
-- Define what the RESTful service layer’s parameters are with [can-set].
+- Define what the RESTful service layer’s parameters are with [can-set.Algebra can-set.Algebra].
 - Create a fake data store that is initialized with data for 3 todos with [can-fixture.store].
 - Trap AJAX requests to `"/api/todos"` and provide responses with the data from the fake data store with [can-fixture].
 - Connect the `Todo` and `Todo.List` types to the RESTful `"/api/todos"` endpoint using [can-connect/can/super-map/super-map].  This allows you to load, create, update, and destroy todos
@@ -138,7 +138,7 @@ on the server.
 
 Update the `HTML` tab to:
 
- - Use [can-stache.helpers.each] to loop through the promise’s resolved value, which
+ - Use [can-stache.helpers.each `{{#each todosPromise.value}}`] to loop through the promise’s resolved value, which
    is the list of todos returned by the server.
  - Read the active and completed number of todos from the promise’s resolved value.
 
@@ -165,7 +165,7 @@ In this section, we will:
 Update the `HTML` tab to:
 
  - Add `destroying` to the `<li>`’s `className` if the `<li>`’s todo is being destroyed using [can-connect/can/map/map.prototype.isDestroying].
- - Call the `todo`’s [can-connect/can/map/map.prototype.destroy] method when the `<button>` is clicked using [can-stache-bindings.event].
+ - Call the `todo`’s [can-connect/can/map/map.prototype.destroy] method when the `<button>` is clicked using [can-stache-bindings.event `($click)`].
 
 @sourceref ./4-destroy/html.html
 @highlight 22-23,27,only
@@ -180,7 +180,7 @@ are created, updated or destroyed.  If you’ve created the right [can-set.Algeb
 shouldn’t have to manage lists yourself.
 
 Finally, if you click “Run with JS” after deleting a todo, you’ll notice the page temporarily shows fewer items.
-This is because the fall through cache’s data is shown before the response from fixtured data store
+This is because the fall-through cache’s data is shown before the response from fixtured data store
 is used.
 
 <video controls>
@@ -210,8 +210,8 @@ Update the `JavaScript` tab to:
 Update the `HTML` tab to:
 
  - Create the `todo-create-template` that:
-   - Updates the `todo`’s `name` with the `<input>`’s `value` using [can-stache-bindings.twoWay].
-   - Calls `createTodo` when the `enter` key is pressed using [can-stache-bindings.event].
+   - Updates the `todo`’s `name` with the `<input>`’s `value` using [can-stache-bindings.twoWay `{($value)}`].
+   - Calls `createTodo` when the `enter` key is pressed using [can-stache-bindings.event `($enter)`].
  - Use `<todo-create/>`
 
 @sourceref ./5-create/html.html
@@ -228,8 +228,8 @@ lists that they belong within.
 
 In this section, we will:
 
- - Define a custom element that lists todos passed to it.
- - Use that custom element.
+ - Define a custom element for showing a list of todos.
+ - Use that custom element by passing it the list of fetched todos.
 
 Update the `JavaScript` tab to:
 
@@ -243,7 +243,7 @@ Update the `HTML` tab to:
 
  - Create the `todo-list-template` that loops through a list of `todos` (instead of `todosPromise.value`).
  - Create a `<todo-list>` element and set its `todos` property to the resolved value of `todosPromise`
-   using [can-stache-bindings.toChild].
+   using [can-stache-bindings.toChild `{todos}`].
 
 @sourceref ./6-list/html.html
 @highlight 18-32,43,only
@@ -277,8 +277,8 @@ Update the `HTML` tab to:
  - When the checkbox changes, update the todo on the server with [can-connect/can/map/map.prototype.save],
  - Call `edit` with the current context using [can-stache/keys/this].
  - Set up the edit input to:
-   - Two-way bind its value to the current todo’s `name` using [can-stache-bindings.twoWay].
-   - Call `updateName` when the enter key is pressed using [can-stache-bindings.event].
+   - Two-way bind its value to the current todo’s `name` using [can-stache-bindings.twoWay `{($value)}`].
+   - Call `updateName` when the enter key is pressed using [can-stache-bindings.event `($enter)`].
    - Focus the input when `isEditing` is true using the special [can-util/dom/attr/attr.special.focused] attribute.
    - Call `cancelEdit` if the input element loses focus.
 

--- a/docs/can-guides/introduction/comparison.md
+++ b/docs/can-guides/introduction/comparison.md
@@ -112,7 +112,7 @@ Using **MobX** observables with **React** is fairly popular, though not as popul
 
 ### Data Fetching and Real-time Data
 
-**[Can-Connect](../../can-connect.html)** allows for **CanJS** **observables** to be connected to a data source such as an RESTful API or a real-time data stream, with advanced features like fall through caching and batched minimal requests, so that your components can just request the data they need while can-connect figures out how to fetch that data in the most efficient way possible.
+**[Can-Connect](../../can-connect.html)** allows for **CanJS** **observables** to be connected to a data source such as an RESTful API or a real-time data stream, with advanced features like fall-through caching and batched minimal requests, so that your components can just request the data they need while can-connect figures out how to fetch that data in the most efficient way possible.
 
 **React**, being just a view layer, has no concept of this.
 
@@ -502,7 +502,7 @@ If your team needs to get started quickly, and hit the ground running, Angular 2
 
 ### Data Fetching and Real-time Data
 
-**[Can-Connect](../../can-connect.html)** allows for **CanJS** **observables** to be connected to a data source such as an RESTful API or a real-time data stream, with advanced features like fall through caching and batched minimal requests, so that your components can just request the data they need while can-connect figures out how to fetch that data in the most efficient way possible.
+**[Can-Connect](../../can-connect.html)** allows for **CanJS** **observables** to be connected to a data source such as an RESTful API or a real-time data stream, with advanced features like fall-through caching and batched minimal requests, so that your components can just request the data they need while can-connect figures out how to fetch that data in the most efficient way possible.
 
 **Angular 2**’s HTTP Service doesn’t have the advanced features like minimal requests and fall-through caches, and any real-time data-source would require you to write a custom service.
 

--- a/docs/can-guides/introduction/comparison.md
+++ b/docs/can-guides/introduction/comparison.md
@@ -285,7 +285,7 @@ These layers have a simple and inverse API, the Store layer takes actions and re
 
 ...and there are layers *within those layers*, like **action creators** and **redux-middleware**.
 
-This architecture is nice and simple, with discrete lines of interaction and well defined purpose and interface. The **tradeoff** however, is that to add a feature you need to add **_all_** the individual pieces to each of these layers.
+This architecture is nice and simple, with discrete lines of interaction and well-defined purpose and interface. The **tradeoff** however, is that to add a feature you need to add **_all_** the individual pieces to each of these layers.
 
 To illustrate the idea with an example you wanted to to add a "live video chat" feature to your app. Let’s pretend you have already implemented this sort of thing in some other app, so you are just going to reuse the shared portions of it for this app.
 

--- a/docs/can-guides/introduction/technical.md
+++ b/docs/can-guides/introduction/technical.md
@@ -732,7 +732,7 @@ var DefineMap = require("can-define/map/map"),
 
 // Defines the type of data we get back from the server.
 var Todo = DefineMap.extend({
-  id: "string",
+  id: "number",
   name: "string",
   complete: {type: "boolean", value: false}
 });

--- a/docs/can-guides/introduction/technical.md
+++ b/docs/can-guides/introduction/technical.md
@@ -150,7 +150,7 @@ todoList.push({name: "learn about computes", complete: true})
 
 ### Inferred dependencies
 
-In event stream libraries or other computed computed libraries, you must declare your
+In event stream libraries or other computed libraries, you must declare your
 dependencies like:
 
 ```js
@@ -675,9 +675,9 @@ _Custom Elements_ are broken down themselves into two layers:
  call methods on the _ViewModel_ when a user interacts
  with their HTML.
 
-All off these parts, _Custom Elements_, _Models_,
+All of these parts, _Custom Elements_, _Models_,
 _View Models_, and _Views_, are __mostly__ written using just
-two and a half APIs:
+a couple APIs:
 
 - [can-define] observables for _ViewModels_ and _Models_.
 - [can-stache] templates with [can-stache-bindings] for _Views_.


### PR DESCRIPTION
This covers a few issues:
- Clean up the ATM Guide: https://github.com/canjs/canjs/issues/2894
- Use only chat-related examples in the Chat Guide: https://github.com/canjs/canjs/issues/2881
- Replace uses of “refresh” with “rerun JS”: https://github.com/canjs/canjs/issues/2889
- Documentation considerations: https://github.com/canjs/canjs/issues/2867