### PR TITLE
Add validate.js to github pages build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ publish-docs:
 	git add -f node_modules/feathers-hooks/package.json
 	git add -f node_modules/feathers-rest/package.json
 	git add -f node_modules/feathers-socketio/package.json
+	git add -f node_modules/validate.js/package.json
 	git checkout origin/gh-pages -- CNAME
 	git checkout origin/gh-pages -- release/
 	git commit -m "Publish docs"


### PR DESCRIPTION
validate.js is needed can-define-validate-validatejs demo, adding it to makefile so demo on production works properly.

Resolves https://github.com/canjs/can-define-validate-validatejs/issues/14