### PR TITLE
Fix exposing module in CommonJS format

### DIFF
--- a/map/define/define.js
+++ b/map/define/define.js
@@ -360,7 +360,7 @@ steal('can/util','can/map/map_helpers.js', 'can/map', 'can/compute', function (c
 			}
 			return serialized;
 		};
-
-		return can.define;
 	}
+
+	return can.define;
 });


### PR DESCRIPTION
After transpiling to CommonJS format there is a missing `module.export = can.define` in `map/define/define.js` module.
Instead, there is a `return can.define` statement that is a syntax typo in NodeJS:

![image](https://cloud.githubusercontent.com/assets/227305/26690350/40d920e2-46f9-11e7-815f-b76377e84b07.png)

## Before the fix
![image](https://cloud.githubusercontent.com/assets/227305/26690301/0a467f5c-46f9-11e7-9cee-394154dccabb.png)

## After applying fix
![image](https://cloud.githubusercontent.com/assets/227305/26690295/0177cdf4-46f9-11e7-9649-483b07539d40.png)
