### PR TITLE
#3259 - use bit-docs link syntax for canjs.com links

### DIFF
--- a/docs/can-guides/commitment/recipes/file-navigator-ajax.md
+++ b/docs/can-guides/commitment/recipes/file-navigator-ajax.md
@@ -67,7 +67,7 @@ The first level files and folders should have a `parentId` of `"0"`.
 
 ### Things to know
 
-- [can-fixture] - is used to trap AJAX requests like:
+- [can-fixture] is used to trap AJAX requests like:
 
   ```js
   can.fixture("/api/entities", function(request){
@@ -77,7 +77,7 @@ The first level files and folders should have a `parentId` of `"0"`.
   })
   ```
 
-- [can-fixture.store] - can be used to automatically filter records using the querystring.
+- [can-fixture.store] can be used to automatically filter records using the querystring.
 
   ```js
   var entities = [ .... ];
@@ -85,7 +85,7 @@ The first level files and folders should have a `parentId` of `"0"`.
   can.fixture("/api/entities", entitiesStore);
   ```
 
-- [can-fixture.rand] - can be used to create a random integer.
+- [can-fixture.rand] can be used to create a random integer.
   ```
   can.fixture.rand(10) //-> 10
   can.fixture.rand(10) //-> 0

--- a/docs/can-guides/commitment/recipes/file-navigator-ajax.md
+++ b/docs/can-guides/commitment/recipes/file-navigator-ajax.md
@@ -67,7 +67,7 @@ The first level files and folders should have a `parentId` of `"0"`.
 
 ### Things to know
 
-- [can-fixture](http://canjs.com/doc/can-fixture.html) - is used to trap AJAX requests like:
+- [can-fixture] - is used to trap AJAX requests like:
 
   ```js
   can.fixture("/api/entities", function(request){
@@ -77,7 +77,7 @@ The first level files and folders should have a `parentId` of `"0"`.
   })
   ```
 
-- [can-fixture.store](http://canjs.com/doc/can-fixture.store.html) - can be used to automatically filter records using the querystring.
+- [can-fixture.store] - can be used to automatically filter records using the querystring.
 
   ```js
   var entities = [ .... ];
@@ -85,7 +85,7 @@ The first level files and folders should have a `parentId` of `"0"`.
   can.fixture("/api/entities", entitiesStore);
   ```
 
-- [can-fixture.rand](http://canjs.com/doc/can-fixture.rand.html) - can be used to create a random integer.
+- [can-fixture.rand] - can be used to create a random integer.
   ```
   can.fixture.rand(10) //-> 10
   can.fixture.rand(10) //-> 0
@@ -179,7 +179,7 @@ entity.name = "cats" //-> logs "entity name changed to cats"
 
 ### Things to know
 
