### PR TITLE
Upgrade the migration guide based on feedback.

### DIFF
--- a/docs/can-guides/upgrade/migrating-to-canjs-4.md
+++ b/docs/can-guides/upgrade/migrating-to-canjs-4.md
@@ -94,18 +94,22 @@ can-migrate --apply **/*.js --can-version 4
 
 The first step to upgrading to CanJS 4 is to deal with the breaking changes. Most can be changed relatively simply.
 
-## can-stache Helpers need to get called as Function
-In some examples befor can-define and can-stache helper functions got called inside can-stache templates if you used syntax like 
+### In stache, functions should be called with ()
+
+In CanJS 2.3 we introduced [can-stache/expressions/call call expressions] as a way to call functions with `()` just like you do in JavaScript. This enabled passing arguments as their *values* rather than as computes.
+
+In 4.0, all functions should be called with `()`, otherwise they will be treated as a value, and their `.toString()` method will be called.
+
+This is true of both methods on the ViewModel and helpers.
 
 ```handlebars
-{{helperName}}
+{{playerStats}}
 ```
 
 to:
 
-
 ```handlebars
-{{helperName()}}
+{{playerStats()}}
 ```
 
 ### can-stache/helpers/route replaced with can-stache-route-helpers
@@ -361,6 +365,26 @@ With this:
 ```
 
 Check out the [can-stache.helpers.console] docs for other interesting ways to use the new console methods.
+
+### .each was removed from maps and lists
+
+Previously [can-define/map/map], [can-define/list/list], [can-map], and [can-list] all had an `.each` method for looping over contained values. Due to the changes in scope-walking in stache, this would interfere with [can-stache.helpers.each]. For this reason, this was moved to `.forEach`.
+
+Change:
+
+```js
+players.each(function(player){
+
+})
+```
+
+to:
+
+```js
+players.forEach(function(player){
+
+})
+```
 
 ## Non-breaking warnings
 

--- a/docs/can-guides/upgrade/migrating-to-canjs-4.md
+++ b/docs/can-guides/upgrade/migrating-to-canjs-4.md
@@ -98,7 +98,7 @@ The first step to upgrading to CanJS 4 is to deal with the breaking changes. Mos
 
 > You can migrate this change with this codemod:
 > ```
-can-migrate --apply **/*.js --transform can-stache/route-helpers.js
+> can-migrate --apply **/*.js --transform can-stache/route-helpers.js
 > ```
 
 If you are using the route helpers such as [can-stache-route-helpers.routeUrl], it has been moved into its own package now and no longer exists in [can-stache]. Your app will likely not load until you fix this.
@@ -129,7 +129,7 @@ The batching system was replaced with [can-queues] which has a more sophisticate
 
 > To migrate to can-queues with a codemod run:
 > ```
-can-migrate --apply **/*.js --transform can-queues/batch.js
+> can-migrate --apply **/*.js --transform can-queues/batch.js
 > ```
 
 If you are using [can-event/batch/batch] (or can.event) to batch changes like so:
@@ -358,7 +358,7 @@ Some that you might see include:
 
 > To migrate this change with a codemod run:
 > ```
-can-migrate --apply **/*.js --transform can-route/register.js
+> can-migrate --apply **/*.js --transform can-route/register.js
 > ```
 
 Registering routes in [can-route] used to be done by calling the route function. That often confused people since `route` also includes other methods. We simplified this by moving registration to route.register. Change

--- a/docs/can-guides/upgrade/migrating-to-canjs-4.md
+++ b/docs/can-guides/upgrade/migrating-to-canjs-4.md
@@ -94,6 +94,20 @@ can-migrate --apply **/*.js --can-version 4
 
 The first step to upgrading to CanJS 4 is to deal with the breaking changes. Most can be changed relatively simply.
 
+## can-stache Helpers need to get called as Function
+In some examples befor can-define and can-stache helper functions got called inside can-stache templates if you used syntax like 
+
+```handlebars
+{{helperName}}
+```
+
+to:
+
+
+```handlebars
+{{helperName()}}
+```
+
 ### can-stache/helpers/route replaced with can-stache-route-helpers
 
 > You can migrate this change with this codemod:

--- a/docs/can-guides/upgrade/using-codemods.md
+++ b/docs/can-guides/upgrade/using-codemods.md
@@ -44,7 +44,7 @@ you significantly closer than doing the migration by hand.
 Install `can-migrate` from npm:
 
 ```shell
-npm install -g can-migrate
+npm install -g can-migrate@1
 ```
 
 This will make the `can-migrate` command available globally.


### PR DESCRIPTION
This upgrades the migration guide based on feedback provided in
https://github.com/canjs/canjs/issues/3781.

Also adds a section on the old stache symbols such as `%event`.