### PR TITLE
fix typo in form guides file input

### DIFF
--- a/demos/forms/elements-file-files.html
+++ b/demos/forms/elements-file-files.html
@@ -35,8 +35,8 @@ Component.extend({
 						{{#each(selectedFiles, file=value)}}
 							<tr>
 								<td>{{file.name}}</td>
-								<td>{{file.type}}</td>
 								<td>{{file.size}}</td>
+								<td>{{file.type}}</td>
 							</tr>
 						{{/each}}
 					</tbody>


### PR DESCRIPTION
This corrects the file size value and file type value in the file input section and put them in the right columns.