### PR TITLE
fix 3.x build

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "socket.io-client": "^1.7.2",
-    "steal": "^1.5.5",
+    "steal": "1.5.5",
     "steal-conditional": "^0.4.0",
     "steal-css": "^1.2.4",
     "steal-qunit": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
   "devDependencies": {
     "bit-docs": "^0.0.7",
     "can-make-map": "^1.0.0",
-    "can-test-helpers": "^1.0.1",
+    "can-test-helpers": "1.1.0",
     "es6-promise": "^4.1.0",
     "feathers": "^2.0.3",
     "feathers-authentication-client": "^0.1.6",


### PR DESCRIPTION
Because of https://github.com/canjs/can-test-helpers/issues/10, `can-test-helpers@1.1.1` breaks any tests that have assertions for warnings - since the code is using `can-log@0.1.2` and `can-test-helpers` uses `can-log@1.0`.