### PR TITLE
Move the API Guide page to under “getting started”

### DIFF
--- a/docs/can-guides/Guides.md
+++ b/docs/can-guides/Guides.md
@@ -1,8 +1,7 @@
 @page guides Guides
 @parent canjs 1
-@group guides/getting-started 0 getting started
 @group guides/experiment 2 experiment
-@group guides/commitment 4 commitment
+@group guides/getting-started 3 getting started
 @group guides/contribute 5 contribute
 @group guides/upgrade 6 upgrade
 @subchildren

--- a/docs/can-guides/commitment/api-guide.md
+++ b/docs/can-guides/commitment/api-guide.md
@@ -1,5 +1,5 @@
-@page guides/api API Guide
-@parent guides/commitment 0
+@page guides/api Reading the Docs (API Guide)
+@parent guides/getting-started 1
 
 @description This page walks through how to use and understand CanJS’s API documentation.  
 


### PR DESCRIPTION
This commit renames the API Guide page to “Reading the Docs (API Guide)” and puts it under the “getting started” section of the Guides.

__Before:__
<img width="288" alt="screen shot 2017-07-25 at 2 28 05 pm" src="https://user-images.githubusercontent.com/10070176/28594638-8ce889e8-7145-11e7-81b1-d244d528f76f.png">

__After:__
<img width="282" alt="screen shot 2017-07-25 at 2 28 18 pm" src="https://user-images.githubusercontent.com/10070176/28594647-927a1afc-7145-11e7-9760-4c431d716604.png">


Closes https://github.com/canjs/canjs/issues/2863