### PR TITLE
Add note regarding can-test-helpers

### DIFF
--- a/docs/can-guides/contribute/developing-locally.md
+++ b/docs/can-guides/contribute/developing-locally.md
@@ -106,6 +106,8 @@ Make sure Firefox is closed and run the test suite with:
 npm test
 ```
 
+> NOTE: When adding tests, make sure you checkout [can-test-helpers](https://github.com/canjs/can-test-helpers) as it provides some useful helpers for some tests.
+
 If every test passed, __congrats__! You have everything you need to
 change code and have the core team review it.
 


### PR DESCRIPTION
Updated the developing guide to include a note about using can-test-helpers when writing tests.

Depends on update to can-test-helpers' readme [here](https://github.com/canjs/can-test-helpers/pull/6)