### PR TITLE
Address Issue #3182. 

### DIFF
--- a/list/list.js
+++ b/list/list.js
@@ -859,7 +859,7 @@ steal("can/util", "can/map", "can/map/bubble.js","can/map/map_helpers.js",functi
 				self = this,
 				filtered;
 			this.each(function(item, index, list){
-				filtered = callback.call( thisArg | self, item, index, self);
+				filtered = callback.call( thisArg || self, item, index, self);
 				if(filtered){
 					filteredList.push(item);
 				}
@@ -870,7 +870,7 @@ steal("can/util", "can/map", "can/map/bubble.js","can/map/map_helpers.js",functi
 			var filteredList = new can.List(),
 				self = this;
 			this.each(function(item, index, list){
-				var mapped = callback.call( thisArg | self, item, index, self);
+				var mapped = callback.call( thisArg || self, item, index, self);
 				filteredList.push(mapped);
 
 			});

--- a/list/list_test.js
+++ b/list/list_test.js
@@ -366,7 +366,31 @@ steal("can/util", "can/list", "can/test", "can/compute", "steal-qunit", function
 			}, 10 );
 		}));
 	});
-	
-	
-	
+
+	test('filter with context', function(){
+		var l = new can.List([{id: 1}]);
+		var context = {};
+		var contextWasCorrect = false;
+
+		l.filter(function(){
+			contextWasCorrect = (this === context);
+			return true;
+		}, context);
+
+		equal(contextWasCorrect, true, "context was correctly passed");
+	});
+
+	test('map with context', function(){
+		var l = new can.List([{id: 1}]);
+		var context = {};
+		var contextWasCorrect = false;
+
+		l.map(function(){
+			contextWasCorrect = (this === context);
+			return true;
+		}, context);
+
+		equal(contextWasCorrect, true, "context was correctly passed");
+	});
+
 });

--- a/map/list/list.js
+++ b/map/list/list.js
@@ -1,6 +1,6 @@
 steal('can/util', 'can/map', 'can/list', 'can/compute', function (can) {
 	can.extend(can.List.prototype, {
-		filter: function (callback) {
+		filter: function (callback, thisArg) {
 			// The filtered list
 			var filtered = new this.constructor();
 			var self = this;
@@ -20,7 +20,7 @@ steal('can/util', 'can/map', 'can/list', 'can/compute', function (can) {
 				};
 				// a can.compute that executes the callback
 				var compute = can.compute(function () {
-					return callback(element, self.indexOf(element), self);
+					return callback.call(thisArg || self, element, self.indexOf(element), self);
 				});
 				// Update the filtered list on any compute change
 				compute.bind('change', binder);
@@ -48,14 +48,14 @@ steal('can/util', 'can/map', 'can/list', 'can/compute', function (can) {
 			this.forEach(generator);
 			return filtered;
 		},
-		map: function (callback) {
+		map: function (callback, thisArg) {
 			var mapped = new can.List();
 			var self = this;
 			// Again, lets run a generator function
 			var generator = function (element, index) {
 				// The can.compute for the mapping
 				var compute = can.compute(function () {
-					return callback(element, index, self);
+					return callback.call(thisArg || self, element, index, self);
 				});
 				compute.bind('change', function (ev, val) {
 					// On change, replace the current value with the new one


### PR DESCRIPTION
Addresses canjs/canjs#3182. Fixes the issue in both map() and the filter() functions of using a bitwise instead of logical or as a short-circuit to determine the context to be passed to the client callback function.

These are the same changes in https://github.com/canjs/can-list/pull/38 modified to apply to 2.3-legacy.