### PR TITLE
Register steal-css as a steal-plugin in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,10 @@
       "socket.io-client/dist/socket.io": {
         "format": "cjs"
       }
-    }
+    },
+    "plugins": [
+      "steal-css"
+    ]
   },
   "bit-docs": {
     "html": {


### PR DESCRIPTION
This fixes #3490 by making steal-css available as a plugin in demo frames.  Without it, .css file paths aren't identifies as CSS resources, and are instead treated as modules with implicit .js.