### PR TITLE
Update to latest steal

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "socket.io-client": "^1.7.2",
-    "steal": "1.5.5",
+    "steal": "^1.6.5",
     "steal-conditional": "^0.4.0",
     "steal-css": "^1.2.4",
     "steal-qunit": "^1.0.1",


### PR DESCRIPTION
This is for the 3.x-legacy branch, use the latest version of steal which
fixes a bug that caused the tests here to fail.