### PR TITLE
Adding `git fetch` to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ publish-docs:
 	git add -f node_modules/feathers-rest/package.json
 	git add -f node_modules/feathers-socketio/package.json
 	git add -f node_modules/validate.js/package.json
+	git fetch
 	git checkout origin/gh-pages -- CNAME
 	git checkout origin/gh-pages -- release/
 	git commit -m "Publish docs"


### PR DESCRIPTION
In the Makefile, we checkout files like the release folder from `origin`:

```
git checkout origin/gh-pages -- release/
```

This assumes you have the latest from github, but if you haven't run `git fetch` (or `git pull` if you have it set up correctly) recently, you won't get the latest files from the `gh-pages` branch. This means that releases added manually might be blown away.