### PR TITLE
Use a specific snapshot for all of our JS Bins

### DIFF
--- a/docs/can-guides/experiment/setting-up-canjs.md
+++ b/docs/can-guides/experiment/setting-up-canjs.md
@@ -21,7 +21,7 @@ ask on the [forums](http://forums.donejs.com/c/canjs) or [Gitter chat](https://g
 
 Use this JS Bin to play around with CanJS:
 
-<a class="jsbin-embed" href="//jsbin.com/safigic/embed?html,js,output">CanJS on jsbin.com</a><script src="//static.jsbin.com/js/embed.min.js?3.40.2"></script>
+<a class="jsbin-embed" href="//jsbin.com/safigic/7/embed?html,js,output">CanJS on jsbin.com</a><script src="//static.jsbin.com/js/embed.min.js?3.40.2"></script>
 
 It uses `can.all.js` so you have the [can-core core], [can-ecosystem ecosystem], and [can-infrastructure infrastructure] modules available to you.
 

--- a/docs/can-guides/introduction/technical.md
+++ b/docs/can-guides/introduction/technical.md
@@ -969,7 +969,7 @@ test("<todo-list> can update todo name", function(done){
 });
 ```
 
-Check out these tests running in [this JS&nbsp;Bin](http://justinbmeyer.jsbin.com/xaduto/edit?html,js,output).
+Check out these tests running in [this JS&nbsp;Bin](http://justinbmeyer.jsbin.com/xaduto/3/edit?html,js,output).
 
 ### Flexible
 
@@ -977,7 +977,7 @@ CanJS’s architecture produces observables that stand on their
 own, useful outside of the framework.  CanJS’s observables aren’t dependent on a diffing engine to identify changes.  Instead, any other tool or library can be an observer or call methods
 on the observable.
 
-[This JS Bin](http://jsbin.com/vivowu/edit?html,js,output) shows an analog clock that uses the [Canvas API](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API). The `Analog`
+[This JS Bin](http://jsbin.com/vivowu/7/edit?html,js,output) shows an analog clock that uses the [Canvas API](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API). The `Analog`
 clock listens to a `timer` observable and updates the position of the second, hour, and minute
 hands when the time changes.
 
@@ -1730,7 +1730,7 @@ module integrates jQuery’s and CanJS’s event system.  This allows you to lis
 jQuery custom events like `draginit` directly in [can-stache-bindings.event can-stache event bindings]
 or using [can-control].
 
-[This JS Bin](http://jsbin.com/yifopus/edit?html,css,js,output) lets a user drag an item
+[This JS Bin](http://jsbin.com/yifopus/3/edit?html,css,js,output) lets a user drag an item
 into a trashcan using custom jQuery drag/drop events.
 
 ## Server Side Rendering


### PR DESCRIPTION
Some of the links to JS Bin were for the latest version of the code, not a snapshot, so if the code changed, other users would see those changes.