### PR TITLE
Update can-stache-converter demos to work with API and example pages

### DIFF
--- a/demos/can-stache-converters/input-checkbox.html
+++ b/demos/can-stache-converters/input-checkbox.html
@@ -1,15 +1,17 @@
 <div id="out"></div>
+<script type="text/stache" id="demo-html">
+{{#each items}}
+	<p><input type='checkbox' {($checked)}='boolean-to-inList(this, person.owns)' /> {{upper(this)}}</p>
+{{/each}} 
+ <p>You own: {{ownership}}</p>
+</script>
 <script src="../../node_modules/steal/steal.js" main="@empty">
 var DefineMap = require("can-define/map/map");
 var DefineList = require("can-define/list/list");
 var stache = require("can-stache");
 require("can-stache-converters");
 
-var template = stache(
-	"{{#each items}}" +
-	"<p><input type='checkbox' {($checked)}='boolean-to-inList(this, person.owns)' /> {{upper(this)}}</p>" +
-	"{{/each}}" + 
-  "<p>You own: {{ownership}}</p>");
+var template = stache.from("demo-html");
 		
 var person = new DefineMap({
   owns: ["bike"]

--- a/demos/can-stache-converters/input-radio.html
+++ b/demos/can-stache-converters/input-radio.html
@@ -1,6 +1,11 @@
 <div id="demo">
 <div id='out'></div>
 <script type='text/stache' id="demo-html">
+<p>
+<input type="radio" name="number" {($checked)}="one" /> One? {{one}}<br>
+<input type="radio" name="number" {($checked)}="two" /> Two? {{two}}
+</p>
+<br>
 <p>Attending?
   <input type="radio" {($checked)}="equal(~attending, 'yes')" /> Yes
   <input type='radio' {($checked)}="equal(~attending, 'no')" /> No,
@@ -15,19 +20,9 @@ require("can-stache-converters");
 var DefineMap = require("can-define/map/map");
 			
 var person = new DefineMap({
-  attending: null
-});
-
-
-stache.registerConverter("equal", {
-	get: function(compute, comparer){
-		return compute() === comparer;
-	},
-	set: function(b, compute, comparer){
-		if(b) {
-			compute(comparer);
-		}
-	}
+  attending: null,
+  one: false,
+  two: false
 });
 
 

--- a/demos/can-stache-converters/multi-values.html
+++ b/demos/can-stache-converters/multi-values.html
@@ -32,30 +32,30 @@
 	</style>
 </head>
 <body>
-	<script type="text/stache" id="myTemplate">
-		<select multiple {($values)}="colors" size="7">
-			<option value="red">Red</option>
-			<option value="orange">Orange</option>
-			<option value="yellow">Yellow</option>
-			<option value="green">Green</option>
-			<option value="blue">Blue</option>
-			<option value="indigo">Indigo</option>
-			<option value="violet">Violet</option>
-		</select>
+<script type="text/stache" id="demo-html">
+<select multiple {($values)}="colors" size="7">
+	<option value="red">Red</option>
+	<option value="orange">Orange</option>
+	<option value="yellow">Yellow</option>
+	<option value="green">Green</option>
+	<option value="blue">Blue</option>
+	<option value="indigo">Indigo</option>
+	<option value="violet">Violet</option>
+</select>
 
-		<ul>
-		{{#each colors}}
-		<li>{{this}}</li>
-		{{/each}}
-		</ul>
-	</script>
-	<script src="../../node_modules/steal/steal.js" main="@empty">
+<ul>
+	{{#each colors}}
+	<li>{{this}}</li>
+	{{/each}}
+</ul>
+</script>
+	<script src="../../node_modules/steal/steal.js" id="demo-source" main="@empty">
 		var stache = require("can-stache");
 		var DefineMap = require("can-define/map/map");
 		var DefineList = require("can-define/list/list");
 		require("can-stache-converters");
 
-		var template = stache.from("myTemplate");
+		var template = stache.from("demo-html");
 		var map = new DefineMap({
 			colors: ["green"]
 		});


### PR DESCRIPTION
Related to https://github.com/canjs/can-stache-converters/pull/21, changes to demo pages to fully cover converter functions and fix display.