### PR TITLE
preventing $.event.add and $.event.remove when bind/unbind are called on Document Fragments

### DIFF
--- a/event/event_test.js
+++ b/event/event_test.js
@@ -258,4 +258,24 @@ steal('can/event', "can/control", 'can/test', "can/control", "steal-qunit", func
 		can.$(div).trigger("click");
 		equal(clicked, true, "click event handler was bound successfully via on()");
 	});
+
+	test('should not trigger events on Document Fragments', function () {
+		expect(0);
+		var origAdd = $.event.add;
+		var origRemove = $.event.remove;
+		$.event.add = function() {
+			QUnit.ok(false, 'should not set up jQuery event listener');
+		};
+		$.event.remove = function() {
+			QUnit.ok(false, 'should not remove jQuery event listener');
+		};
+
+		var frag = document.createDocumentFragment();
+
+		can.bind.call(frag, 'click', function() {});
+		can.unbind.call(frag, 'click', function() {});
+
+		$.event.add = origAdd;
+		$.event.remove = origRemove;
+	});
 });

--- a/util/jquery/jquery.js
+++ b/util/jquery/jquery.js
@@ -39,6 +39,13 @@ steal('jquery', 'can/util/can.js', 'can/util/attr', "can/event", "can/util/fragm
 		$: $,
 		each: can.each,
 		bind: function (ev, cb) {
+			// don't set up event listeners for document fragments
+			// since events will not be triggered and the handlers
+			// could lead to memory leaks
+			if (this.nodeType === 11) {
+				return;
+			}
+
 			// If we can bind to it...
 			if (this.bind && this.bind !== can.bind) {
 				this.bind(ev, cb);
@@ -51,6 +58,12 @@ steal('jquery', 'can/util/can.js', 'can/util/attr', "can/event", "can/util/fragm
 			return this;
 		},
 		unbind: function (ev, cb) {
+			// event handlers are not set up on document fragments
+			// so they do not need to be removed
+			if (this.nodeType === 11) {
+				return;
+			}
+
 			// If we can bind to it...
 			if (this.unbind && this.unbind !== can.unbind) {
 				this.unbind(ev, cb);


### PR DESCRIPTION
Porting fix from https://github.com/canjs/can-jquery/pull/67/files to CanJS 2.3.