### PR TITLE
Adds can-observe as an ecosystem package

### DIFF
--- a/docs/can-canjs/canjs.md
+++ b/docs/can-canjs/canjs.md
@@ -180,7 +180,9 @@ render templates in script tags
 - **[can-define-validate-validatejs]** <small><%can-define-validate-validatejs.package.version%></small> Validation for DefineMaps using the ValidateJS library
   - `npm install can-define-validate-validatejs --save`
   - <a class="github-button" href="https://github.com/canjs/can-define-validate-validatejs" data-count-href="/canjs/can-define-validate-validatejs/stargazers" data-count-api="/repos/canjs/can-define-validate-validatejs#stargazers_count">Star</a>
-
+- **[can-observe]** <small><%can-observe.package.version%></small> Create plain observable objects
+  - `npm install can-observe --save`
+  - <a class="github-button" href="https://github.com/canjs/can-observe" data-count-href="/canjs/can-observe/stargazers" data-count-api="/repos/canjs/can-observe#stargazers_count">Star</a>
 
 </div>
 
@@ -278,6 +280,7 @@ __Ecosystem collection__
   "can-view-import": "<%can-view-import.package.version%>",
   "can-zone": "<%can-zone.package.version%>",
   "steal-stache": "<%steal-stache.package.version%>",
+  "can-observe": "<%can-observe.package.version%>"
 ```
 
 __Legacy Collection__

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "can-map-backup": "3.0.3",
     "can-map-define": "3.0.5",
     "can-namespace": "1.0.0",
+    "can-observe": "^0.1.2",
     "can-observation": "3.1.2",
     "can-route": "3.0.8",
     "can-route-pushstate": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "can-map-backup": "3.0.3",
     "can-map-define": "3.0.5",
     "can-namespace": "1.0.0",
-    "can-observe": "^0.1.2",
+    "can-observe": "0.1.3",
     "can-observation": "3.1.2",
     "can-route": "3.0.8",
     "can-route-pushstate": "3.0.3",

--- a/test/test.js
+++ b/test/test.js
@@ -59,6 +59,10 @@ require('can-connect-signalr/test');
 // require('can-vdom/test/test');
 // require('can-zone/test/test');
 
+if(typeof Proxy === 'function') {
+	require('can-observe/test');
+}
+
 
 // Integration tests
 require('../docs/can-guides/experiment/todomvc/test');


### PR DESCRIPTION
This adds can-observe as an ecosystem package. can-observe uses Proxys
to make plain objects observable.

See the docs to learn more:
https://github.com/canjs/can-observe/blob/master/docs/can-observe.md