-You can create a `DefineMap` type using [DefineMap.extend](http://canjs.com/doc/can-define/map/map.extend.html) with the type's properties and the properties' types like:
+You can create a `DefineMap` type using [can-define/map/map.extend DefineMap.extend] with the type's properties and the properties' types like:
 
 ```js
 Type = can.DefineMap.extend({
@@ -217,7 +217,7 @@ Entity.getList({parentId: "0"}).then(function(entities){
 
 ### Things to know
 
-[can.connect.baseMap()](http://canjs.com/doc/can-connect/can/base-map/base-map.html) can connect a `Map` type to
+[can-connect/can/base-map/base-map can.connect.baseMap()] can connect a `Map` type to
 a `url` like:
 
 ```js
@@ -249,7 +249,7 @@ in the same way it's expected by the designer.
 
 ### Things to know
 
-- CanJS uses [can-stache](http://canjs.com/doc/can-stache.html) to render data in a template
+- CanJS uses [can-stache] to render data in a template
   and keep it live.  Templates can be authored in `<script>` tags like:
 
   ```html
@@ -258,8 +258,8 @@ in the same way it's expected by the designer.
   </script>
   ```
 
-  A [can-stache](http://canjs.com/doc/can-stache.html) template uses
-  [{{key}}](http://canjs.com/doc/can-stache.tags.escaped.html) magic tags to insert data into
+  A [can-stache] template uses
+  [can-stache.tags.escaped {{key}}] magic tags to insert data into
   the HTML output like:
 
   ```html
@@ -268,7 +268,7 @@ in the same way it's expected by the designer.
   </script>
   ```
 
-- Load a template from a `<script>` tag with [can.stache.from](http://canjs.com/doc/can-stache.from.html) like:
+- Load a template from a `<script>` tag with [can-stache.from can.stache.from] like:
   ```js
   var template = can.stache.from(SCRIPT_ID);
   ```
@@ -337,9 +337,9 @@ In this section, we'll list the files and folders within the root folder.
 
 ### Things to know
 
-- Use [{{#if value}}](http://canjs.com/doc/can-stache.helpers.if.html) to do `if/else` branching in `can-stache`.
-- Use [{{#each value}}](http://canjs.com/doc/can-stache.helpers.each.html) to do looping in `can-stache`.
-- Use [{{#eq value1 value2}}](http://canjs.com/doc/can-stache.helpers.is.html) to test equality in `can-stache`.
+- Use [can-stache.helpers.if {{#if value}}] to do `if/else` branching in `can-stache`.
+- Use [can-stache.helpers.each {{#each value}}] to do looping in `can-stache`.
+- Use [can-stache.helpers.is {{#eq value1 value2}}] to test equality in `can-stache`.
 - `Promise`s are observable in `can-stache`.  Given a promise `somePromise`, you can:
   - Check if the promise is loading like: `{{#if somePromise.isPending}}`.
   - Loop through the resolved value of the promise like: `{{#each somePromise.value}}`.
@@ -393,7 +393,7 @@ clicks on the root folder's name should toggle if the children are displayed.
 
 ### Things to know
 
-- CanJS uses [ViewModels](http://canjs.com/doc/guides/technical.html#MaintainableMVVM) to manage the behavior
+- CanJS uses [guides/technicalViewModels#MaintainableMVVM ViewModels] to manage the behavior
   of views.  ViewModels can have their own state, such as if a folder `isOpen` and should be showing
   its children. `ViewModels` are custructor functions created with [can-define/map/map can.DefineMap].
 
@@ -513,7 +513,7 @@ Now we want to make all the folders able to open and close.  This means creating
 
 ### Things to know
 
-- [can.Component](http://canjs.com/doc/can-component.html) is used to create custom elements like:
+- [can-component can.Component] is used to create custom elements like:
   ```js
   var MyComponentVM = DefineMap.extend({
     message: {value: "Hello There!"}

--- a/docs/can-guides/commitment/recipes/file-navigator-simple.md
+++ b/docs/can-guides/commitment/recipes/file-navigator-simple.md
@@ -122,7 +122,7 @@ Lets render `rootEntityData` in the page with its immediate children.
 
 ### What you need to know
 
-- CanJS uses [can-stache](http://canjs.com/doc/can-stache.html) to render data in a template
+- CanJS uses [can-stache] to render data in a template
   and keep it live.  Templates can be authored in `<script>` tags like:
 
   ```html
@@ -131,8 +131,8 @@ Lets render `rootEntityData` in the page with its immediate children.
   </script>
   ```
 
-  A [can-stache](http://canjs.com/doc/can-stache.html) template uses
-  [{{key}}](http://canjs.com/doc/can-stache.tags.escaped.html) magic tags to insert data into
+  A [can-stache] template uses
+  [can-stache.tags.escaped {{key}}] magic tags to insert data into
   the HTML output like:
 
   ```html
@@ -141,7 +141,7 @@ Lets render `rootEntityData` in the page with its immediate children.
   </script>
   ```
 
-- Load a template from a `<script>` tag with [can.stache.from](http://canjs.com/doc/can-stache.from.html) like:
+- Load a template from a `<script>` tag with [can-stache.from can.stache.from] like:
   ```js
   var template = can.stache.from(SCRIPT_ID);
   ```
@@ -160,10 +160,10 @@ Lets render `rootEntityData` in the page with its immediate children.
   document.body.appendChild(frag);
   ```
 
-- Use [{{#if value}}](http://canjs.com/doc/can-stache.helpers.if.html) to do `if/else` branching in `can-stache`.
-- Use [{{#each value}}](http://canjs.com/doc/can-stache.helpers.each.html) to do looping in `can-stache`.
-- Use [{{#eq value1 value2}}](http://canjs.com/doc/can-stache.helpers.is.html) to test equality in `can-stache`.
-- [{{./key}}](http://canjs.com/doc/can-stache/keys/current.html) only returns the value in the current scope.
+- Use [can-stache.helpers.if {{#if value}}] to do `if/else` branching in `can-stache`.
+- Use [can-stache.helpers.each {{#each value}}] to do looping in `can-stache`.
+- Use [can-stache.helpers.is {{#eq value1 value2}}] to test equality in `can-stache`.
+- [can-stache/keys/current {{./key}}] only returns the value in the current scope.
 - Write a `<ul>` to contain all the files.  Within the `<ul>` there should be:
   - An `<li>` with a className that includes `file` or `folder` and `hasChildren` if the folder has children.
   - The `<li>` should have `📝 <span>{{FILE_NAME}}</span>` if a file and `📁 <span>{{FOLDER_NAME}}</span>` if a folder.
@@ -208,13 +208,13 @@ find a folder, we need to render its contents.
 
 ### Things to know
 
-- A template can call out to another registered _partial_ template with with [{{>PARTIAL_NAME}}](http://canjs.com/doc/can-stache.tags.partial.html) like the following:
+- A template can call out to another registered _partial_ template with with [can-stache.tags.partial {{>PARTIAL_NAME}}] like the following:
 
   ```html
   {{>PARTIAL_NAME}}
   ```
 
-- You can register partial templates with [can.stache.registerPartial](http://canjs.com/doc/can-stache.registerPartial.html) like the following:
+- You can register partial templates with [can-stache.registerPartial can.stache.registerPartial] like the following:
 
   ```js
   var template = can.stache.from("TEMPLATE_ID");
@@ -268,7 +268,7 @@ we change the data, the UI will automatically change.
 
 ### Things to know
 
-- [DefineMap.extend](http://canjs.com/doc/can-define/map/map.extend.html) allows you to define a type by defining the type's
+- [can-define/map/map.extend DefineMap.extend] allows you to define a type by defining the type's
   properties and the properties' types like:
 
   ```js
@@ -293,7 +293,7 @@ we change the data, the UI will automatically change.
   person.name = "Kevin" //-> logs "entity name changed to Kevin"
   ```
 
-- `can.DefineMap` supports an [Array shorthand](http://canjs.com/doc/can-define.types.propDefinition.html#Array) that allows one to specify a [can.DefineList](http://canjs.com/doc/can-define/list/list.html) of typed instances like:
+- `can.DefineMap` supports an [can-define.types.propDefinition#Array Array shorthand] that allows one to specify a [can-define/list/list can.DefineList] of typed instances like:
 
   ```js
   Person = can.DefineMap.extend("Person",{
@@ -392,9 +392,9 @@ We want to be able to toggle if a folder is open or closed.
   });
   ```
 
-- Use [{{#if value}}](http://canjs.com/doc/can-stache.helpers.if.html) to do `if/else` branching in `can-stache`.
+- Use [can-stache.helpers.if {{#if value}}] to do `if/else` branching in `can-stache`.
 
-- Use [($EVENT)](http://canjs.com/doc/can-stache-bindings.event.html) to listen to an event on an element and call a method in `can-stache`.  For example, the following calls `doSomething()` when the `<div>` is clicked.
+- Use [can-stache-bindings.event ($EVENT)] to listen to an event on an element and call a method in `can-stache`.  For example, the following calls `doSomething()` when the `<div>` is clicked.
 
    ```html
    <div ($click)="doSomething()"> ... </div>

--- a/docs/can-guides/commitment/recipes/playlist-editor/playlist-editor.md
+++ b/docs/can-guides/commitment/recipes/playlist-editor/playlist-editor.md
@@ -118,13 +118,13 @@ In this section, we will:
   frag //-> <h1>Hello World</h1>
   ```
 
-- Load a template from a `<script>` tag with [can.stache.from](http://canjs.com/doc/can-stache.from.html) like:
+- Load a template from a `<script>` tag with [can-stach.from can.stache.from] like:
 
   ```js
   var template = can.stache.from(SCRIPT_ID);
   ```  
 
-- Use [{{#if value}}](http://canjs.com/doc/can-stache.helpers.if.html) to do `if/else` branching in `can-stache`.
+- Use [can-stache.helpers.if {{#if value}}] to do `if/else` branching in `can-stache`.
 - `Promise`s are observable in `can-stache`.  Given a promise `somePromise`, you can:
   - Check if the promise is loading like: `{{#if somePromise.isPending}}`.
   - Loop through the resolved value of the promise like: `{{#each somePromise.value}}`.

--- a/docs/can-guides/commitment/recipes/todomvc-with-steal/todomvc-with-steal.md
+++ b/docs/can-guides/commitment/recipes/todomvc-with-steal/todomvc-with-steal.md
@@ -346,18 +346,18 @@ Update _models/todo.js_ to the following:
 ### What you need to know
 
 - [Stache Basics Presentation](https://drive.google.com/open?id=0Bx-kNqf-wxZeSjVJMTRJdXRXcWs)
-- CanJS uses [can-stache](http://canjs.com/doc/can-stache.html) to render data in a template
+- CanJS uses [can-stache] to render data in a template
   and keep it live. Templates can be loaded with [steal-stache].
 
-  A [can-stache](http://canjs.com/doc/can-stache.html) template uses
-  [{{key}}](http://canjs.com/doc/can-stache.tags.escaped.html) magic tags to insert data into
+  A [can-stache] template uses
+  [can-stache.tags.escaped {{key}}] magic tags to insert data into
   the HTML output like:
 
   ```html
     {{something.name}}
   ```
-- Use [{{#if value}}](http://canjs.com/doc/can-stache.helpers.if.html) to do `if/else` branching in `can-stache`.
-- Use [{{#each value}}](http://canjs.com/doc/can-stache.helpers.each.html) to do looping in `can-stache`.
+- Use [can-stache.helpers.if {{#if value}}] to do `if/else` branching in `can-stache`.
+- Use [can-stache.helpers.each {{#each value}}] to do looping in `can-stache`.
 
 ### The solution
 

--- a/docs/can-guides/commitment/recipes/weather-report/weather-report.md
+++ b/docs/can-guides/commitment/recipes/weather-report/weather-report.md
@@ -160,8 +160,8 @@ We want an `input` element to:
   <input {^$value}="property"/>
   ```
 
-- A [can-stache](http://canjs.com/doc/can-stache.html) template uses
-  [{{key}}](http://canjs.com/doc/can-stache.tags.escaped.html) magic tags to insert data into
+- A [can-stache] template uses
+  [can-stache.tags.escaped {{key}}] magic tags to insert data into
   the HTML output like:
 
   ```html
@@ -417,7 +417,7 @@ When a user clicks on a place, we need to indicate their selection.
   ```
 
 
-- The [http://canjs.com/doc/can-define.types.html “any” type] can be used to define a property as
+- The [can-define.types “any” type] can be used to define a property as
   accepting any data type like:
 
   ```js

--- a/docs/can-guides/contribute/including-new-modules.md
+++ b/docs/can-guides/contribute/including-new-modules.md
@@ -5,7 +5,7 @@
 
 @body
 
-A project that is useful to the CanJS community can be included on the [CanJS documentation](http://canjs.com/) site.
+A project that is useful to the CanJS community can be included on the [CanJS documentation](https://canjs.com/) site.
 
 Before submitting a PR with these changes, make sure that the source module has [guides/contributing/documentation] and tests that follow [guides/contributing/code] standards set forth by the CanJS community.
 

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 [![Build Status](https://travis-ci.org/canjs/canjs.png?branch=master)](https://travis-ci.org/canjs/canjs)
 [![Join the chat at https://gitter.im/canjs/canjs](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/canjs/canjs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-> WARNING: This npm package is for the [CanJS client-side MV* libraries](http://canjs.com). It was formerly
+> WARNING: This npm package is for the [CanJS client-side MV* libraries](https://canjs.com). It was formerly
 the [node-can project](https://github.com/sebi2k1/node-can) which has been moved 
 to [socketcan](https://www.npmjs.com/package/socketcan). A HUGE thanks to Sebastian Haas for 
 letting us use the `can` name!


### PR DESCRIPTION
resolves #3259 

Blocked by https://github.com/bit-docs/bit-docs-generate-html/pull/34