### PR TITLE
Update the Playlist Editor recipe for 4.0

### DIFF
--- a/docs/can-guides/commitment/recipes/playlist-editor/1-setup.html
+++ b/docs/can-guides/commitment/recipes/playlist-editor/1-setup.html
@@ -1,16 +1,15 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta name="description" content="CanJS 3.7 - Playlist Editor Final">
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>JS Bin</title>
+  <title>CanJS Playlist Editor</title>
 </head>
 <body>
 
 <script id="app-template" type="text/stache">
   {{#if(googleApiLoadedPromise.isPending)}}
-    <div>Loading Google API ...</div>
+    <div>Loading Google API…</div>
   {{else}}
     <div>Loaded Google API</div>
   {{/if}}
@@ -18,22 +17,21 @@
 
 <script src="https://code.jquery.com/jquery-2.2.4.js"></script>
 <script src="https://unpkg.com/jquerypp@2/dist/global/jquerypp.js"></script>
-<script src="https://unpkg.com/can@3/dist/global/can.all.js"></script>
+<script src="https://unpkg.com/can@4/dist/global/can.all.js"></script>
 
 <script>
-var googleScriptLoaded;
-var googleApiLoadedPromise = new Promise(function(resolve){
-  googleScriptLoaded = function(){
-    gapi.load('client:auth2', function() {
-		gapi.client.init({
-			'apiKey': 'AIzaSyBcnGGOryOnmjUC09T78VCFEqRQRgvPnAc',
-			'clientId': '764983721035-85cbj35n0kmkmrba10f4jtte8fhpst84.apps.googleusercontent.com',
-			'discoveryDocs': [ 'https://www.googleapis.com/discovery/v1/apis/youtube/v3/rest' ],
-			'scope': 'https://www.googleapis.com/auth/youtube'
-		}).then(resolve);
-	});
+window.googleApiLoadedPromise = new Promise(function(resolve) {
+  window.googleScriptLoaded = function() {
+    gapi.load("client:auth2", function() {
+      gapi.client.init({
+        apiKey: 'AIzaSyBcnGGOryOnmjUC09T78VCFEqRQRgvPnAc',
+        clientId: '764983721035-85cbj35n0kmkmrba10f4jtte8fhpst84.apps.googleusercontent.com',
+        discoveryDocs: [ "https://www.googleapis.com/discovery/v1/apis/youtube/v3/rest" ],
+        scope: "https://www.googleapis.com/auth/youtube"
+      }).then(resolve);
+    });
   }
-})
+});
 </script>
 
 <script async defer src="https://apis.google.com/js/api.js"

--- a/docs/can-guides/commitment/recipes/playlist-editor/1-setup.js
+++ b/docs/can-guides/commitment/recipes/playlist-editor/1-setup.js
@@ -1,10 +1,10 @@
-var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
+const PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   googleApiLoadedPromise: {
     default: googleApiLoadedPromise
   }
 });
 
-var vm = new PlaylistVM();
-var template = can.stache.from("app-template");
-var fragment = template(vm);
+const vm = new PlaylistVM();
+const template = can.stache.from("app-template");
+const fragment = template(vm);
 document.body.appendChild(fragment);

--- a/docs/can-guides/commitment/recipes/playlist-editor/2-signin.html
+++ b/docs/can-guides/commitment/recipes/playlist-editor/2-signin.html
@@ -1,6 +1,6 @@
 <script id="app-template" type="text/stache">
   {{#if(googleApiLoadedPromise.isPending)}}
-    <div>Loading Google API ...</div>
+    <div>Loading Google API…</div>
   {{else}}
     {{#if(signedIn)}}
 	  Welcome {{givenName}}! <button on:click="googleAuth.signOut()">Sign Out</button>

--- a/docs/can-guides/commitment/recipes/playlist-editor/2-signin.js
+++ b/docs/can-guides/commitment/recipes/playlist-editor/2-signin.js
@@ -1,6 +1,6 @@
-var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
+const PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   init: function() {
-    var self = this;
+    const self = this;
 
     self.on("googleAuth", function(ev, googleAuth) {
       self.signedIn = googleAuth.isSignedIn.get();
@@ -26,7 +26,7 @@ var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   }
 });
 
-var vm = new PlaylistVM();
-var template = can.stache.from("app-template");
-var fragment = template(vm);
+const vm = new PlaylistVM();
+const template = can.stache.from("app-template");
+const fragment = template(vm);
 document.body.appendChild(fragment);

--- a/docs/can-guides/commitment/recipes/playlist-editor/3-search.html
+++ b/docs/can-guides/commitment/recipes/playlist-editor/3-search.html
@@ -1,6 +1,6 @@
 <script id="app-template" type="text/stache">
   {{#if(googleApiLoadedPromise.isPending)}}
-    <div>Loading Google API ...</div>
+    <div>Loading Google API…</div>
   {{else}}
     {{#if(signedIn)}}
       Welcome {{givenName}}! <button on:click="googleAuth.signOut()">Sign Out</button>
@@ -9,21 +9,21 @@
     {{/if}}
 
     <div>
-      <input value:bind="searchQuery" placeholder="Search for videos"/>
+      <input value:bind="searchQuery" placeholder="Search for videos" />
     </div>
 
     {{#if(searchResultsPromise.isPending)}}
-      <div class="loading">Loading videos...</div>
+      <div class="loading">Loading videos…</div>
     {{/if}}
 
     {{#if(searchResultsPromise.isResolved)}}
       <ul class='source'>
       {{#each(searchResultsPromise.value)}}
         <li>
-          <a href="https://www.youtube.com/watch?v={{./id.videoId}}" target='_blank'>
-            <img src="{{./snippet.thumbnails.default.url}}" width="50px"/>
+          <a href="https://www.youtube.com/watch?v={{id.videoId}}" target='_blank'>
+            <img src="{{snippet.thumbnails.default.url}}" width="50px" />
           </a>
-          {{./snippet.title}}
+          {{snippet.title}}
         </li>
       {{/each}}
       </ul>

--- a/docs/can-guides/commitment/recipes/playlist-editor/3-search.js
+++ b/docs/can-guides/commitment/recipes/playlist-editor/3-search.js
@@ -1,6 +1,6 @@
-var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
+const PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   init: function() {
-    var self = this;
+    const self = this;
 
     self.on("googleAuth", function(ev, googleAuth) {
       self.signedIn = googleAuth.isSignedIn.get();
@@ -31,22 +31,22 @@ var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   get searchResultsPromise() {
     if (this.searchQuery.length > 2) {
 
-      var results = gapi.client.youtube.search.list({
-          q: this.searchQuery,
-          part: 'snippet',
-          type: 'video'
-        }).then(function(response){
-        console.log(response.result.items);
+      const results = gapi.client.youtube.search.list({
+        q: this.searchQuery,
+        part: "snippet",
+        type: "video"
+      }).then(function(response) {
+        console.info("Search results:", response.result.items);
         return response.result.items;
       });
-      return new Promise(function(resolve, reject){
+      return new Promise(function(resolve, reject) {
         results.then(resolve, reject);
       });
     }
   }
 });
 
-var vm = new PlaylistVM();
-var template = can.stache.from("app-template");
-var fragment = template(vm);
+const vm = new PlaylistVM();
+const template = can.stache.from("app-template");
+const fragment = template(vm);
 document.body.appendChild(fragment);

--- a/docs/can-guides/commitment/recipes/playlist-editor/4-drag.html
+++ b/docs/can-guides/commitment/recipes/playlist-editor/4-drag.html
@@ -1,6 +1,6 @@
 <script id="app-template" type="text/stache">
   {{#if(googleApiLoadedPromise.isPending)}}
-    <div>Loading Google API ...</div>
+    <div>Loading Google API…</div>
   {{else}}
     {{#if(signedIn)}}
       Welcome {{givenName}}! <button on:click="googleAuth.signOut()">Sign Out</button>
@@ -9,21 +9,21 @@
     {{/if}}
 
     <div>
-      <input value:bind="searchQuery" placeholder="Search for videos"/>
+      <input value:bind="searchQuery" placeholder="Search for videos" />
     </div>
 
     {{#if(searchResultsPromise.isPending)}}
-      <div class="loading">Loading videos...</div>
+      <div class="loading">Loading videos…</div>
     {{/if}}
 
     {{#if(searchResultsPromise.isResolved)}}
       <ul class='source'>
       {{#each(searchResultsPromise.value)}}
-        <li on:draginit="videoDrag(%arguments[1])">
-          <a draggable="false" href="https://www.youtube.com/watch?v={{./id.videoId}}" target='_blank'>
-            <img draggable="false" src="{{./snippet.thumbnails.default.url}}" width="50px"/>
+        <li on:draginit="../videoDrag(scope.arguments[1])">
+          <a draggable="false" href="https://www.youtube.com/watch?v={{id.videoId}}" target='_blank'>
+            <img draggable="false" src="{{snippet.thumbnails.default.url}}" width="50px" />
           </a>
-          {{./snippet.title}}
+          {{snippet.title}}
         </li>
       {{/each}}
       </ul>

--- a/docs/can-guides/commitment/recipes/playlist-editor/4-drag.js
+++ b/docs/can-guides/commitment/recipes/playlist-editor/4-drag.js
@@ -1,6 +1,6 @@
-var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
+const PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   init: function() {
-    var self = this;
+    const self = this;
 
     self.on("googleAuth", function(ev, googleAuth) {
       self.signedIn = googleAuth.isSignedIn.get();
@@ -31,15 +31,15 @@ var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   get searchResultsPromise() {
     if (this.searchQuery.length > 2) {
 
-      var results = gapi.client.youtube.search.list({
-          q: this.searchQuery,
-          part: 'snippet',
-          type: 'video'
-        }).then(function(response){
-        console.log(response.result.items);
+      const results = gapi.client.youtube.search.list({
+        q: this.searchQuery,
+        part: "snippet",
+        type: "video"
+      }).then(function(response) {
+        console.info("Search results:", response.result.items);
         return response.result.items;
       });
-      return new Promise(function(resolve, reject){
+      return new Promise(function(resolve, reject) {
         results.then(resolve, reject);
       });
     }
@@ -49,7 +49,9 @@ var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   }
 });
 
-var vm = new PlaylistVM();
-var template = can.stache.from("app-template");
-var fragment = template(vm);
+can.addJQueryEvents(jQuery);
+
+const vm = new PlaylistVM();
+const template = can.stache.from("app-template");
+const fragment = template(vm);
 document.body.appendChild(fragment);

--- a/docs/can-guides/commitment/recipes/playlist-editor/5-drop.html
+++ b/docs/can-guides/commitment/recipes/playlist-editor/5-drop.html
@@ -1,6 +1,6 @@
 <script id="app-template" type="text/stache">
   {{#if(googleApiLoadedPromise.isPending)}}
-    <div>Loading Google API ...</div>
+    <div>Loading Google API…</div>
   {{else}}
     {{#if(signedIn)}}
       Welcome {{givenName}}! <button on:click="googleAuth.signOut()">Sign Out</button>
@@ -9,22 +9,22 @@
     {{/if}}
 
     <div>
-      <input value:bind="searchQuery" placeholder="Search for videos"/>
+      <input value:bind="searchQuery" placeholder="Search for videos" />
     </div>
 
     {{#if(searchResultsPromise.isPending)}}
-      <div class="loading">Loading videos...</div>
+      <div class="loading">Loading videos…</div>
     {{/if}}
 
     {{#if(searchResultsPromise.isResolved)}}
       <ul class='source'>
       {{#each(searchResultsPromise.value)}}
-        <li on:draginit="videoDrag(%arguments[1])"
-            {{data "dragData"}}>
-          <a draggable="false" href="https://www.youtube.com/watch?v={{./id.videoId}}" target='_blank'>
-            <img draggable="false" src="{{./snippet.thumbnails.default.url}}" width="50px"/>
+        <li on:draginit="../videoDrag(scope.arguments[1])"
+            {{domData("dragData")}}>
+          <a draggable="false" href="https://www.youtube.com/watch?v={{id.videoId}}" target='_blank'>
+            <img draggable="false" src="{{snippet.thumbnails.default.url}}" width="50px" />
           </a>
-          {{./snippet.title}}
+          {{snippet.title}}
         </li>
       {{/each}}
       </ul>
@@ -32,17 +32,17 @@
       {{#if(searchResultsPromise.value.length)}}
         <div class='new-playlist'>
           <ul
-		    on:dropover="addDropPlaceholder(0,getDragData(%arguments[2]))"
+		    on:dropover="addDropPlaceholder(0,getDragData(scope.arguments[2]))"
 			on:dropout="clearDropPlaceholder()"
-			on:dropon="addVideo(0,getDragData(%arguments[2]))">
+			on:dropon="addVideo(0,getDragData(scope.arguments[2]))">
 
             {{#each(videosWithDropPlaceholder)}}
               <li class="{{#if(isPlaceholder)}}placeholder{{/if}}">
-                <a href="https://www.youtube.com/watch?v={{./video.id.videoId}}" target='_blank'>
-                  <img src="{{./video.snippet.thumbnails.default.url}}" width="50px"/>
+                <a href="https://www.youtube.com/watch?v={{video.id.videoId}}" target='_blank'>
+                  <img src="{{video.snippet.thumbnails.default.url}}" width="50px" />
                 </a>
 
-                {{./video.snippet.title}}
+                {{video.snippet.title}}
               </li>
             {{else}}
               <div class="content">Drag video here</div>

--- a/docs/can-guides/commitment/recipes/playlist-editor/5-drop.js
+++ b/docs/can-guides/commitment/recipes/playlist-editor/5-drop.js
@@ -1,6 +1,6 @@
-var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
+const PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   init: function() {
-    var self = this;
+    const self = this;
 
     self.on("googleAuth", function(ev, googleAuth) {
       self.signedIn = googleAuth.isSignedIn.get();
@@ -31,15 +31,15 @@ var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   get searchResultsPromise() {
     if (this.searchQuery.length > 2) {
 
-      var results = gapi.client.youtube.search.list({
-          q: this.searchQuery,
-          part: 'snippet',
-          type: 'video'
-        }).then(function(response){
-        console.log(response.result.items);
+      const results = gapi.client.youtube.search.list({
+        q: this.searchQuery,
+        part: "snippet",
+        type: "video"
+      }).then(function(response) {
+        console.info("Search results:", response.result.items);
         return response.result.items;
       });
-      return new Promise(function(resolve, reject){
+      return new Promise(function(resolve, reject) {
         results.then(resolve, reject);
       });
     }
@@ -47,8 +47,8 @@ var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   videoDrag: function(drag) {
     drag.ghost().addClass("ghost");
   },
-  getDragData: function(drag){
-	return can.data.get.call(drag.element[0], "dragData");
+  getDragData: function(drag) {
+    return can.domData.get(drag.element[0], "dragData");
   },
   dropPlaceholderData: "any",
   playlistVideos: {
@@ -73,7 +73,7 @@ var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
     }
   },
   get videosWithDropPlaceholder() {
-    var copy = this.playlistVideos.map(function(video) {
+    const copy = this.playlistVideos.map(function(video) {
       return {
         video: video,
         isPlaceholder: false
@@ -89,7 +89,9 @@ var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   }
 });
 
-var vm = new PlaylistVM();
-var template = can.stache.from("app-template");
-var fragment = template(vm);
+can.addJQueryEvents(jQuery);
+
+const vm = new PlaylistVM();
+const template = can.stache.from("app-template");
+const fragment = template(vm);
 document.body.appendChild(fragment);

--- a/docs/can-guides/commitment/recipes/playlist-editor/6-order.html
+++ b/docs/can-guides/commitment/recipes/playlist-editor/6-order.html
@@ -1,6 +1,6 @@
 <script id="app-template" type="text/stache">
   {{#if(googleApiLoadedPromise.isPending)}}
-    <div>Loading Google API ...</div>
+    <div>Loading Google API…</div>
   {{else}}
     {{#if(signedIn)}}
       Welcome {{givenName}}! <button on:click="googleAuth.signOut()">Sign Out</button>
@@ -9,22 +9,22 @@
     {{/if}}
 
     <div>
-      <input value:bind="searchQuery" placeholder="Search for videos"/>
+      <input value:bind="searchQuery" placeholder="Search for videos" />
     </div>
 
     {{#if(searchResultsPromise.isPending)}}
-      <div class="loading">Loading videos...</div>
+      <div class="loading">Loading videos…</div>
     {{/if}}
 
     {{#if(searchResultsPromise.isResolved)}}
       <ul class='source'>
       {{#each(searchResultsPromise.value)}}
-        <li on:draginit="videoDrag(%arguments[1])"
-            {{data "dragData"}}>
-          <a draggable="false" href="https://www.youtube.com/watch?v={{./id.videoId}}" target='_blank'>
-            <img draggable="false" src="{{./snippet.thumbnails.default.url}}" width="50px"/>
+        <li on:draginit="../videoDrag(scope.arguments[1])"
+            {{domData("dragData")}}>
+          <a draggable="false" href="https://www.youtube.com/watch?v={{id.videoId}}" target='_blank'>
+            <img draggable="false" src="{{snippet.thumbnails.default.url}}" width="50px" />
           </a>
-          {{./snippet.title}}
+          {{snippet.title}}
         </li>
       {{/each}}
       </ul>
@@ -32,17 +32,17 @@
       {{#if(searchResultsPromise.value.length)}}
         <div class='new-playlist'>
           <ul sortable
-            on:sortableplaceholderat="addDropPlaceholder(%event.index, %event.dragData)"
-            on:sortableinsertat="addVideo(%event.index, %event.dragData)"
+            on:sortableplaceholderat="addDropPlaceholder(scope.event.index, scope.event.dragData)"
+            on:sortableinsertat="addVideo(scope.event.index, scope.event.dragData)"
             on:dropout="clearDropPlaceholder()">
 
             {{#each(videosWithDropPlaceholder)}}
               <li class="{{#if(isPlaceholder)}}placeholder{{/if}}">
-                <a href="https://www.youtube.com/watch?v={{./video.id.videoId}}" target='_blank'>
-                  <img src="{{./video.snippet.thumbnails.default.url}}" width="50px"/>
+                <a href="https://www.youtube.com/watch?v={{video.id.videoId}}" target='_blank'>
+                  <img src="{{video.snippet.thumbnails.default.url}}" width="50px" />
                 </a>
 
-                {{./video.snippet.title}}
+                {{video.snippet.title}}
               </li>
             {{else}}
               <div class="content">Drag video here</div>

--- a/docs/can-guides/commitment/recipes/playlist-editor/6-order.js
+++ b/docs/can-guides/commitment/recipes/playlist-editor/6-order.js
@@ -1,6 +1,6 @@
-var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
+const PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   init: function() {
-    var self = this;
+    const self = this;
 
     self.on("googleAuth", function(ev, googleAuth) {
       self.signedIn = googleAuth.isSignedIn.get();
@@ -31,15 +31,15 @@ var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   get searchResultsPromise() {
     if (this.searchQuery.length > 2) {
 
-      var results = gapi.client.youtube.search.list({
-          q: this.searchQuery,
-          part: 'snippet',
-          type: 'video'
-        }).then(function(response){
-        console.log(response.result.items);
+      const results = gapi.client.youtube.search.list({
+        q: this.searchQuery,
+        part: "snippet",
+        type: "video"
+      }).then(function(response) {
+        console.info("Search results:", response.result.items);
         return response.result.items;
       });
-      return new Promise(function(resolve, reject){
+      return new Promise(function(resolve, reject) {
         results.then(resolve, reject);
       });
     }
@@ -47,8 +47,8 @@ var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   videoDrag: function(drag) {
     drag.ghost().addClass("ghost");
   },
-  getDragData: function(drag){
-	return can.data.get.call(drag.element[0], "dragData");
+  getDragData: function(drag) {
+    return can.domData.get(drag.element[0], "dragData");
   },
   dropPlaceholderData: "any",
   playlistVideos: {
@@ -73,7 +73,7 @@ var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
     }
   },
   get videosWithDropPlaceholder() {
-    var copy = this.playlistVideos.map(function(video) {
+    const copy = this.playlistVideos.map(function(video) {
       return {
         video: video,
         isPlaceholder: false
@@ -89,7 +89,9 @@ var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   }
 });
 
-var Sortable = can.Control.extend({
+can.addJQueryEvents(jQuery);
+
+const Sortable = can.Control.extend({
   "{element} dropmove": function(el, ev, drop, drag) {
     this.fireEventForDropPosition(ev, drop, drag, "sortableplaceholderat");
   },
@@ -97,16 +99,16 @@ var Sortable = can.Control.extend({
     this.fireEventForDropPosition(ev, drop, drag, "sortableinsertat");
   },
   fireEventForDropPosition: function(ev, drop, drag, eventName) {
-    var dragData = can.data.get.call(drag.element[0], "dragData");
+    const dragData = can.domData.get(drag.element[0], "dragData");
 
-    var sortables = $(this.element).children();
+    const sortables = $(this.element).children();
 
     for (var i = 0; i < sortables.length; i++) {
       //check if cursor is past 1/2 way
-      var sortable = $(sortables[i]);
+      const sortable = $(sortables[i]);
       if (ev.pageY < Math.floor(sortable.offset().top + sortable.height() / 2)) {
         // index at which it needs to be inserted before
-        $(this.element).trigger({
+        can.domEvents.dispatch(this.element, {
           type: eventName,
           index: i,
           dragData: dragData
@@ -115,13 +117,13 @@ var Sortable = can.Control.extend({
       }
     }
     if (!sortables.length) {
-      $(this.element).trigger({
+      can.domEvents.dispatch(this.element, {
         type: eventName,
         index: 0,
         dragData: dragData
       });
     } else {
-      $(this.element).trigger({
+      can.domEvents.dispatch(this.element, {
         type: eventName,
         index: i,
         dragData: dragData
@@ -134,7 +136,7 @@ can.view.callbacks.attr("sortable", function(el) {
   new Sortable(el);
 });
 
-var vm = new PlaylistVM();
-var template = can.stache.from("app-template");
-var fragment = template(vm);
+const vm = new PlaylistVM();
+const template = can.stache.from("app-template");
+const fragment = template(vm);
 document.body.appendChild(fragment);

--- a/docs/can-guides/commitment/recipes/playlist-editor/7-revert.js
+++ b/docs/can-guides/commitment/recipes/playlist-editor/7-revert.js
@@ -1,6 +1,6 @@
-var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
+const PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   init: function() {
-    var self = this;
+    const self = this;
 
     self.on("googleAuth", function(ev, googleAuth) {
       self.signedIn = googleAuth.isSignedIn.get();
@@ -31,15 +31,15 @@ var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   get searchResultsPromise() {
     if (this.searchQuery.length > 2) {
 
-      var results = gapi.client.youtube.search.list({
-          q: this.searchQuery,
-          part: 'snippet',
-          type: 'video'
-        }).then(function(response){
-        console.log(response.result.items);
+      const results = gapi.client.youtube.search.list({
+        q: this.searchQuery,
+        part: "snippet",
+        type: "video"
+      }).then(function(response) {
+        console.info("Search results:", response.result.items);
         return response.result.items;
       });
-      return new Promise(function(resolve, reject){
+      return new Promise(function(resolve, reject) {
         results.then(resolve, reject);
       });
     }
@@ -47,8 +47,8 @@ var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   videoDrag: function(drag) {
     drag.ghost().addClass("ghost");
   },
-  getDragData: function(drag){
-	return can.data.get.call(drag.element[0], "dragData");
+  getDragData: function(drag) {
+    return can.domData.get(drag.element[0], "dragData");
   },
   dropPlaceholderData: "any",
   playlistVideos: {
@@ -73,7 +73,7 @@ var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
     }
   },
   get videosWithDropPlaceholder() {
-    var copy = this.playlistVideos.map(function(video) {
+    const copy = this.playlistVideos.map(function(video) {
       return {
         video: video,
         isPlaceholder: false
@@ -89,7 +89,9 @@ var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   }
 });
 
-var Sortable = can.Control.extend({
+can.addJQueryEvents(jQuery);
+
+const Sortable = can.Control.extend({
   "{element} dropinit": function() {
     this.droppedOn = false;
   },
@@ -106,16 +108,16 @@ var Sortable = can.Control.extend({
     }
   },
   fireEventForDropPosition: function(ev, drop, drag, eventName) {
-    var dragData = can.data.get.call(drag.element[0], "dragData");
+    const dragData = can.domData.get(drag.element[0], "dragData");
 
-    var sortables = $(this.element).children();
+    const sortables = $(this.element).children();
 
     for (var i = 0; i < sortables.length; i++) {
       //check if cursor is past 1/2 way
-      var sortable = $(sortables[i]);
+      const sortable = $(sortables[i]);
       if (ev.pageY < Math.floor(sortable.offset().top + sortable.height() / 2)) {
         // index at which it needs to be inserted before
-        $(this.element).trigger({
+        can.domEvents.dispatch(this.element, {
           type: eventName,
           index: i,
           dragData: dragData
@@ -124,13 +126,13 @@ var Sortable = can.Control.extend({
       }
     }
     if (!sortables.length) {
-      $(this.element).trigger({
+      can.domEvents.dispatch(this.element, {
         type: eventName,
         index: 0,
         dragData: dragData
       });
     } else {
-      $(this.element).trigger({
+      can.domEvents.dispatch(this.element, {
         type: eventName,
         index: i,
         dragData: dragData
@@ -143,7 +145,7 @@ can.view.callbacks.attr("sortable", function(el) {
   new Sortable(el);
 });
 
-var vm = new PlaylistVM();
-var template = can.stache.from("app-template");
-var fragment = template(vm);
+const vm = new PlaylistVM();
+const template = can.stache.from("app-template");
+const fragment = template(vm);
 document.body.appendChild(fragment);

--- a/docs/can-guides/commitment/recipes/playlist-editor/8-create-playlist.html
+++ b/docs/can-guides/commitment/recipes/playlist-editor/8-create-playlist.html
@@ -1,6 +1,6 @@
 <script id="app-template" type="text/stache">
   {{#if(googleApiLoadedPromise.isPending)}}
-    <div>Loading Google API ...</div>
+    <div>Loading Google API…</div>
   {{else}}
     {{#if(signedIn)}}
       Welcome {{givenName}}! <button on:click="googleAuth.signOut()">Sign Out</button>
@@ -9,22 +9,22 @@
     {{/if}}
 
     <div>
-      <input value:bind="searchQuery" placeholder="Search for videos"/>
+      <input value:bind="searchQuery" placeholder="Search for videos" />
     </div>
 
     {{#if(searchResultsPromise.isPending)}}
-      <div class="loading">Loading videos...</div>
+      <div class="loading">Loading videos…</div>
     {{/if}}
 
     {{#if(searchResultsPromise.isResolved)}}
       <ul class='source'>
       {{#each(searchResultsPromise.value)}}
-        <li on:draginit="videoDrag(%arguments[1])"
-            {{data "dragData"}}>
-          <a draggable="false" href="https://www.youtube.com/watch?v={{./id.videoId}}" target='_blank'>
-            <img draggable="false" src="{{./snippet.thumbnails.default.url}}" width="50px"/>
+        <li on:draginit="../videoDrag(scope.arguments[1])"
+            {{domData("dragData")}}>
+          <a draggable="false" href="https://www.youtube.com/watch?v={{id.videoId}}" target='_blank'>
+            <img draggable="false" src="{{snippet.thumbnails.default.url}}" width="50px" />
           </a>
-          {{./snippet.title}}
+          {{snippet.title}}
         </li>
       {{/each}}
       </ul>
@@ -32,17 +32,17 @@
       {{#if(searchResultsPromise.value.length)}}
         <div class='new-playlist'>
           <ul sortable
-            on:sortableplaceholderat="addDropPlaceholder(%event.index, %event.dragData)"
-            on:sortableinsertat="addVideo(%event.index, %event.dragData)"
+            on:sortableplaceholderat="addDropPlaceholder(scope.event.index, scope.event.dragData)"
+            on:sortableinsertat="addVideo(scope.event.index, scope.event.dragData)"
             on:dropout="clearDropPlaceholder()">
 
             {{#each(videosWithDropPlaceholder)}}
               <li class="{{#if(isPlaceholder)}}placeholder{{/if}}">
-                <a href="https://www.youtube.com/watch?v={{./video.id.videoId}}" target='_blank'>
-                  <img src="{{./video.snippet.thumbnails.default.url}}" width="50px"/>
+                <a href="https://www.youtube.com/watch?v={{video.id.videoId}}" target='_blank'>
+                  <img src="{{video.snippet.thumbnails.default.url}}" width="50px" />
                 </a>
 
-                {{./video.snippet.title}}
+                {{video.snippet.title}}
               </li>
             {{else}}
               <div class="content">Drag video here</div>

--- a/docs/can-guides/commitment/recipes/playlist-editor/8-create-playlist.js
+++ b/docs/can-guides/commitment/recipes/playlist-editor/8-create-playlist.js
@@ -1,6 +1,6 @@
-var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
+const PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   init: function() {
-    var self = this;
+    const self = this;
 
     self.on("googleAuth", function(ev, googleAuth) {
       self.signedIn = googleAuth.isSignedIn.get();
@@ -40,15 +40,15 @@ var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   get searchResultsPromise() {
     if (this.searchQuery.length > 2) {
 
-      var results = gapi.client.youtube.search.list({
-          q: this.searchQuery,
-          part: 'snippet',
-          type: 'video'
-        }).then(function(response){
-        console.log(response.result.items);
+      const results = gapi.client.youtube.search.list({
+        q: this.searchQuery,
+        part: "snippet",
+        type: "video"
+      }).then(function(response) {
+        console.info("Search results:", response.result.items);
         return response.result.items;
       });
-      return new Promise(function(resolve, reject){
+      return new Promise(function(resolve, reject) {
         results.then(resolve, reject);
       });
     }
@@ -56,8 +56,8 @@ var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   videoDrag: function(drag) {
     drag.ghost().addClass("ghost");
   },
-  getDragData: function(drag){
-	return can.data.get.call(drag.element[0], "dragData");
+  getDragData: function(drag) {
+    return can.domData.get(drag.element[0], "dragData");
   },
   dropPlaceholderData: "any",
   playlistVideos: {
@@ -82,7 +82,7 @@ var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
     }
   },
   get videosWithDropPlaceholder() {
-    var copy = this.playlistVideos.map(function(video) {
+    const copy = this.playlistVideos.map(function(video) {
       return {
         video: video,
         isPlaceholder: false
@@ -98,21 +98,21 @@ var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   },
   createPlaylistPromise: "any",
   createPlaylist: function() {
-    var playlistName = prompt("What would you like to name your playlist?");
+    const playlistName = prompt("What would you like to name your playlist?");
     if (!playlistName) {
       return;
     }
 
-    var playlistId;
-    var lastPromise = gapi.client.youtube.playlists.insert({
-      part: 'snippet,status',
+    let playlistId;
+    let lastPromise = gapi.client.youtube.playlists.insert({
+      part: "snippet,status",
       resource: {
         snippet: {
           title: playlistName,
-          description: 'A private playlist created with the YouTube API and CanJS'
+          description: "A private playlist created with the YouTube API and CanJS"
         },
         status: {
-          privacyStatus: 'private'
+          privacyStatus: "private"
         }
       }
     }).then(function(response) {
@@ -120,11 +120,11 @@ var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
     });
 
 
-    var playlistVideos = this.playlistVideos.slice();
+    const playlistVideos = this.playlistVideos.slice();
     playlistVideos.forEach(function(video) {
       lastPromise = lastPromise.then(function() {
         return gapi.client.youtube.playlistItems.insert({
-          part: 'snippet',
+          part: "snippet",
           resource: {
             snippet: {
               playlistId: playlistId,
@@ -141,7 +141,9 @@ var PlaylistVM = can.DefineMap.extend("PlaylistVM", {
   }
 });
 
-var Sortable = can.Control.extend({
+can.addJQueryEvents(jQuery);
+
+const Sortable = can.Control.extend({
   "{element} dropinit": function() {
     this.droppedOn = false;
   },
@@ -158,16 +160,16 @@ var Sortable = can.Control.extend({
     }
   },
   fireEventForDropPosition: function(ev, drop, drag, eventName) {
-    var dragData = can.data.get.call(drag.element[0], "dragData");
+    const dragData = can.domData.get(drag.element[0], "dragData");
 
-    var sortables = $(this.element).children();
+    const sortables = $(this.element).children();
 
     for (var i = 0; i < sortables.length; i++) {
       //check if cursor is past 1/2 way
-      var sortable = $(sortables[i]);
+      const sortable = $(sortables[i]);
       if (ev.pageY < Math.floor(sortable.offset().top + sortable.height() / 2)) {
         // index at which it needs to be inserted before
-        $(this.element).trigger({
+        can.domEvents.dispatch(this.element, {
           type: eventName,
           index: i,
           dragData: dragData
@@ -176,13 +178,13 @@ var Sortable = can.Control.extend({
       }
     }
     if (!sortables.length) {
-      $(this.element).trigger({
+      can.domEvents.dispatch(this.element, {
         type: eventName,
         index: 0,
         dragData: dragData
       });
     } else {
-      $(this.element).trigger({
+      can.domEvents.dispatch(this.element, {
         type: eventName,
         index: i,
         dragData: dragData
@@ -195,7 +197,7 @@ can.view.callbacks.attr("sortable", function(el) {
   new Sortable(el);
 });
 
-var vm = new PlaylistVM();
-var template = can.stache.from("app-template");
-var fragment = template(vm);
+const vm = new PlaylistVM();
+const template = can.stache.from("app-template");
+const fragment = template(vm);
 document.body.appendChild(fragment);

--- a/docs/can-guides/commitment/recipes/playlist-editor/playlist-editor.md
+++ b/docs/can-guides/commitment/recipes/playlist-editor/playlist-editor.md
@@ -1,17 +1,18 @@
 @page guides/recipes/playlist-editor Playlist Editor (Advanced)
 @parent guides/recipes
-@hide
 
-@description Learn how to use YouTube's API to search for videos and make a playlist.  This
-makes authenticated requests with OAuth2. It uses [https://jquerypp.com jQuery++] for
-drag/drop events. It shows using custom attributes and custom events. This guide takes
+@description Learn how to use YouTube’s API to search for videos and make a playlist.  This
+makes authenticated requests with OAuth2. It uses [jQuery++](https://jquerypp.com) for
+drag/drop events. It shows using custom attributes and custom events.  This guide takes
 an hour to complete.
 
 @body
 
 The final widget looks like:
 
-<a class="jsbin-embed" href="https://jsbin.com/meqowis/3/embed?output">JS Bin on jsbin.com</a>
+<a class="jsbin-embed" href="https://jsbin.com/lixorej/2/embed?output">
+  Finished CanJS Playlist Editor on jsbin.com
+</a>
 
 To use the widget:
 
@@ -24,7 +25,9 @@ To use the widget:
 
 __Start this tutorial by cloning the following JS Bin__:
 
-<a class="jsbin-embed" href="https://jsbin.com/ducabam/2/embed?html,output">JS Bin on jsbin.com</a>
+<a class="jsbin-embed" href="https://jsbin.com/fovireg/1/embed?html,js,output">
+  Starting CanJS Playlist Editor on jsbin.com
+</a>
 
 This JS Bin has initial prototype HTML and CSS which is useful for
 getting the application to look right.
@@ -39,20 +42,20 @@ The following video goes through this recipe:
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/0GLa33tdDTg" frameborder="0" allowfullscreen></iframe>
 
-## Setup CanJS and Load Google API
+## Set up CanJS and Load Google API
 
 ### The problem
 
 In this section, we will:
 
-1. Load Google's JS API client, `gapi`, and initialize it to make requests on behalf of
+1. Load Google’s JS API client, `gapi`, and initialize it to make requests on behalf of
    the registered "CanJS Playlist" app.
-2. Setup a basic CanJS application.
-3. Use the basic CanJS application to show when Google's JS API has finished loading.
+2. Set up a basic CanJS application.
+3. Use the basic CanJS application to show when Google’s JS API has finished loading.
 
 ### What you need to know
 
-- The preferred way of loading Google's JS API is with an `async` script tag like:
+- The preferred way of loading Google’s JS API is with an `async` script tag like:
 
   ```html
   <script async defer src="https://apis.google.com/js/api.js"
@@ -64,13 +67,13 @@ In this section, we will:
   The `async` attribute allows other JS to execute while the `api.js` file is loading.
   Once complete, this will call a `googleScriptLoaded` function.
 
-- Once `api.js` is loaded, it adds the   [gapi](https://developers.google.com/api-client-library/javascript/reference/referencedocs)
-  object to the window.  This is Google's JS API.  It can be used to load other APIs that extend the `gapi` library.
+- Once `api.js` is loaded, it adds the [gapi](https://developers.google.com/api-client-library/javascript/reference/referencedocs)
+  object to the window.  This is Google’s JS API.  It can be used to load other APIs that extend the `gapi` library.
 
   The following can be used to load the OAuth2 GAPI libraries:
 
   ```js
-  gapi.load('client:auth2', completeCallback);
+  gapi.load("client:auth2", completeCallback);
   ```
 
   Once this functionality is loaded, we can tell `gapi` to make requests on behalf of a registered
@@ -79,10 +82,10 @@ In this section, we will:
 
   ```js
   gapi.client.init({
-	  'apiKey': 'AIzaSyAbHbOuFtJRvTX731PQXGSTy59eh5rEiE0',
-      'clientId': '764983721035-85cbj35n0kmkmrba10f4jtte8fhpst84.apps.googleusercontent.com',
-      'discoveryDocs': [ 'https://www.googleapis.com/discovery/v1/apis/youtube/v3/rest' ],
-      'scope': 'https://www.googleapis.com/auth/youtube'
+	  apiKey: "AIzaSyAbHbOuFtJRvTX731PQXGSTy59eh5rEiE0",
+    clientId: "764983721035-85cbj35n0kmkmrba10f4jtte8fhpst84.apps.googleusercontent.com",
+    discoveryDocs: [ "https://www.googleapis.com/discovery/v1/apis/youtube/v3/rest" ],
+    scope: "https://www.googleapis.com/auth/youtube"
   }).then( completeCallback )
   ```
 
@@ -92,10 +95,10 @@ In this section, we will:
   asynchronous behavior. A promise can be created like:
 
   ```js
-  var messagePromise = new Promise(function(resolve, reject){
-    setTimeout(function(){
-		resolve("Hello There")
-	},1000)
+  const messagePromise = new Promise(function(resolve, reject) {
+    setTimeout(function() {
+      resolve("Hello There");
+    }, 1000);
   });
   ```
 
@@ -106,7 +109,7 @@ In this section, we will:
   Anyone can listen to when `messagePromise` resolves with a value like:
 
   ```js
-  messagePromise.then(function(messageValue){
+  messagePromise.then(function(messageValue) {
 	  messageValue //-> "Hello There"
   });
   ```
@@ -118,15 +121,15 @@ In this section, we will:
 - A [can-stache] template is used to render data into a document fragment:
 
   ```js
-  var template = can.stache("<h1>{{message}}</h1>");
-  var fragment = template({message: "Hello World"});
-  // fragment -> <h1>Hello World</h1>
+  const template = can.stache("<h1>{{message}}</h1>");
+  const fragment = template({message: "Hello World"});
+  fragment //-> <h1>Hello World</h1>
   ```
 
-- Load a template from a `<script>` tag with [can-stach.from can.stache.from] like:
+- Load a template from a `<script>` tag with [can-stache.from can.stache.from] like:
 
   ```js
-  var template = can.stache.from(SCRIPT_ID);
+  const template = can.stache.from(SCRIPT_ID);
   ```  
 
 - Use [can-stache.helpers.if {{#if(value)}}] to do `if/else` branching in `can-stache`.
@@ -138,7 +141,7 @@ In this section, we will:
 - [can-define/map/map can.DefineMap] can be used to define the behavior of observable objects like:
 
   ```js
-  var Type = can.DefineMap.extend({
+  const Type = can.DefineMap.extend({
 	  message: "string"
   });
   ```
@@ -148,17 +151,17 @@ In this section, we will:
   [can-component]).
 
   ```js
-  var PlaylistVM = can.DefineMap.extend({
+  const PlaylistVM = can.DefineMap.extend({
 	  message: "string"
   });
 
-  var messageVM = new PlaylistVM();
-  var fragment = template(messageVM)
+  const messageVM = new PlaylistVM();
+  const fragment = template(messageVM)
   ```
 
 - `can.DefineMap` can specify a default value and a type:
   ```js
-  var PlaylistVM = can.DefineMap.extend({
+  const PlaylistVM = can.DefineMap.extend({
     count: {default: 33}
   });
   new PlaylistVM().count //-> 33
@@ -167,11 +170,13 @@ In this section, we will:
 
 ### The solution
 
-Update the __HTML__ tab to:
+Update the __HTML__ tab by deleting everything inside the `<body>` and replacing
+it with:
 
-> Note: Please use your own `clientId` if you use this code outside this guide.
+> **Note:** use your own `clientId` if you use this code outside this guide and JS Bin.
 
 @sourceref ./1-setup.html
+@highlight 10-40,only
 
 Update the __JavaScript__ tab to:
 
@@ -189,9 +194,9 @@ In this section, we will:
 
 1. Show a `Sign In` button that signs a person into their google account.
 2. Show a `Sign Out` button that signs a person out of their google account.
-3. Automatically know via google's API when the user signs in and out, and update the
+3. Automatically know via google’s API when the user signs in and out, and update the
    page accordingly.
-4. Show a welcome message with the user's given name.
+4. Show a welcome message with the user’s given name.
 
 ### What you need to know
 
@@ -200,8 +205,8 @@ In this section, we will:
   can be retrieved like:
 
   ```js
-  googleApiLoadedPromise.then(function(){
-	  var googleAuth = gapi.auth2.getAuthInstance()
+  googleApiLoadedPromise.then(function() {
+	  const googleAuth = gapi.auth2.getAuthInstance()
   });
   ```
 
@@ -210,8 +215,8 @@ In this section, we will:
   - Know if someone is signed in: `googleAuth.isSignedIn.get()`
   - Sign someone in: `googleAuth.signIn()`
   - Sign someone out: `googleAuth.signOut()`
-  - Listen to when someone's signedIn status changes: `googleAuth.isSignedIn.listen(callback)`
-  - Get the user's name: `googleAuth.currentUser.get().getBasicProfile().getGivenName()`
+  - Listen to when someone’s signedIn status changes: `googleAuth.isSignedIn.listen(callback)`
+  - Get the user’s name: `googleAuth.currentUser.get().getBasicProfile().getGivenName()`
 
 
 
@@ -223,7 +228,7 @@ In this section, we will:
   ```js
   DefineMap.extend({
     signedIn: "boolean",
-    get signedOut(){
+    get signedOut() {
       return !this.signedIn;
     }
   });
@@ -232,10 +237,10 @@ In this section, we will:
 - Use [can-define.types.get asynchronous getters] to get data from asynchronous sources.  For example:
 
   ```js
-  var PlaylistVM = can.DefineMap.extend({
+  const PlaylistVM = can.DefineMap.extend({
     property: {
       get: function(lastSet, resolve) {
-        apiLoadedPromise.then(function(){
+        apiLoadedPromise.then(function() {
 			resolve( api.getValue() );
 		})
       }
@@ -243,27 +248,27 @@ In this section, we will:
   });
   ```
 
-- DefineMap's `init` method can be used to perform initialization behavior.  For example,
+- DefineMap’s `init` method can be used to perform initialization behavior.  For example,
   the following might initialize `googleApiLoadedPromise`:
 
   ```js
   DefineMap.extend({
-	  init: function(){
+	  init: function() {
 		  this.googleApiLoadedPromise = googleApiLoadedPromise;
 	  },
 	  googleApiLoadedPromise: "any"
   })
   ```
 
-- `DefineMap`'s [can-event-queue/map/map.on] lets you listen on changes in a DefineMap.
+- `DefineMap`’s [can-event-queue/map/map.on] lets you listen on changes in a DefineMap.
   This can be used to change values when other values change.  The following will increment
   `nameChange` everytime the `name` property changes:
 
   ```js
   DefineMap.extend({
-	  init: function(){
-		  var self = this;
-		  self.on("name", function(){
+	  init: function() {
+		  const self = this;
+		  self.on("name", function() {
 		      self.nameChange++;	  
 		  })
 	  },
@@ -277,7 +282,7 @@ In this section, we will:
 - Use [can-stache-bindings.event on:EVENT] to listen to an event on an element and call a method in `can-stache`.  For example, the following calls `sayHi()` when the `<div>` is clicked.
 
    ```html
-   <div on:click="sayHi()"> … </div>
+   <div on:click="sayHi()"> <!-- ... --> </div>
    ```
 
 ### The solution
@@ -307,20 +312,20 @@ In this section, we will:
 
 ### What you need to know
 
-- Use [can-stache-bindings.twoWay value:bind] to setup a two-way binding in `can-stache`.  For example, the following keeps `searchQuery` and the input's `value` in sync:
+- Use [can-stache-bindings.twoWay value:bind] to setup a two-way binding in `can-stache`.  For example, the following keeps `searchQuery` and the input’s `value` in sync:
 
    ```html
-   <input value:bind="searchQuery"/>
+   <input value:bind="searchQuery" />
    ```
 
 - Use `gapi.client.youtube.search.list` to search YouTube like:
 
   ```js
-  var googlePromise = gapi.client.youtube.search.list({
+  const googlePromise = gapi.client.youtube.search.list({
     q: "dogs",
-    part: 'snippet',
-    type: 'video'
-  }).then(function(response){
+    part: "snippet",
+    type: "video"
+  }).then(function(response) {
     response //-> {
 	// result: {
 	//   items: [
@@ -340,7 +345,7 @@ In this section, we will:
 - To convert a `googlePromise` to a native `Promise` use:
 
   ```js
-  new Promise(function(resolve, reject){
+  new Promise(function(resolve, reject) {
     googlePromise.then(resolve, reject);	  
   })
   ```
@@ -382,7 +387,7 @@ In this section, we will:
   You can bind on them manually with jQuery like:
 
   ```js
-  $(element).on('draginit', function(ev, drag) {
+  $(element).on("draginit", function(ev, drag) {
     drag.limit($(this).parent());
     drag.horizontal();
   });
@@ -392,7 +397,14 @@ In this section, we will:
   `drag` events in [can-stache] and pass the `drag` argument to a function like:
 
   ```html
-  on:draginit="startedDrag(%arguments[1])"
+  on:draginit="startedDrag(scope.arguments[1])"
+  ```
+
+- You can use [can-dom-events/helpers/add-jquery-events can.addJQueryEvents()]
+  to listen to custom jQuery events (such as jQuery++’s `draginit` above):
+
+  ```js
+  can.addJQueryEvents(jQuery);
   ```
 
 - The `drag.ghost()` method copies the elements being dragged and drags that
@@ -408,12 +420,13 @@ In this section, we will:
 
   ```js
   PlaylistVM = DefineMap.extend({
-	startedDrag: function(){
-	  console.log("you did it!")
-	}
+  	startedDrag: function() {
+  	  console.log("you did it!")
+  	}
   });
   new PlaylistVM().startedDrag();
   ```
+
 - Certain browsers have default drag behaviors for certain elements like `<a>` and `<img>`
 	that can be prevented with the `draggable="false"` attribute.
 
@@ -431,6 +444,7 @@ Update the __JavaScript__ tab to:
 
 
 ## Drop videos
+
 ### The problem
 
 In this section, we will:
@@ -439,7 +453,7 @@ In this section, we will:
 2. When the user drags a video over the playlist element, a placeholder of the
    video will appear in the first position of the playlist.
 3. If the video is dragged out of the playlist element, the placeholder will be removed.
-4. If the video is dropped on the playlist element, it will be added to the playlist's
+4. If the video is dropped on the playlist element, it will be added to the playlist’s
    list of videos.
 5. Prepare for inserting the placeholder or video in any position in the list.
 
@@ -452,8 +466,8 @@ In this section, we will:
 
   ```js
   PlaylistVM = DefineMap.extend({
-      ...
-      // {video: video, index: 0}
+    // ...
+    // {video: video, index: 0}
 	  dropPlaceholderData: "any",
 	  // [video1, video2, ...]
 	  playlistVideos: {
@@ -461,11 +475,11 @@ In this section, we will:
 	     Default: can.DefineList
 	  },
 	  get videosWithDropPlaceholder() {
-         var copyOfPlaylistVideos = this.placeListVideos.map(...);
+      const copyOfPlaylistVideos = this.placeListVideos.map( /* ... */ );
 
-         // insert this.dropPlaceholderData into copyOfPlaylistVideos
+      // insert this.dropPlaceholderData into copyOfPlaylistVideos
 
-		 return copyOfPlaylistVideos;
+      return copyOfPlaylistVideos;
 	  }
   })
   ```
@@ -474,8 +488,8 @@ In this section, we will:
   add video to the playlist (`addVideo`) should take an index like:
 
   ```js
-  addDropPlaceholder: function(index, video) { ... }
-  addVideo: function(index, video) { ... }
+  addDropPlaceholder: function(index, video) { /* ... */ }
+  addVideo: function(index, video) { /* ... */ }
   ```
 
   These functions will be called with `0` as the index for this section.  
@@ -492,14 +506,14 @@ In this section, we will:
   You can bind on them manually with jQuery like:
 
   ```js
-  $(element).on('dropon', function(ev, drop, drag) {...});
+  $(element).on("dropon", function(ev, drop, drag) { /* ... */ });
   ```
 
   Notice that `drop` is now the 2nd argument to the event.  You can listen to
   `drop` events in [can-stache], and pass the `drag` argument to a function, like:
 
   ```html
-  on:dropon="addVideo(%arguments[2])"
+  on:dropon="addVideo(scope.arguments[2])"
   ```
 
 - You will need to associate the drag objects with the video being dragged so
@@ -509,18 +523,19 @@ In this section, we will:
   - The `drag.element` is the jQuery-wrapped element that the user initiated the
     drag motion upon.
 
-  - CanJS's `{{data DATANAME}}` helper lets you associate custom data with an element. The following
+  - CanJS’s [can-stache.helpers.domData {{domData("DATANAME")}}] helper lets you
+    associate custom data with an element. The following
     saves the current `context` of the `<li>` as `"dragData"` on the `<li>`:
 
-    ```
-    <li ($draginit)="videoDrag(%arguments[1])"
-              {{data "dragData"}}>
+    ```html
+    <li on:draginit="../videoDrag(scope.arguments[1])"
+              {{domData("dragData")}}>
     ```
 
-  - [can-util/dom/data/data.get can.data.get] can access this data like:
+  - [can-dom-data.get can.domData.get] can access this data like:
 
     ```js
-    can.data.get.call(drag.element[0], "dragData");
+    can.domData.get(drag.element[0], "dragData");
     ```
 
 ### The solution
@@ -533,7 +548,7 @@ Update the template in the __HTML__ tab to:
 Update the __JavaScript__ tab to:
 
 @sourceref ./5-drop.js
-@highlight 50-89,only
+@highlight 50-89,92,only
 
 
 
@@ -548,12 +563,12 @@ In this section, we will:
 
 - ViewModels are best left knowing very little about the DOM. This makes them more
   easily unit-testable.  To make this interaction, we need to know where the mouse
-  is in relation to the playlist's videos.  This requires a lot of DOM interaction
+  is in relation to the playlist’s videos.  This requires a lot of DOM interaction
   and is best done outside the ViewModel.
 
-  Specifically, we'd like to translate the `dropmove` and `dropon` events
+  Specifically, we’d like to translate the `dropmove` and `dropon` events
   into other events that let people know where the `dropmove` and `dropon` events
-  are happening in relationship to the __drop target__'s child elements.
+  are happening in relationship to the __drop target__’s child elements.
 
   Our goal is to:
 
@@ -569,8 +584,8 @@ In this section, we will:
   way.  Use [can-control.extend] to define a `can.Control` type, as follows:
 
   ```js
-  var Sortable = can.Control.extend({
-	  ... event handlers and methods ...
+  const Sortable = can.Control.extend({
+	  // Event handlers and methods
   });
   ```
 
@@ -578,14 +593,14 @@ In this section, we will:
   as follows:
 
   ```js
-  var Sortable = can.Control.extend({
-	"{element} dropmove": function(el, ev, drop, drag) {
+  const Sortable = can.Control.extend({
+    "{element} dropmove": function(el, ev, drop, drag) {
       // do stuff on dropmove like call method:
       this.method();
     },
-	method: function(){
-	  // do something
-	}
+    method: function() {
+      // do something
+    }
   });
   ```
 
@@ -606,7 +621,9 @@ In this section, we will:
   This can be useful to create controls on an element with that attribute.  For example, if a user has:
 
   ```html
-  <ul sortable>...</ul>
+  <ul sortable>
+    <!-- ... -->
+  </ul>
   ```
 
   The following will create the `Sortable` control on that `<ul>`:
@@ -617,28 +634,28 @@ In this section, we will:
   });
   ```
 
-- Use [$.trigger](https://api.jquery.com/trigger/) to fire custom events with jQuery:
+- Use [can-dom-events.dispatch can.domEvents.dispatch] to fire custom events:
 
   ```js
-  $(element).trigger({
+  can.domEvents.dispatch(element, {
     type: "sortableinsertat",
     index: 0,
     dragData: dragData
   });
   ```
 
-- Access the event object in a [can-stache-bindings.event] with `%event`, like:
+- Access the event object in a [can-stache-bindings.event] with `scope.event`, like:
 
   ```html
-  on:sortableinsertat="addVideo(%event.index, %event.dragData)"
+  on:sortableinsertat="addVideo(scope.event.index, scope.event.dragData)"
   ```
 
 - Mouse events like `click` and `dropmove` and `dropon` have a `pageY` property that
-  tells how many pixels down the page a user's mouse is.
-- [jQuery.offset](https://api.jquery.com/offset/) returns an element's position on the page.
-- [jQuery.height](https://api.jquery.com/height/) returns an element's height.
-- If the mouse position is below an element's center, the placeholder should be inserted
-  after the element.  If the mouse position is above an element's center, it should be inserted
+  tells how many pixels down the page a user’s mouse is.
+- [jQuery.offset](https://api.jquery.com/offset/) returns an element’s position on the page.
+- [jQuery.height](https://api.jquery.com/height/) returns an element’s height.
+- If the mouse position is below an element’s center, the placeholder should be inserted
+  after the element.  If the mouse position is above an element’s center, it should be inserted
   before the element.
 
 ### The solution
@@ -651,7 +668,7 @@ Update the template in the __HTML__ tab to:
 Update the __JavaScript__ tab to:
 
 @sourceref ./6-order.js
-@highlight 92-135,only
+@highlight 94-137,only
 
 
 
@@ -674,7 +691,7 @@ In this section, we will:
 Update the __JavaScript__ tab to:
 
 @sourceref ./7-revert.js
-@highlight 93-95,100,103-107,only
+@highlight 95-97,102,105-109,only
 
 
 
@@ -697,22 +714,22 @@ In this section, we will:
   To create a playlist:
 
   ```js
-  var lastPromise = gapi.client.youtube.playlists.insert({
-	part: 'snippet,status',
-	resource: {
-	  snippet: {
-		title: PLAYLIST_NAME,
-		description: 'A private playlist created with the YouTube API and CanJS'
-	  },
-	  status: {
-		privacyStatus: 'private'
-	  }
-	}
+  let lastPromise = gapi.client.youtube.playlists.insert({
+    part: "snippet,status",
+    resource: {
+      snippet: {
+        title: PLAYLIST_NAME,
+        description: "A private playlist created with the YouTube API and CanJS"
+      },
+      status: {
+        privacyStatus: "private"
+      }
+    }
   }).then(function(response) {
-	response //->{} response.result.id
-	// result: {
-	//   id: "lk2asf8o"
-	// }
+    response //->{} response.result.id
+    // result: {
+    //   id: "lk2asf8o"
+    // }
   });
   ```
 
@@ -720,7 +737,7 @@ In this section, we will:
 
   ```js
   gapi.client.youtube.playlistItems.insert({
-    part: 'snippet',
+    part: "snippet",
     resource: {
       snippet: {
         playlistId: playlistId,
@@ -735,13 +752,13 @@ In this section, we will:
   ```js
   lastPromise = makeRequest(1);
 
-  lastPromise = lastPromise.then(function(){
+  lastPromise = lastPromise.then(function() {
     return makeRequest(2);	  
-  })
+  });
 
-  lastPromise = lastPromise.then(function(){
+  lastPromise = lastPromise.then(function() {
     return makeRequest(3);	  
-  })
+  });
   ```
 
   When a callback to `.then` returns a promise, `.then` returns a promise that resolves
@@ -750,14 +767,14 @@ In this section, we will:
 - Use [can-stache-bindings.toChild {$disabled}] to make an input disabled, like:
 
   ```html
-  <button disabled:from="createPlaylistPromise.isPending()">...
+  <button disabled:from="createPlaylistPromise.isPending()">
   ```
 
 - When the promise has finished, set the `playlistVideos` property back to an empty list. This
   can be done by listening to `createPlaylistPromise`:
 
   ```js
-  this.on("createPlaylistPromise", function(ev, promise) { ... })
+  this.on("createPlaylistPromise", function(ev, promise) { /* ... */ })
   ```
 
 ### The solution
@@ -772,6 +789,14 @@ Update the __JavaScript__ tab to:
 @sourceref ./8-create-playlist.js
 @highlight 12-19,99-141,only
 
+## Result
+
 Congrats! _You now have your very own YouTube Playlist Editor_.
 
-<script src="https://static.jsbin.com/js/embed.min.js?4.0.4"></script>
+When finished, you should see something like the following JS Bin:
+
+<a class="jsbin-embed" href="https://jsbin.com/lixorej/2/embed?output">
+  Finished CanJS Playlist Editor on jsbin.com
+</a>
+
+<script src="https://static.jsbin.com/js/embed.min.js?4.1.4"></script>


### PR DESCRIPTION
- Use can-dom-data with the {{domData}} helper
- Use can-dom-events/helpers/add-jquery-events to listen for jQuery events from jQuery++
- Other various changes for CanJS 4
- Update the JS Bins—they will work when CanJS 4.2 is released

Here’s a gif of the JS Bin working when pointed at a local build of can 4.2:
![working playlist editor](https://user-images.githubusercontent.com/10070176/38220320-720101a0-368e-11e8-9e12-f9f6ad89ebe3.gif)
