### PR TITLE
More demo updates

### DIFF
--- a/demos/can-route/data.html
+++ b/demos/can-route/data.html
@@ -108,7 +108,7 @@ var AppState = DefineMap.extend({
 			});
 			if(!selected.length) return;
 			var ids = [];
-			selected.each(function(item){
+			selected.forEach(function(item){
 				ids.push(item.id);
 			});
 			return ids.join(",");

--- a/demos/can-stache-bindings-legacy/event-args.html
+++ b/demos/can-stache-bindings-legacy/event-args.html
@@ -1,0 +1,19 @@
+<script type='text/stache' can-autorender id='demo-html'>
+	{{#each items}}
+		<li ($click)='items.splice(%index,1)'>{{name}}</li>
+	{{/each}}
+</script>
+
+<script src="../../node_modules/steal/steal.js" main="@empty" id='demo-source'>
+import "can-view-autorender";
+import "can-stache-bindings";
+import "can-stache";
+import viewModel from "can-view-model";
+import DefineList from "can-define/list/list";
+
+var el = document.getElementById("demo-html");
+viewModel(el, {
+	items: new DefineList([{name: "first"}, {name: "second"}])
+});
+</script>
+

--- a/demos/can-stache-bindings-legacy/reference-one-way.html
+++ b/demos/can-stache-bindings-legacy/reference-one-way.html
@@ -1,0 +1,27 @@
+<script type="text/stache" id="demo-html">
+<year-selector *year-selector />
+Celebrate like it's {{*yearSelector.selectedYear}}!
+</script>
+<script src="../../node_modules/steal/steal.js" id='demo-source'>
+import Component from "can-component";
+import DefineMap from "can-define/map/map";
+import stache from "can-stache";
+
+Component.extend({
+	tag: "year-selector",
+	template: stache("<select {($value)}='selectedYear'>"+
+			"<option value='1999'>1999</option>"+
+			"<option value='2014'>2014</option>"+
+		"</select>"),
+	ViewModel: DefineMap.extend({
+		selectedYear: {
+			value: 1999,
+			type: 'number'
+		}
+	})
+});
+
+var tree = stache(document.getElementById("demo-html").innerHTML)({});
+document.body.appendChild(tree);
+</script>
+

--- a/demos/can-stache-bindings-legacy/reference.html
+++ b/demos/can-stache-bindings-legacy/reference.html
@@ -1,0 +1,54 @@
+<div id='demo-html'>
+<script id="app" type="text/stache">
+<drivers {^selected}="*editing"/>
+<edit-plate {(plate-name)}="*editing.licensePlate"/>
+</script>
+<script id='drivers-stache' type='text/stache'>
+<ul>
+  {{#each drivers}}
+    <li ($click)="select(.)">
+      {{title}} {{first}} {{last}} - {{licensePlate}}
+    </li>
+  {{/each}}
+</ul>
+</script>
+</div>
+<script src="../../node_modules/steal/steal.js" main="@empty" id='demo-source'>
+import "can-stache-bindings";
+import "can-view-autorender";
+import stache from "can-stache";
+import Component from "can-component";
+import DefineList from "can-define/list/list";
+import DefineMap from "can-define/map/map";
+
+Component.extend({
+	tag: "drivers",
+	template: stache(document.getElementById("drivers-stache").innerHTML),
+	ViewModel: DefineMap.extend({
+		drivers: {
+			value: new DefineList([
+				{ title: "Dr.", first: "Cosmo", last: "Kramer", licensePlate: "543210" },
+				{ title: "Ms.", first: "Elaine", last: "Benes", licensePlate: "621433" }
+			])
+		},
+		selected: "any",
+		select: function(driver){
+			this.selected = driver;
+		}
+	})
+});
+
+Component.extend({
+	tag: "edit-plate",
+	template: stache("<input value='{{plateName}}' ($input)='update($element.value)'/>"),
+	ViewModel: DefineMap.extend({
+		plateName: "string",
+		update: function(value){
+			this.plateName = value;
+		}
+	})
+});
+
+var tree = stache(document.getElementById('app').innerHTML)({});
+document.body.appendChild(tree);
+</script>

--- a/demos/can-stache-bindings-legacy/to-child.html
+++ b/demos/can-stache-bindings-legacy/to-child.html
@@ -1,0 +1,66 @@
+<script type='text/stache' id='demo-html'>
+<p>Alison: <player-scores {scores}="game.scoresForPlayer('Alison')"/></p>
+<p>Jeff: <player-scores {scores}="game.scoresForPlayer('Jeff')"/></p>
+</script>
+
+<script src="../../node_modules/steal/steal.js" main="@empty" id='demo-source'>
+import "can-view-autorender";
+import "can-stache-bindings";
+import Component from "can-component";
+import DefineList from "can-define/list/list";
+import DefineMap from "can-define/map/map";
+import stache from "can-stache";
+
+var Score = DefineMap.extend({
+	points: "number",
+	player: "string"
+});
+
+var ScoreList = DefineList.extend({
+	"#": Score
+}, {
+	sum: function(){
+		var sum = 0;
+		this.forEach(function(score){
+			sum += score.points;
+		});
+		return sum;
+	}
+});
+
+Component.extend({
+	tag: "player-scores",
+	template: stache('{{#each scores}} {{points}} {{/each}} = {{scores.sum()}}'),
+	ViewModel: DefineMap.extend({
+		scores: { Type: ScoreList }
+	})
+});
+
+var Game = DefineMap.extend({
+	scores: {
+		Type: ScoreList
+	},
+	scoresForPlayer: function(name){
+		return this.scores.filter(function(score){
+			return score.player === name;
+		});
+	}
+});
+
+var game = new Game({
+	scores: [
+		{player: "Alison", points: 2},
+		{player: "Alison", points: 3},
+		{player: "Jeff", points: 5},
+		{player: "Jeff", points: 1},
+		{player: "Alison", points: 6},
+		{player: "Jeff", points: 1},
+	]
+});
+
+var el = document.getElementById("demo-html");
+var frag = stache(el.innerHTML)({
+	game: game
+});
+document.body.appendChild(frag);
+</script>

--- a/demos/can-stache-bindings-legacy/to-parent-function.html
+++ b/demos/can-stache-bindings-legacy/to-parent-function.html
@@ -1,0 +1,93 @@
+<script type='text/stache' id='demo-html'>
+	<my-tabs {^@add-panel}="@*addPanel">
+	  <my-panel {add-panel}="@*addPanel" title="CanJS">CanJS Content</my-panel>
+	  <my-panel {add-panel}="@*addPanel" title="StealJS">StealJS Content</my-panel>
+	</my-tabs>
+</script>
+<script src="../../node_modules/steal/steal.js" main="@empty">
+var Component = require("can-component");
+var DefineMap = require("can-define/map/map");
+var DefineList = require("can-define/list/list");
+var canBatch = require("can-event/batch/batch");
+var stache = require("can-stache");
+	
+Component.extend({
+	tag: "my-tabs",
+	template: 	
+		stache("<ul>"+
+			// Create an LI for each item in the panel's viewModel object
+    		"{{#panels}}"+
+    			"<li {{#isActive}}class='active'{{/isActive}} "+
+    			    "($click)='makeActive(.)'>"+
+    			  "{{title}}"+
+    			"</li>"+
+    		"{{/panels}}"+
+    	"</ul>"+
+    	"<content></content>"),
+	ViewModel: DefineMap.extend({
+		// Contains a list of all panel scopes within the
+		// tabs element.
+		panels: {
+			value: new DefineList([])
+		},
+		active: "any",
+		// When a `<panel>` element is inserted into the document,
+		// it calls this method to add the panel's viewModel to the
+		// panels array.
+		addPanel: function(panel){
+			// If this is the first panel, activate it.
+			if(this.panels.length === 0) {
+				this.makeActive(panel);
+			} 
+			this.panels.push(panel);
+		},
+		// When a `<panel>` element is removed from the document,
+		// it calls this method to remove the panel's viewModel from
+		// the panels array.
+		removePanel: function(panel){
+			var panels = this.panels;
+			canBatch.start();
+			panels.splice(panels.indexOf(panel),1);
+			// if the panel was active, make the first item active
+			if(panel === this.active){
+				if(panels.length){
+					this.makeActive(panels[0]);
+				} else {
+					this.active = undefined;
+				}
+			}
+			canBatch.stop();
+		},
+		makeActive: function(panel){
+			this.active = panel;
+			this.panels.forEach(function(panel){
+				panel.active = false;
+			});
+			panel.active = true;
+		},
+		// this is viewModel, not mustache
+		// consider removing viewModel as arg
+		isActive: function( panel ) {
+			return this.active === panel;
+		}
+	})
+});
+
+Component.extend({
+	template: stache("{{#if active}}<content></content>{{/if}}"),
+	tag:"my-panel",
+	ViewModel: DefineMap.extend({
+		active: { value: false },
+		addPanel: "any",
+		init: function(){
+			this.addPanel(this);
+		}
+	})
+});
+
+var el = document.getElementById("demo-html");
+var frag = stache(el.innerHTML)({});
+
+document.body.appendChild(frag);
+</script>
+

--- a/demos/can-stache-bindings-legacy/to-parent.html
+++ b/demos/can-stache-bindings-legacy/to-parent.html
@@ -1,0 +1,57 @@
+<script type='text/stache' id='demo-html'>
+<drivers-list {^selected}="*editing">
+	<ul>
+		{{#each drivers}}
+			<li ($click)="select(.)">
+				{{title}} {{first}} {{last}} - {{licensePlate}}
+			</li>
+		{{/each}}
+	</ul>
+</drivers-list>
+<edit-plate {(plate-name)}="*editing.licensePlate"/>
+</script>
+
+<script src="../../node_modules/steal/steal.js" main="@empty" id='demo-source'>
+import "can-view-autorender";
+import "can-stache-bindings";
+import Component from "can-component";
+import DefineMap from "can-define/map/map";
+import DefineList from "can-define/list/list";
+import stache from "can-stache";
+
+Component.extend({
+	tag: "drivers-list",
+	ViewModel: DefineMap.extend({
+		drivers: {
+			value: new DefineList([
+				{ title: "Dr.", first: "Cosmo", last: "Kramer", licensePlate: "ASSMAN" },
+				{ title: "Ms.", first: "Elaine", last: "Benes", licensePlate: "621433" }
+			])
+		},
+		selected: {
+			value: false
+		},
+		select: function(driver){
+			this.selected = driver;
+		}
+	}),
+	leakScope: true
+});
+
+
+Component.extend({
+	tag: "edit-plate",
+	template: stache("<input value='{{plateName}}' ($input)='update($element.value)'/>"),
+	ViewModel: DefineMap.extend({
+		plateName: "string",
+		update: function(value){
+			this.plateName = value;
+		}
+	})
+});
+
+var el = document.getElementById("demo-html");
+var frag = stache(el.innerHTML)({});
+document.body.appendChild(frag);
+</script>
+

--- a/demos/can-stache-bindings-legacy/two-way.html
+++ b/demos/can-stache-bindings-legacy/two-way.html
@@ -1,0 +1,67 @@
+<div id='demo-html'>
+<script id="app" type="text/stache">
+<my-app>
+  <drivers {^selected}="editing"/>
+  <edit-plate {(plate-name)}="editing.licensePlate"/>
+</my-app>
+</script>
+<script id='drivers-stache' type='text/stache'>
+<ul>
+  {{#each drivers}}
+    <li ($click)="select(.)">
+      {{title}} {{first}} {{last}} - {{licensePlate}}
+    </li>
+  {{/each}}
+</ul>
+</script>
+</div>
+<script src="../../node_modules/steal/steal.js" main="@empty" id='demo-source'>
+import "can-view-autorender";
+import "can-stache-bindings";
+import stache from "can-stache";
+import Component from "can-component";
+import DefineMap from "can-define/map/map";
+import DefineList from "can-define/list/list";
+
+Component.extend({
+	tag: "my-app",
+	ViewModel: DefineMap.extend({
+		editing: "any"
+	})
+});
+
+var drivers = new DefineList([
+	{ title: "Dr.", first: "Cosmo", last: "Kramer", licensePlate: "543210" },
+	{ title: "Ms.", first: "Elaine", last: "Benes", licensePlate: "621433" }
+]);
+
+Component.extend({
+	tag: "drivers",
+	template: stache(document.getElementById('drivers-stache').innerHTML),
+	ViewModel: DefineMap.extend({
+		drivers: {
+			value: drivers
+		},
+		selected: "any",
+		select: function(driver){
+			this.selected = driver;
+		}
+	})
+});
+
+
+Component.extend({
+	tag: "edit-plate",
+	template: stache("<input value='{{plateName}}' ($input)='update($element.value)'/>"),
+	ViewModel: DefineMap.extend({
+		plateName: "string",
+		update: function(value){
+			this.plateName = value;
+		}
+	})
+});
+
+var tree = stache(document.getElementById('app').innerHTML)({});
+document.body.appendChild(tree);
+</script>
+

--- a/demos/can-stache-bindings/event-args.html
+++ b/demos/can-stache-bindings/event-args.html
@@ -1,6 +1,6 @@
 <script type='text/stache' can-autorender id='demo-html'>
 {{#each(items)}}
-	<li on:click='items.splice(%index,1)'>{{name}}</li>
+	<li on:click='items.splice(scope.index,1)'>{{name}}</li>
 {{/each}}
 </script>
 

--- a/demos/can-stache-bindings/reference-one-way.html
+++ b/demos/can-stache-bindings/reference-one-way.html
@@ -1,6 +1,6 @@
 <script type="text/stache" id="demo-html">
-<year-selector *year-selector />
-Celebrate like it’s {{*yearSelector.selectedYear}}!
+<year-selector this:to="scope.vars.yearSelector" />
+Celebrate like it’s {{scope.vars.yearSelector.selectedYear}}!
 </script>
 <script src="../../node_modules/steal/steal.js" id='demo-source'>
 import Component from "can-component";

--- a/demos/can-stache-bindings/reference.html
+++ b/demos/can-stache-bindings/reference.html
@@ -1,15 +1,15 @@
 <div id='demo-html'>
 <script id="app" type="text/stache">
-<drivers selected:to="*editing"/>
-<edit-plate plateName:bind="*editing.licensePlate"/>
+<my-drivers selected:to="scope.vars.editing"/>
+<edit-plate plateName:bind="scope.vars.editing.licensePlate"/>
 </script>
 <script id='drivers-stache' type='text/stache'>
 <ul>
-  {{#each(drivers)}}
-    <li on:click="select(this)">
-      {{title}} {{first}} {{last}} - {{licensePlate}}
-    </li>
-  {{/each}}
+	{{#each(drivers)}}
+		<li on:click="select(this)">
+			{{title}} {{first}} {{last}} - {{licensePlate}}
+		</li>
+	{{/each}}
 </ul>
 </script>
 </div>
@@ -22,14 +22,16 @@ import DefineList from "can-define/list/list";
 import DefineMap from "can-define/map/map";
 
 Component.extend({
-	tag: "drivers",
+	tag: "my-drivers",
 	view: stache(document.getElementById("drivers-stache").innerHTML),
 	ViewModel: DefineMap.extend({
 		drivers: {
-			value: new DefineList([
-				{ title: "Dr.", first: "Cosmo", last: "Kramer", licensePlate: "543210" },
-				{ title: "Ms.", first: "Elaine", last: "Benes", licensePlate: "621433" }
-			])
+			value: function () {
+				return new DefineList([
+					{ title: "Dr.", first: "Cosmo", last: "Kramer", licensePlate: "543210" },
+					{ title: "Ms.", first: "Elaine", last: "Benes", licensePlate: "621433" }
+				]);
+			}
 		},
 		selected: "any",
 		select: function(driver){

--- a/demos/can-stache-bindings/to-parent-function.html
+++ b/demos/can-stache-bindings/to-parent-function.html
@@ -1,7 +1,10 @@
+<style type="text/css">
+.active {font-weight: bold}
+</style>
 <script type='text/stache' id='demo-html'>
-<my-tabs @addPanel:to="@*addPanel">
-  <my-panel addPanel:from="@*addPanel" title="CanJS">CanJS Content</my-panel>
-  <my-panel addPanel:from="@*addPanel" title="StealJS">StealJS Content</my-panel>
+<my-tabs @addPanel:to="scope.vars.addPanel">
+	<my-panel addPanel:from="scope.vars@addPanel" title:from="'CanJS'">CanJS Content</my-panel>
+	<my-panel addPanel:from="scope.vars@addPanel" title:from="'StealJS'">StealJS Content</my-panel>
 </my-tabs>
 </script>
 <script src="../../node_modules/steal/steal.js" main="@empty">
@@ -16,19 +19,21 @@ Component.extend({
 	view:
 		stache("<ul>"+
 			// Create an LI for each item in the panel's viewModel object
-    		"{{#panels}}"+
-    			"<li {{#isActive}}class='active'{{/isActive}} "+
-    			    "on:click='makeActive(this)'>"+
-    			  "{{title}}"+
-    			"</li>"+
-    		"{{/panels}}"+
-    	"</ul>"+
-    	"<content></content>"),
+				"{{#each(panels, panel=value)}}"+
+					"<li {{#scope.root.isActive(panel)}}class='active'{{/isActive}} "+
+							"on:click='scope.root.makeActive(panel)'>"+
+						"{{panel.title}}"+
+					"</li>"+
+				"{{/each}}"+
+			"</ul>"+
+			"<content></content>"),
 	ViewModel: DefineMap.extend({
 		// Contains a list of all panel scopes within the
 		// tabs element.
 		panels: {
-			value: new DefineList([])
+			value: function() {
+				return new DefineList([]);
+			}
 		},
 		active: "any",
 		// When a `<panel>` element is inserted into the document,

--- a/demos/can-stache-bindings/to-parent.html
+++ b/demos/can-stache-bindings/to-parent.html
@@ -1,5 +1,5 @@
 <script type='text/stache' id='demo-html'>
-<drivers-list selected:to="*editing">
+<drivers-list selected:to="scope.vars.editing">
 	<ul>
 		{{#each(drivers)}}
 			<li on:click="select(this)">
@@ -8,7 +8,7 @@
 		{{/each}}
 	</ul>
 </drivers-list>
-<edit-plate plateName:bind="*editing.licensePlate"/>
+<edit-plate plateName:bind="scope.vars.editing.licensePlate"/>
 </script>
 
 <script src="../../node_modules/steal/steal.js" main="@empty" id='demo-source'>
@@ -23,10 +23,12 @@ Component.extend({
 	tag: "drivers-list",
 	ViewModel: DefineMap.extend({
 		drivers: {
-			value: new DefineList([
-				{ title: "Dr.", first: "Cosmo", last: "Kramer", licensePlate: "ASSMAN" },
-				{ title: "Ms.", first: "Elaine", last: "Benes", licensePlate: "621433" }
-			])
+			value: function() {
+				return new DefineList([
+					{ title: "Dr.", first: "Cosmo", last: "Kramer", licensePlate: "ASSMAN" },
+					{ title: "Ms.", first: "Elaine", last: "Benes", licensePlate: "621433" }
+				]);
+			}
 		},
 		selected: {
 			value: false
@@ -54,4 +56,3 @@ var el = document.getElementById("demo-html");
 var frag = stache(el.innerHTML)({});
 document.body.appendChild(frag);
 </script>
-

--- a/demos/can-stache-bindings/two-way.html
+++ b/demos/can-stache-bindings/two-way.html
@@ -1,17 +1,17 @@
 <div id='demo-html'>
 <script id="app" type="text/stache">
 <my-app>
-  <drivers selected:to="editing"/>
-  <edit-plate plateName:bind="editing.licensePlate"/>
+	<my-drivers selected:to="editing"/>
+	<edit-plate plateName:bind="editing.licensePlate"/>
 </my-app>
 </script>
 <script id='drivers-stache' type='text/stache'>
 <ul>
-  {{#each(drivers)}}
-    <li on:click="select(this)">
-      {{title}} {{first}} {{last}} - {{licensePlate}}
-    </li>
-  {{/each}}
+	{{#each(drivers)}}
+		<li on:click="select(this)">
+			{{title}} {{first}} {{last}} - {{licensePlate}}
+		</li>
+	{{/each}}
 </ul>
 </script>
 </div>
@@ -36,11 +36,13 @@ var drivers = new DefineList([
 ]);
 
 Component.extend({
-	tag: "drivers",
+	tag: "my-drivers",
 	view: stache(document.getElementById('drivers-stache').innerHTML),
 	ViewModel: DefineMap.extend({
 		drivers: {
-			value: drivers
+			value: function() {
+				return drivers;
+			}
 		},
 		selected: "any",
 		select: function(driver){
@@ -64,4 +66,3 @@ Component.extend({
 var tree = stache(document.getElementById('app').innerHTML)({});
 document.body.appendChild(tree);
 </script>
-

--- a/demos/can-stache-converters/multi-values.html
+++ b/demos/can-stache-converters/multi-values.html
@@ -1,37 +1,31 @@
-<!doctype html>
-<html>
-<head>
-	<title>values!</title>
-	<style>
-		select[multiple] {
-			font-size: 15px;
-			background: dimgrey;
-			padding: 0.3em;
-		}
-		[value=red] {
-			color: red;
-		}
-		[value=orange] {
-			color: orange;
-		}
-		[value=yellow] {
-			color: yellow;
-		}
-		[value=green] {
-			color: green;
-		}
-		[value=blue] {
-			color: blue;
-		}
-		[value=indigo] {
-			color: indigo;
-		}
-		[value=violet] {
-			color: violet;
-		}
-	</style>
-</head>
-<body>
+<style type="text/css">
+select[multiple] {
+	font-size: 15px;
+	background: dimgrey;
+	padding: 0.3em;
+}
+[value=red] {
+	color: red;
+}
+[value=orange] {
+	color: orange;
+}
+[value=yellow] {
+	color: yellow;
+}
+[value=green] {
+	color: green;
+}
+[value=blue] {
+	color: blue;
+}
+[value=indigo] {
+	color: indigo;
+}
+[value=violet] {
+	color: violet;
+}
+</style>
 <script type="text/stache" id="demo-html">
 <select multiple values:bind="colors" size="7">
 	<option value="red">Red</option>
@@ -44,24 +38,21 @@
 </select>
 
 <ul>
-	{{#each(colors)}}
+	{{#each colors}}
 		<li>{{this}}</li>
 	{{/each}}
 </ul>
 </script>
-	<script src="../../node_modules/steal/steal.js" id="demo-source" main="@empty">
-		var stache = require("can-stache");
-		var DefineMap = require("can-define/map/map");
-		var DefineList = require("can-define/list/list");
-		require("can-stache-converters");
+<script src="../../node_modules/steal/steal.js" id="demo-source" main="@empty">
+var stache = require("can-stache");
+var DefineMap = require("can-define/map/map");
+var DefineList = require("can-define/list/list");
+require("can-stache-converters");
 
-		var template = stache.from("demo-html");
-		var map = new DefineMap({
-			colors: ["green"]
-		});
+var template = stache.from("demo-html");
+var map = new DefineMap({
+	colors: ["green"]
+});
 
-		document.body.appendChild(template(map));
-	</script>
-
-</body>
-</html>
+document.body.appendChild(template(map));
+</script>

--- a/demos/can-view-callbacks/dynamic_tooltip.html
+++ b/demos/can-view-callbacks/dynamic_tooltip.html
@@ -23,13 +23,13 @@
 	<tfoot>
 		<tr>
 			<td colspan="3">
-				<button tooltip="{{deleteTooltip}}"
+				<button tooltip="{{deleteTooltip()}}"
 						{{^selected.length}}class="disabled"{{/selected.length}}
 						on:click="notImplemented()">
 					Delete
 				</button>
 				<button
-					tooltip="{{archiveTooltip}}"
+					tooltip="{{archiveTooltip()}}"
 					{{^selected.length}}class="disabled"{{/selected.length}}
 					on:click="notImplemented()">
 					Archive
@@ -97,7 +97,6 @@ $("#app").html( template({
 		}
 	},
 	deleteTooltip: function(){
-		console.log("calling delete", selected.length);
 		var selectedCount = selected.length
 		if(selectedCount) {
 			return "Delete "+selectedCount+" users";


### PR DESCRIPTION
- Add `demos/can-stache-bindings-legacy/`
- Update the can-stache-bindings demos with new CanJS 3 features
- Fix the can-stache-converters `select[multiple]` demo
- Update can-view-callbacks demos with new syntax