### PR TITLE
Only update Sauce Labs badge for master builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ before_install:
 - ./firefox-allow-popups.sh
 - "export DISPLAY=:99.0"
 - "sh -e /etc/init.d/xvfb start"
+- if [ "$TRAVIS_BRANCH" != "master" ] || [ "$TRAVIS_PULL_REQUEST" != false ]; then SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY_NOT_MASTER SAUCE_USERNAME=$SAUCE_USERNAME_NOT_MASTER; fi
+- echo "Sauce Labs username is $SAUCE_USERNAME"
 - |
     if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^docs)/'
     then


### PR DESCRIPTION
When Travis runs and the branch isn’t `master`, we use a different Sauce Labs user so our badge isn’t updated with builds that aren’t on `master`.

Closes https://github.com/canjs/canjs/issues/3134