### PR TITLE
updates to release notes generation script

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "qunitjs": "^2.4.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
+    "semver": "^5.5.0",
     "socket.io-client": "^1.7.2",
     "steal": "^1.6.5",
     "steal-conditional": "^0.4.0",


### PR DESCRIPTION
This adds a link for each version (even those without release notes),
doesn't add a link for the version of the dependency in <older version>,
and sorts the results alphabetically and then by semver version #.