### PR TITLE
Add react view models to ecosystem

### DIFF
--- a/build.js
+++ b/build.js
@@ -3,57 +3,58 @@ var globalJS = require("steal-tools/lib/build/helpers/global").js;
 
 var baseNormalize = globalJS.normalize();
 var ignoreModules = [function(name){
-    if(name.indexOf("jquery") === 0 || name.indexOf("kefir") === 0 || name.indexOf('validate.js') === 0) {
-        return true;
-    } else {
-        return false;
-    }
+  return name.indexOf("jquery") === 0 ||
+    name.indexOf("kefir") === 0 ||
+    name.indexOf('validate.js') === 0 ||
+    (name.indexOf('react') === 0 && name.indexOf('react-view-models') < 0) ||
+    name.indexOf('fbjs') === 0;
 }];
 var exportsMap = {
     "jquery": "jQuery",
     "can-util/namespace": "can",
     "kefir": "Kefir",
-    "validate.js": "validate"
+    "validate.js": "validate",
+    "react": "React"
 };
 stealTools.export({
-	system: {
-		config: __dirname + "/package.json!npm",
-		main: "can/all"
-	},
-	options: {
-		useNormalizedDependencies: false,
-		verbose: true
-	},
-	outputs: {
-		"all": {
-			modules: ["can/all"],
-			format: "global",
-			dest: globalJS.dest(__dirname+"/dist/global/can.all.js"),
-			useNormalizedDependencies: true,
-			normalize: function(depName, depLoad, curName, curLoad, loader){
-				return baseNormalize.call(this, depName, depLoad, curName, curLoad, loader, true);
-			},
-			ignore: ignoreModules,
-			exports: exportsMap,
-			removeDevelopmentCode: false
-		},
-		"core": {
-			modules: ["can/can"],
-			format: "global",
-			dest: globalJS.dest(__dirname+"/dist/global/can.js"),
-			useNormalizedDependencies: true,
-			normalize: function(depName, depLoad, curName, curLoad, loader){
-				return baseNormalize.call(this, depName, depLoad, curName, curLoad, loader, true);
-			},
-			ignore: ignoreModules,
-			exports: exportsMap,
-			removeDevelopmentCode: false
-		}
-	}
+  system: {
+    config: __dirname + "/package.json!npm",
+    main: "can/all"
+  },
+  options: {
+    useNormalizedDependencies: false,
+    verbose: true
+  },
+  outputs: {
+    "all": {
+      modules: ["can/all"],
+      format: "global",
+      dest: globalJS.dest(__dirname+"/dist/global/can.all.js"),
+      useNormalizedDependencies: true,
+      normalize: function(depName, depLoad, curName, curLoad, loader){
+        return baseNormalize.call(this, depName, depLoad, curName, curLoad, loader, true);
+      },
+      ignore: ignoreModules,
+      exports: exportsMap,
+      removeDevelopmentCode: false
+    },
+    "core": {
+      modules: ["can/can"],
+      format: "global",
+      dest: globalJS.dest(__dirname+"/dist/global/can.js"),
+      useNormalizedDependencies: true,
+      normalize: function(depName, depLoad, curName, curLoad, loader){
+        return baseNormalize.call(this, depName, depLoad, curName, curLoad, loader, true);
+      },
+      ignore: ignoreModules,
+      exports: exportsMap,
+      removeDevelopmentCode: false
+    }
+  }
 }).catch(function(e){
 
-	setTimeout(function(){
-		throw e;
-	},1);
+  setTimeout(function(){
+    throw e;
+  },1);
 
 });

--- a/docs/can-canjs/canjs.md
+++ b/docs/can-canjs/canjs.md
@@ -168,7 +168,9 @@ render templates in script tags
 - **[can-define-stream]** <small><%can-define-stream.package.version%></small> Define property values using streams
   - `npm install can-define-stream --save`
   - <a class="github-button" href="https://github.com/canjs/can-define-stream" data-count-href="/canjs/can-define-stream/stargazers" data-count-api="/repos/canjs/can-define-stream#stargazers_count">Star</a>
-
+- **[react-view-models]** <small><%react-view-models.package.version%></small> Connect view-models to React components
+  - `npm install react-view-models --save`
+  - <a class="github-button" href="https://github.com/BigAB/react-view-models" data-count-href="/BigAB/react-view-models/stargazers" data-count-api="/repos/BigAB/react-view-models#stargazers_count">Star</a>
 
 </div>
 
@@ -265,6 +267,7 @@ __Ecosystem collection__
   "can-view-autorender": "<%can-view-autorender.package.version%>",
   "can-view-import": "<%can-view-import.package.version%>",
   "can-zone": "<%can-zone.package.version%>",
+  "react-view-models": "<%react-view-models.package.version%>",
   "steal-stache": "<%steal-stache.package.version%>",
 ```
 

--- a/docs/can-canjs/canjs.md
+++ b/docs/can-canjs/canjs.md
@@ -170,7 +170,7 @@ render templates in script tags
   - <a class="github-button" href="https://github.com/canjs/can-define-stream" data-count-href="/canjs/can-define-stream/stargazers" data-count-api="/repos/canjs/can-define-stream#stargazers_count">Star</a>
 - **[react-view-models]** <small><%react-view-models.package.version%></small> Connect view-models to React components
   - `npm install react-view-models --save`
-  - <a class="github-button" href="https://github.com/BigAB/react-view-models" data-count-href="/BigAB/react-view-models/stargazers" data-count-api="/repos/BigAB/react-view-models#stargazers_count">Star</a>
+  - <a class="github-button" href="https://github.com/canjs/react-view-models" data-count-href="/canjs/react-view-models/stargazers" data-count-api="/repos/canjs/react-view-models#stargazers_count">Star</a>
 
 </div>
 

--- a/ecosystem.js
+++ b/ecosystem.js
@@ -10,5 +10,6 @@ require("can-view-import");
 require("can-zone");
 require("can-stream");
 require("can-define-stream");
+require("react-view-models");
 
 module.exports = can;

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "can-view-parser": "3.0.4",
     "can-view-scope": "3.1.2",
     "can-view-target": "3.0.7",
-    "can-zone": "0.6.2"
+    "can-zone": "0.6.2",
+    "react-view-models": "0.0.8"
   },
   "devDependencies": {
     "async": "^2.1.2",
@@ -143,10 +144,11 @@
       "bit-docs-tag-package": "^0.0.5"
     },
     "glob": {
-      "pattern": "{node_modules,docs}/{can-*,steal-stache}/**/*.{js,md}",
+      "pattern": "{node_modules,docs}/{can-*,react-view-models,steal-stache}/**/*.{js,md}",
       "ignore": [
         "node_modules/can-wait/examples/**/*",
-        "node_modules/can-*/dist/**/*"
+        "node_modules/can-*/dist/**/*",
+        "node_modules/react-view-models/{dist,node_modules}/**/*"
       ]
     },
     "altVersions": {

--- a/test/test.js
+++ b/test/test.js
@@ -58,6 +58,7 @@ require('can-connect-feathers/test/test');
 // require('can-jquery/test/test');
 // require('can-vdom/test/test');
 // require('can-zone/test/test');
+// require('react-view-models/dist/test/test');
 
 
 // Integration tests


### PR DESCRIPTION
This adds [React View-Models](/canjs/react-view-models) to the CanJS website documentation

The  [react-view-models](/canjs/react-view-models) tests in this PR are commented out, because we currently can't get the tests to run with the CanJS tests, due to the way React and react-addons-test-utils are packaged, but I left them in commented in case we do find a good way of including them without crazy workarounds.

