### PR TITLE
Add can-param to the Infrastructure collection

### DIFF
--- a/docs/can-canjs/can-infrastructure.md
+++ b/docs/can-canjs/can-infrastructure.md
@@ -113,7 +113,7 @@ The JS utilities consist of:
 - Environment detection helpers: [can-util/js/is-browser-window/is-browser-window], [can-util/js/is-node/is-node], [can-util/js/is-web-worker/is-web-worker].
 - Environment identification helpers: [can-util/js/global/global], [can-util/js/import/import], [can-util/js/base-url/base-url].
 - Polyfills - [can-util/js/set-immediate/set-immediate].
-- URL helpers: [can-util/js/param/param], [can-util/js/deparam/deparam], [can-util/js/join-uris/join-uris].
+- URL helpers: [can-param], [can-util/js/deparam/deparam], [can-util/js/join-uris/join-uris].
 - Diffing helpers: [can-util/js/diff/diff], [can-util/js/diff-object/diff-object].
 - String helpers: [can-util/js/string/string], [can-util/js/string-to-any/string-to-any].
 - Object identification helpers: [can-util/js/cid/cid].

--- a/docs/can-canjs/canjs.md
+++ b/docs/can-canjs/canjs.md
@@ -113,6 +113,9 @@ _Utility libraries that power the core collection._
 - **[can-cid]** <small><%can-cid.package.version%></small> Get a unique identifier for objects
   - `npm install can-cid --save`
   - <a class="github-button" href="https://github.com/canjs/can-cid" data-count-href="/canjs/can-cid/stargazers" data-count-api="/repos/canjs/can-cid#stargazers_count">Star</a>
+- **[can-param]** <small><%can-param.package.version%></small> Serialize an array or object into a query string
+  - `npm install can-param --save`
+  - <a class="github-button" href="https://github.com/canjs/can-param" data-count-href="/canjs/can-param/stargazers" data-count-api="/repos/canjs/can-param#stargazers_count">Star</a>
 - **[can-types]** <small><%can-types.package.version%></small> A stateful container for CanJS type information
   - `npm install can-types --save`
   - <a class="github-button" href="https://github.com/canjs/can-types" data-count-href="/canjs/can-types/stargazers" data-count-api="/repos/canjs/can-types#stargazers_count">Star</a>

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "can-map-define": "3.0.5",
     "can-namespace": "1.0.0",
     "can-observation": "3.1.2",
+    "can-param": "1.0.1",
     "can-route": "3.0.8",
     "can-route-pushstate": "3.0.3",
     "can-set": "1.1.0",

--- a/test/test.js
+++ b/test/test.js
@@ -13,6 +13,7 @@ require('can-stache-converters/test/test');
 
 
 // Infrastructure tests
+require('can-param/can-param-test');
 require('../event/event_test');
 if (!System.isEnv('production')) {
 	System.import('can-observation/can-observation_test');


### PR DESCRIPTION
- Add it and its tests as a dependency
- Link to it from the home and Infrastructure pages

From my local build of the site:
<img width="1080" alt="screen shot 2017-03-29 at 11 01 23 pm" src="https://cloud.githubusercontent.com/assets/10070176/24489692/cdc5f2bc-14d3-11e7-8121-65eafacb2613.png">