### PR TITLE
Adds the can/es module for tree-shaking bundlers

### DIFF
--- a/docs/can-guides/experiment/advanced-setting-up.md
+++ b/docs/can-guides/experiment/advanced-setting-up.md
@@ -1,0 +1,48 @@
+@page guides/advanced-setup Experimental ES Module Usage
+@parent guides/getting-started 4
+@outline 2
+
+@description Use [ES modules](http://exploringjs.com/es6/ch_modules.html)' *named exports* feature to import just the APIs of CanJS that you are using.
+
+@body
+
+CanJS provides an ES module that contains [named exports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export#Using_named_exports) which can be imported and used to pluck out the parts that you need. When used in conjunction with [tree shaking](http://exploringjs.com/es6/ch_modules.html#_benefit-dead-code-elimination-during-bundling) you gain:
+
+* Fewer packages to import in each of your modules.
+* Bundles that exclude all of the parts of CanJS that you don't use.
+
+To use, import the `can/es` module like so:
+
+```js
+import { Component, DefineMap } from "can/es";
+
+const ViewModel = DefineMap.extend({
+	message: "string"
+});
+
+Component.extend({
+	tag: "my-component",
+	ViewModel
+});
+```
+
+If you are using [webpack](https://webpack.js.org/guides/tree-shaking/#src/components/Sidebar/Sidebar.jsx) tree-shaking is only available when in production mode. The following config shows a typical setup:
+
+__webpack.config.js__
+
+```js
+const path = require('path');
+
+module.exports = {
+  entry: './index.js',
+  mode: 'production',
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname)
+  }
+};
+```
+
+## Names
+
+The names that can be exported by this module mirror what is part of the `can` namespace object that you get from `import can from "can"`. You can see the names that `can/es` exports [here](https://github.com/canjs/canjs/blob/master/es.js).

--- a/docs/can-guides/experiment/advanced-setting-up.md
+++ b/docs/can-guides/experiment/advanced-setting-up.md
@@ -45,4 +45,4 @@ module.exports = {
 
 ## Names
 
-The names that can be exported by this module mirror what is part of the `can` namespace object that you get from `import can from "can"`. You can see the names that `can/es` exports [here](https://github.com/canjs/canjs/blob/master/es.js).
+The names that can be imported from this module mirror what is part of the `can` namespace object that you get from `import can from "can"`. You can see the names that `can/es` exports [here](https://github.com/canjs/canjs/blob/master/es.js).

--- a/docs/can-guides/experiment/setting-up-canjs.md
+++ b/docs/can-guides/experiment/setting-up-canjs.md
@@ -162,6 +162,8 @@ Finally, create a page that loads `dist/bundle.js`:
 </html>
 ```
 
+Optionally you can use the `can` package, allowing [tree shaking](https://developer.mozilla.org/en-US/docs/Glossary/Tree_shaking). See the [guides/advanced-setup experimental guide] for how to do that.
+
 ## Browserify and npm
 
 > Get started with CanJS and [Browserify](http://browserify.org) by [cloning this example repo on GitHub](https://github.com/canjs/browserify-example).

--- a/es.js
+++ b/es.js
@@ -1,0 +1,25 @@
+import "can-stache-bindings";
+import "can-stache-route-helpers";
+
+// Core
+export { default as assign } from "can-assign";
+export { default as Component } from 'can-component';
+export { default as connect } from "can-connect/all";
+export { default as define } from "can-define";
+export { default as DefineMap } from "can-define/map/map";
+export { default as DefineList } from "can-define/list/list";
+export { default as route } from "can-route";
+export { default as set } from "can-set";
+export { default as SimpleObservable } from "can-simple-observable";
+export { default as stache } from "can-stache";
+export { default as encoder } from "can-attribute-encoder";
+export { default as ajax } from "can-ajax";
+export { default as globals } from "can-globals";
+export { default as Reflect } from "can-reflect";
+export { default as defineLazyValue } from "can-define-lazy-value";
+export { default as domEvents } from "can-dom-events";
+export { default as radioChange } from "can-event-dom-radiochange";
+export { default as makeInterfaceValidator } from "can-validate-interface";
+export { default as viewModel } from "can-view-model";
+
+// Ecosystem?

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
       "url": "http://opensource.org/licenses/mit-license.php"
     }
   ],
+  "sideEffects": false,
   "steal": {
     "npmAlgorithm": "flat",
     "main": "can",


### PR DESCRIPTION
This change adds a new module, `can/es` which exports everything from
__core__ as named exports. This enables people to import only the parts
of CanJS they need:

```js
import { Component, DefineMap } from "can/es";
```

Provided they use a tree-shaking capable bundler, the bundle size will
not be too large.

Closes #4013