### PR TITLE
Add information about calling Stache Helpers as function

### DIFF
--- a/docs/can-guides/upgrade/migrating-to-canjs-4.md
+++ b/docs/can-guides/upgrade/migrating-to-canjs-4.md
@@ -80,6 +80,20 @@ If you are using [Yarn](https://yarnpkg.com/en/) the process is almost identical
 
 Once you have CanJS 4 installed, the next step is to fix breaking changes.
 
+## can-stache Helpers need to get called as Function
+In some examples befor can-define and can-stache helper functions got called inside can-stache templates if you used syntax like 
+
+```handlebars
+{{helperName}}
+```
+
+to:
+
+
+```handlebars
+{{helperName()}}
+```
+
 ### can-stache/helpers/route replaced with can-stache-route-helpers
 
 If you are using the route helpers such as [can-stache-route-helpers.routeUrl], it has been moved into its own package now and no longer exists in [can-stache]. Your app will likely not load until you fix this.


### PR DESCRIPTION
Its importent to point out for stache helpers that they now get called as function else they return as toString() there is no warning for that at present