### PR TITLE
Prevent compute.read from throwing when operating on certain primitives

### DIFF
--- a/compute/read.js
+++ b/compute/read.js
@@ -209,7 +209,8 @@ steal("can/util", function(can){
 			// this is the default
 			test: function(){return true;},
 			read: function(value, prop){
-				if(value == null) {
+				var valueType = typeof value;
+				if(value == null || (valueType !== 'object' && valueType !== 'function')) {
 					return undefined;
 				} else {
 					if(prop.key in value) {

--- a/compute/read_test.js
+++ b/compute/read_test.js
@@ -139,5 +139,11 @@ steal("can/compute", "can/test", "can/map", "steal-qunit", function () {
 		read = can.compute.read(map, can.compute.read.reads("expandoProp") );
 		equal(read.value,"val", "got expando prop");
 	});
+
+	test("read works on primitive objects", function(){
+		var read = can.compute.read('foo', can.compute.read.reads('bar'));
+		
+		equal(read.value, undefined);
+	});
 	
 });


### PR DESCRIPTION
Fixes #3636