### PR TITLE
Revert "Update can-connect to the latest version 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "can-cid": "1.0.3",
     "can-component": "3.3.0",
     "can-compute": "3.3.1",
-    "can-connect": "1.5.6",
+    "can-connect": "1.5.5",
     "can-connect-cloneable": "0.2.0",
     "can-connect-feathers": "3.6.0",
     "can-connect-ndjson": "0.1.1",


### PR DESCRIPTION
Reverts canjs/canjs#3478

The IE9 tests failed, so this shouldn't have been merged:
![image](https://user-images.githubusercontent.com/5851984/29095012-0d7aeb22-7c55-11e7-927e-6b4226b3c951.png)
