### PR TITLE
Change require() calls to link tags in can-view-callbacks demo HTMLs.

### DIFF
--- a/demos/can-view-callbacks/dynamic_tooltip.html
+++ b/demos/can-view-callbacks/dynamic_tooltip.html
@@ -4,6 +4,7 @@
 		opacity: 0.5;
 	}
 </style>
+<link rel="stylesheet" href="../../node_modules/jquery-ui/themes/base/all.css" />
 <div id="demo">
 <div id="app"></div>
 <script type="text/stache" id="app-template">
@@ -51,7 +52,6 @@ var domEvents = require("can-util/dom/events/events");
 
 var $ = require("jquery");
 require("jquery-ui/ui/widgets/tooltip");
-require("jquery-ui/themes/base/all.css");
 
 require("can-stache-bindings");
 require("can-util/dom/events/attributes/attributes");

--- a/demos/can-view-callbacks/fade_in_when.html
+++ b/demos/can-view-callbacks/fade_in_when.html
@@ -1,3 +1,4 @@
+<link rel="stylesheet" href="../../node_modules/jquery-ui/themes/base/all.css" />
 <div id="app"></div>
 <script type="text/stache" id="info-template">
 	<button toggle="showing">
@@ -17,7 +18,6 @@ var domEvents = require("can-util/dom/events/events");
 
 var $ = require("jquery");
 require("jquery-ui/ui/widgets/tooltip");
-require("jquery-ui/themes/base/all.css");
 
 require("can-stache-bindings");
 require("can-util/dom/events/attributes/attributes");

--- a/demos/can-view-callbacks/tooltip.html
+++ b/demos/can-view-callbacks/tooltip.html
@@ -7,6 +7,7 @@
 
 	}
 </style>
+<link rel="stylesheet" href="../../node_modules/jquery-ui/themes/base/all.css" />
 <div id="demo">
 <div id="app"></div>
 <script type="text/stache" id="app-template">
@@ -26,7 +27,6 @@ var $ = require("jquery");
 var stache = require("can-stache");
 var canViewCallbacks = require("can-view-callbacks");
 require("jquery-ui/ui/widgets/tooltip");
-require("jquery-ui/themes/base/all.css");
 
 canViewCallbacks.attr("tooltip", function( el, attrData ) {
 	$(el).tooltip({


### PR DESCRIPTION
Fixes #3490