### PR TITLE
WIP: Add can-model to the Legacy library list

### DIFF
--- a/docs/can-canjs/canjs.md
+++ b/docs/can-canjs/canjs.md
@@ -188,6 +188,9 @@ still accept patches._
 - **[can-map-backup]** <small><%can-map-backup.package.version%></small> Save the last state
   - `npm install can-map-backup --save`
   - <a class="github-button" href="https://github.com/canjs/can-map-backup" data-count-href="/canjs/can-map-backup/stargazers" data-count-api="/repos/canjs/can-map-backup#stargazers_count">Star</a>
+- **[can-model]** <small><%can-model.package.version%></small> Observable models for server data
+  - `npm install can-model --save`
+  - <a class="github-button" href="https://github.com/canjs/can-model" data-count-href="/canjs/can-model/stargazers" data-count-api="/repos/canjs/can-model#stargazers_count">Star</a>
 - **[can-ejs]** <small><%can-ejs.package.version%></small> EJS templates
   - `npm install can-ejs --save`
   - <a class="github-button" href="https://github.com/canjs/can-ejs" data-count-href="/canjs/can-ejs/stargazers" data-count-api="/repos/canjs/can-ejs#stargazers_count">Star</a>

--- a/legacy.js
+++ b/legacy.js
@@ -13,6 +13,7 @@ require("can-map");
 require("can-list");
 require("can-map-backup");
 require("can-map-define");
+require("can-model");
 require("can-connect/can/model/model");
 require("can-ejs");
 require("can-validate-legacy");

--- a/model/model_test.js
+++ b/model/model_test.js
@@ -1,0 +1,1 @@
+require('can-model/model_test');

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "can-map": "3.0.4",
     "can-map-backup": "3.0.2",
     "can-map-define": "3.0.3",
+    "can-model": "3.0.0",
     "can-namespace": "1.0.0",
     "can-observation": "3.0.5",
     "can-route": "3.0.6",

--- a/test/test.js
+++ b/test/test.js
@@ -46,6 +46,7 @@ if (!System.isEnv('production')) {
 require('../control/control_test');
 require('../list/list_test');
 require('../map/map_test');
+require('../model/model_test');
 require('can-map-define/can-map-define_test');
 require('can-view-href/test/test');
 require('can-map-backup/can-map-backup_test');


### PR DESCRIPTION
Five tests are failing when I run `npm run testee` locally.

I’m not sure why the `can-model` tests would work fine locally but not when included in this repo, so if someone has any guidance, it’d be much appreciated.

Fixes #2793