### PR TITLE
Updated the guide setting draggable to false

### DIFF
--- a/docs/can-guides/commitment/recipes/playlist-editor/3-search.html
+++ b/docs/can-guides/commitment/recipes/playlist-editor/3-search.html
@@ -21,9 +21,9 @@
       {{#each searchResultsPromise.value}}
         <li>
           <a href="https://www.youtube.com/watch?v={{./id.videoId}}" target='_blank'>
-          <img src="{{./snippet.thumbnails.default.url}}" width="50px"/>
+            <img src="{{./snippet.thumbnails.default.url}}" width="50px"/>
           </a>
-           {{./snippet.title}}
+          {{./snippet.title}}
         </li>
       {{/each}}
       </ul>

--- a/docs/can-guides/commitment/recipes/playlist-editor/4-drag.html
+++ b/docs/can-guides/commitment/recipes/playlist-editor/4-drag.html
@@ -21,9 +21,9 @@
       {{#each searchResultsPromise.value}}
         <li ($draginit)="videoDrag(%arguments[1])">
           <a draggable="false" href="https://www.youtube.com/watch?v={{./id.videoId}}" target='_blank'>
-          <img draggable="false" src="{{./snippet.thumbnails.default.url}}" width="50px"/>
+            <img draggable="false" src="{{./snippet.thumbnails.default.url}}" width="50px"/>
           </a>
-           {{./snippet.title}}
+          {{./snippet.title}}
         </li>
       {{/each}}
       </ul>

--- a/docs/can-guides/commitment/recipes/playlist-editor/4-drag.html
+++ b/docs/can-guides/commitment/recipes/playlist-editor/4-drag.html
@@ -20,8 +20,8 @@
       <ul class='source'>
       {{#each searchResultsPromise.value}}
         <li ($draginit)="videoDrag(%arguments[1])">
-          <a href="https://www.youtube.com/watch?v={{./id.videoId}}" target='_blank'>
-          <img src="{{./snippet.thumbnails.default.url}}" width="50px"/>
+          <a draggable="false" href="https://www.youtube.com/watch?v={{./id.videoId}}" target='_blank'>
+          <img draggable="false" src="{{./snippet.thumbnails.default.url}}" width="50px"/>
           </a>
            {{./snippet.title}}
         </li>

--- a/docs/can-guides/commitment/recipes/playlist-editor/5-drop.html
+++ b/docs/can-guides/commitment/recipes/playlist-editor/5-drop.html
@@ -21,8 +21,8 @@
       {{#each searchResultsPromise.value}}
         <li ($draginit)="videoDrag(%arguments[1])"
             {{data "dragData"}}>
-          <a href="https://www.youtube.com/watch?v={{./id.videoId}}" target='_blank'>
-          <img src="{{./snippet.thumbnails.default.url}}" width="50px"/>
+          <a draggable="false" href="https://www.youtube.com/watch?v={{./id.videoId}}" target='_blank'>
+          <img draggable="false" src="{{./snippet.thumbnails.default.url}}" width="50px"/>
           </a>
            {{./snippet.title}}
         </li>

--- a/docs/can-guides/commitment/recipes/playlist-editor/5-drop.html
+++ b/docs/can-guides/commitment/recipes/playlist-editor/5-drop.html
@@ -22,9 +22,9 @@
         <li ($draginit)="videoDrag(%arguments[1])"
             {{data "dragData"}}>
           <a draggable="false" href="https://www.youtube.com/watch?v={{./id.videoId}}" target='_blank'>
-          <img draggable="false" src="{{./snippet.thumbnails.default.url}}" width="50px"/>
+            <img draggable="false" src="{{./snippet.thumbnails.default.url}}" width="50px"/>
           </a>
-           {{./snippet.title}}
+          {{./snippet.title}}
         </li>
       {{/each}}
       </ul>

--- a/docs/can-guides/commitment/recipes/playlist-editor/6-order.html
+++ b/docs/can-guides/commitment/recipes/playlist-editor/6-order.html
@@ -21,8 +21,8 @@
       {{#each searchResultsPromise.value}}
         <li ($draginit)="videoDrag(%arguments[1])"
             {{data "dragData"}}>
-          <a href="https://www.youtube.com/watch?v={{./id.videoId}}" target='_blank'>
-          <img src="{{./snippet.thumbnails.default.url}}" width="50px"/>
+          <a draggable="false" href="https://www.youtube.com/watch?v={{./id.videoId}}" target='_blank'>
+          <img draggable="false" src="{{./snippet.thumbnails.default.url}}" width="50px"/>
           </a>
            {{./snippet.title}}
         </li>

--- a/docs/can-guides/commitment/recipes/playlist-editor/6-order.html
+++ b/docs/can-guides/commitment/recipes/playlist-editor/6-order.html
@@ -22,9 +22,9 @@
         <li ($draginit)="videoDrag(%arguments[1])"
             {{data "dragData"}}>
           <a draggable="false" href="https://www.youtube.com/watch?v={{./id.videoId}}" target='_blank'>
-          <img draggable="false" src="{{./snippet.thumbnails.default.url}}" width="50px"/>
+            <img draggable="false" src="{{./snippet.thumbnails.default.url}}" width="50px"/>
           </a>
-           {{./snippet.title}}
+          {{./snippet.title}}
         </li>
       {{/each}}
       </ul>

--- a/docs/can-guides/commitment/recipes/playlist-editor/8-create-playlist.html
+++ b/docs/can-guides/commitment/recipes/playlist-editor/8-create-playlist.html
@@ -21,8 +21,8 @@
       {{#each searchResultsPromise.value}}
         <li ($draginit)="videoDrag(%arguments[1])"
             {{data "dragData"}}>
-          <a href="https://www.youtube.com/watch?v={{./id.videoId}}" target='_blank'>
-          <img src="{{./snippet.thumbnails.default.url}}" width="50px"/>
+          <a draggable="false" href="https://www.youtube.com/watch?v={{./id.videoId}}" target='_blank'>
+          <img draggable="false" src="{{./snippet.thumbnails.default.url}}" width="50px"/>
           </a>
            {{./snippet.title}}
         </li>

--- a/docs/can-guides/commitment/recipes/playlist-editor/8-create-playlist.html
+++ b/docs/can-guides/commitment/recipes/playlist-editor/8-create-playlist.html
@@ -22,9 +22,9 @@
         <li ($draginit)="videoDrag(%arguments[1])"
             {{data "dragData"}}>
           <a draggable="false" href="https://www.youtube.com/watch?v={{./id.videoId}}" target='_blank'>
-          <img draggable="false" src="{{./snippet.thumbnails.default.url}}" width="50px"/>
+            <img draggable="false" src="{{./snippet.thumbnails.default.url}}" width="50px"/>
           </a>
-           {{./snippet.title}}
+          {{./snippet.title}}
         </li>
       {{/each}}
       </ul>

--- a/docs/can-guides/commitment/recipes/playlist-editor/playlist-editor.md
+++ b/docs/can-guides/commitment/recipes/playlist-editor/playlist-editor.md
@@ -409,13 +409,15 @@ In this section, we will:
   });
   new PlaylistVM().startedDrag();
   ```
+- Certain browsers have default drag behaviors for certain elements like `<a>` and `<img>`
+	that can be prevented with the `draggable="false"` attribute.
 
 ### The solution
 
 Update the template in the __HTML__ tab to:
 
 @sourceref ./4-drag.html
-@highlight 22,only
+@highlight 22-24,only
 
 Update the __JavaScript__ tab to:
 

--- a/docs/can-guides/commitment/recipes/playlist-editor/playlist-editor.md
+++ b/docs/can-guides/commitment/recipes/playlist-editor/playlist-editor.md
@@ -10,7 +10,7 @@ an hour to complete.
 
 The final widget looks like:
 
-<a class="jsbin-embed" href="https://jsbin.com/xiponom/16/embed?output">JS Bin on jsbin.com</a>
+<a class="jsbin-embed" href="https://jsbin.com/meqowis/embed?output">JS Bin on jsbin.com</a>
 
 To use the widget:
 

--- a/docs/can-guides/commitment/recipes/playlist-editor/playlist-editor.md
+++ b/docs/can-guides/commitment/recipes/playlist-editor/playlist-editor.md
@@ -10,7 +10,7 @@ an hour to complete.
 
 The final widget looks like:
 
-<a class="jsbin-embed" href="https://jsbin.com/meqowis/embed?output">JS Bin on jsbin.com</a>
+<a class="jsbin-embed" href="https://jsbin.com/meqowis/2/embed?output">JS Bin on jsbin.com</a>
 
 To use the widget:
 


### PR DESCRIPTION
Some browsers like Chrome have default draggable behavior for things like image and anchor elements. Setting `draggable="false"` on these will prevent that behavior.

This fixes issue #3244 on the video playlist editor guide where dragging on the thumbnail will no longer create a separate drag for the image or link.

For #3244 