### PR TITLE
Add can-migrate-codemods docs to the ecosystem docs

### DIFF
--- a/docs/can-canjs/can-api.md
+++ b/docs/can-canjs/can-api.md
@@ -193,6 +193,9 @@ _Useful libraries that add important features or extend the core collection._
 - **[can-ndjson-stream]** <small><%can-ndjson-stream.package.version%></small> Convert ndjson stream into a ReadableStream of JS objects
   - `npm install can-ndjson-stream --save`
   - <a class="github-button" href="https://github.com/canjs/can-ndjson-stream">Star</a>
+- **[can-migrate-codemods]** <small><%can-migrate-codemods.package.version%></small> Code refactor CLI with transformation scripts to help migrate CanJS from 2.x to 3.x
+  - `npm install -g can-migrate-codemods`
+  - <a class="github-button" href="https://github.com/canjs/can-migrate-codemods">Star</a>
 
 </div>
 

--- a/ecosystem.js
+++ b/ecosystem.js
@@ -11,6 +11,7 @@ require("can-define-validate-validatejs");
 require("can-fixture");
 require("can-fixture-socket");
 require("can-jquery");
+require("can-migrate-codemods");
 require("can-ndjson-stream");
 require("can-stache-converters");
 require("can-validate");

--- a/ecosystem.js
+++ b/ecosystem.js
@@ -11,7 +11,6 @@ require("can-define-validate-validatejs");
 require("can-fixture");
 require("can-fixture-socket");
 require("can-jquery");
-require("can-migrate-codemods");
 require("can-ndjson-stream");
 require("can-stache-converters");
 require("can-validate");

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "can-map": "3.3.1",
     "can-map-backup": "3.1.0",
     "can-map-define": "3.1.1",
+    "can-migrate-codemods": "0.0.1",
     "can-namespace": "1.0.0",
     "can-ndjson-stream": "0.1.4",
     "can-observation": "3.3.1",


### PR DESCRIPTION
Here is what it looks like live:
![image](https://user-images.githubusercontent.com/3348231/28217898-6d669154-687c-11e7-9167-3bd25e28228f.png)

(very zoomed out)
![image](https://user-images.githubusercontent.com/3348231/28217918-839f97a4-687c-11e7-9399-fab74bb322b8.png)
