### PR TITLE
Fix ValueConstructor behavior example

### DIFF
--- a/docs/can-guides/commitment/recipes/todomvc-with-steal/todomvc-with-steal.md
+++ b/docs/can-guides/commitment/recipes/todomvc-with-steal/todomvc-with-steal.md
@@ -731,12 +731,13 @@ custom element.
 a `DefineMap` property is read for the first time.
 
   ```js
+  var SubType = DefineMap.extend({})
   var Type = DefineMap.extend({
-      property: {value: Value}
+      property: {Value: SubType}
   })
 
   var map = new Type();
-  map.property instanceof Value //-> true
+  map.property instanceof SubType //-> true
   ```
 
 - Use [can-view-import] to import a module from a template like:


### PR DESCRIPTION
Renamed `value => Value` and gave a potential example of a `Value` with a dummy `SubType`.