### PR TITLE
Remove flexibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,9 +187,6 @@
         "steal-stache": "^3.0.5"
       },
       "package": {
-        "devDependencies": {
-          "flexibility": "^2.0.1"
-        },
         "steal": {
           "configDependencies": [
             "./node_modules/steal-conditional/conditional"
@@ -206,7 +203,7 @@
       "bit-docs-tag-sourceref": "^0.0.3",
       "bit-docs-generate-html": "^0.8.0",
       "bit-docs-generate-searchmap": "^0.2.0",
-      "bit-docs-html-canjs": "^2.0.0",
+      "bit-docs-html-canjs": "^2.0.2",
       "bit-docs-prettify": "^0.1.1",
       "bit-docs-html-highlight-line": "^0.2.2",
       "bit-docs-tag-demo": "^0.3.0",


### PR DESCRIPTION
It’s not needed because we don’t support IE 9 and 10.