### PR TITLE
change name to id

### DIFF
--- a/docs/can-guides/commitment/migrating_to_3.0.md
+++ b/docs/can-guides/commitment/migrating_to_3.0.md
@@ -323,7 +323,7 @@ Here’s a list of all the paths in CanJS 2.3 that now have separate modules in 
 - `can/view/stache/stache` — [can-stache]
 - `can/view/target/target` — [can-view-target]
 
-<a name="Future_proofmigrationpath"></a>
+<a id="Future_proofmigrationpath"></a>
 ## Latest & greatest migration path
 
 In addition to the steps taken in the two sections above, make the following changes to your application if you *really* want to stay ahead of the curve.


### PR DESCRIPTION
The "name" attribute is deprecated. It was causing this issue: https://github.com/canjs/bit-docs-html-canjs/issues/208.