### PR TITLE
Added instruction to Setting Up CanJS section.

### DIFF
--- a/docs/can-guides/experiment/setting-up-canjs.md
+++ b/docs/can-guides/experiment/setting-up-canjs.md
@@ -35,14 +35,18 @@ npm install can-component can-compute can-connect can-define can-route can-route
 npm install steal steal-stache --save
 ```
 
-Then, add the following to your package.json as a top level property, not as a dependency. It must be added manually.
+Next, add the following [configuration](https://stealjs.com/docs/StealJS.configuration.html) to your `package.json`:
 
 ```
+{
+    ...
     "steal": {
+    ...
         "plugins": [
             "steal-stache"
         ]
     }
+}
 ```
 
 Next, create a `main.stache` template for your app:

--- a/docs/can-guides/experiment/setting-up-canjs.md
+++ b/docs/can-guides/experiment/setting-up-canjs.md
@@ -35,6 +35,16 @@ npm install can-component can-compute can-connect can-define can-route can-route
 npm install steal steal-stache --save
 ```
 
+Then, add the following to your package.json as a top level property, not as a dependency. It must be added manually.
+
+```
+    "steal": {
+        "plugins": [
+            "steal-stache"
+        ]
+    }
+```
+
 Next, create a `main.stache` template for your app:
 
 ```


### PR DESCRIPTION
A top level property must be added manually to the package.json file in order for the instructions to work. It is not added automatically when you install the packages.