### PR TITLE
Add steal-stache plugin configuration instructions to the migration guide

### DIFF
--- a/docs/can-guides/commitment/migrating_to_3.0.md
+++ b/docs/can-guides/commitment/migrating_to_3.0.md
@@ -247,7 +247,19 @@ If you use StealJS, you’ll need to install [steal-stache] to load your templat
 npm install steal-stache --save
 ```
 
-You don’t need to do anything else to make your templates load correctly.
+If you’re using StealJS 0.16, you don’t need to do anything else to make your templates load correctly.
+
+If you’re using StealJS 1, you also need to add `steal-stache` to the `plugins` configuration in your `package.json`:
+
+```json
+{
+  ...
+  "steal": {
+    ...
+    "plugins": ["steal-stache"]
+  }
+}
+```
 
 ## Modernized migration path
 

--- a/docs/can-guides/contribute/bug-report.md
+++ b/docs/can-guides/contribute/bug-report.md
@@ -19,7 +19,7 @@ move the issue to the correct repository if necessary.
 
 When creating an issue, it’s very helpful to include:
 
- - Small examples using tools like JS&nbsp;Bin. You can clone the following [CanJS bin](http://jsbin.com/ziyiqe/2/edit?html,js,output) that includes everything in CanJS. Make
+ - Small examples using tools like JS&nbsp;Bin. You can clone the following [CanJS bin](http://jsbin.com/losoceranu/1/edit?html,js,output) that includes everything in CanJS. Make
    sure it’s pointing at the same version of CanJS you are using.  
  - Breaking unit tests (optional). See [guides/contributing/code].
  - Proposed fix solutions (optional)


### PR DESCRIPTION
Also fix a JS Bin link to use CanJS 3.