### PR TITLE
Improve the Setting Up CanJS page

### DIFF
--- a/docs/can-guides/experiment/setting-up-canjs.md
+++ b/docs/can-guides/experiment/setting-up-canjs.md
@@ -10,248 +10,357 @@ You can download CanJS from npm or a CDN. We recommend using npm. If you don’t
 
 Once downloaded or installed, you can load CanJS in a variety of ways:
 
- - StealJS
- - Browserify
- - `<script>` tags
+- [StealJS](#StealJS)
+- [webpack](#webpack)
+- [Browserify](#Browserify)
+- [`<script>` tags](#Scripttags)
 
-This guide shows how to setup common combinations.  If you don’t see yours, please
+This guide shows how to set up common combinations.  If you don’t see yours, please
 ask on the [forums](https://forums.donejs.com/c/canjs) or [Gitter chat](https://gitter.im/canjs/canjs).
 
 ## JS Bin
 
 Use this JS Bin to play around with CanJS:
 
-<a class="jsbin-embed" href="https://jsbin.com/lewaqih/3/embed?html,js,output">CanJS on jsbin.com</a>
+<a class="jsbin-embed" href="https://bitovi-jsbin.jsbin.com/safigic/23/edit?html,js,output">CanJS on jsbin.com</a>
 <script src="https://static.jsbin.com/js/embed.min.js?4.0.4"></script>
 
 It uses `can.all.js` so you have the [can-core core], [can-ecosystem ecosystem], and [can-infrastructure infrastructure] modules available to you.
 
-## StealJS and npm
+## npm
 
-> Get started with CanJS and [StealJS](https://stealjs.com) by [cloning this example repo on GitHub](https://github.com/canjs/stealjs-example).
+> Want to skip setting up a new project locally and just clone a repo? Check out
+> our example repos for [StealJS](https://github.com/canjs/stealjs-example),
+> [webpack](https://github.com/canjs/webpack-example), and
+> [Browserify](https://github.com/canjs/browserify-example).
 
-Install [can-core CanJS’s core modules] and StealJS with npm:
+First, [go through npm’s guide to installing Node.js and npm](https://docs.npmjs.com/getting-started/installing-node).
+If you’re new to development, that page has [additional resources](https://docs.npmjs.com/getting-started/installing-node#learn-more)
+for learning about Node.js, npm, using a command-line terminal, and more.
+
+Next, create a new directory on your computer and navigate to that directory in
+your terminal.
+
+In your terminal, [create a new package.json](https://docs.npmjs.com/cli/init):
 
 ```
-npm install can-component can-connect can-define can-route can-route-pushstate can-set can-stache can-stache-bindings --save
+npm init -y
+```
+
+Next, install [can-component] (that’s CanJS’s main package) and
+[http-server](https://www.npmjs.com/package/http-server)
+(so you can load the files we create):
+
+```
+npm install can-component --save
+npm install http-server --save-dev
+```
+
+Next, add a [start script](https://docs.npmjs.com/cli/start) to run the
+HTTP server. Add the following line to your `package.json`:
+
+```
+{
+  "name": "my-canjs-app",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "http-server -c-1",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "can-component": "^4.0.0"
+  },
+  "devDependencies": {
+    "http-server": "^0.11.0"
+  }
+}
+```
+@highlight 7,only
+
+Last, start the HTTP server from your terminal:
+
+```
+npm start
+```
+
+When the server starts, it’ll tell you the addresses you can open in your
+browser to see your project. They will be similar to [http://localhost:8080/].
+
+Next, you can choose to use [StealJS](#StealJS), [webpack](#webpack), or
+[Browserify](#Browserify) to load your project.
+
+### StealJS
+
+> You can skip these instructions by
+> [cloning this example repo on GitHub](https://github.com/canjs/stealjs-example).
+
+Install [StealJS](https://stealjs.com) and the [steal-stache] plugin from npm:
+
+```
 npm install steal steal-stache --save
 ```
 
-Next, add the following [configuration](https://stealjs.com/docs/StealJS.configuration.html) to your `package.json`:
+Next, add the following [steal configuration](https://stealjs.com/docs/StealJS.configuration.html)
+to your `package.json`:
 
 ```
 {
-    ...
-    "steal": {
-    ...
-        "plugins": [
-            "steal-stache"
-        ]
-    }
+  "name": "my-canjs-app",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "http-server -c-1",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "steal": {
+    "plugins": ["steal-stache"]
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "can-component": "^4.0.0",
+    "steal": "^1.11.0",
+    "steal-stache": "^4.1.0"
+  },
+  "devDependencies": {
+    "http-server": "^0.11.0"
+  }
 }
 ```
+@highlight 10-12,only
 
-Next, create a `main.stache` template for your app:
+Next, create an `app.stache` template for your app:
 
 ```html
-<!-- main.stache -->
+{{! app.stache }}
 <h1>{{message}}</h1>
 ```
 
-Next, create a `main` module for your application. Import [can-define/map/map] and your template to say “Hello World”:
+Next, create an `index.js` module for your application. Import [can-component] and
+your template to say “Hello World”:
 
 ```js
-// main.js
-import DefineMap from "can-define/map/map";
-import template from "./main.stache!";
+// index.js
+import Component from "can-component";
+import template from "./app.stache";
 
-const data = new DefineMap({message: "Hello World"});
-
-document.body.appendChild(template(data));
+Component.extend({
+  tag: "my-app",
+  view: template,
+  ViewModel: {
+    message: {
+      default: "Hello World"
+    }
+  }
+});
 ```
 
-Finally, create a page that loads `steal.js` and specifies `main` as the main module:
+Finally, create an `index.html` page that loads `steal.js` and includes your
+`<my-app>` component:
 
 ```html
-<html>
-  <body>
-    <script src="./node_modules/steal/steal.js" data-main="main"></script>
-  </body>
-</html>
+<!doctype html>
+<title>CanJS and StealJS</title>
+<script src="./node_modules/steal/steal.js"></script>
+<my-app></my-app>
 ```
+@highlight 3-4
 
-StealJS supports “modlet” module names that end with `/`.  This means that the above could
-also be written like:
+Now you can load that page in your browser at one of the addresses the HTTP
+server showed you earlier (something like [http://localhost:8080/]). You should
+see “Hello World” on the page—if you don’t, join our
+[Gitter chat](https://gitter.im/canjs/canjs) and we can help you figure out what
+went wrong.
 
-```js
-// main.js
-import DefineMap from "can-define/map/";
-import template from "./main.stache!";
+Ready to build an app with CanJS? Check out our [guides/chat] or one of our
+[guides/recipes]!
 
-const data = new DefineMap({message: "Hello World"});
+### webpack
 
-document.body.appendChild(template(data));
-```
-@highlight 2-2
+> You can skip these instructions by
+> [cloning this example repo on GitHub](https://github.com/canjs/webpack-example).
 
-Besides ES6 modules, StealJS supports AMD and CommonJS.  You could also write `main.js` like:
-
-```js
-// main.js
-import DefineMap from "can-define/map/map";
-import template from "./main.stache!";
-
-const data = new DefineMap({message: "Hello World"});
-
-document.body.appendChild(template(data));
-```
-@highlight 2-3
-
-__Note:__ if you see dozens of errors in your console, you may need to set `system.npmAlgorithm` to `flat` in your `package.json` (see the [Steal docs](https://stealjs.com/docs/StealJS.quick-start.html#section_Setup) for more info).
-
-### Building for production
-
-StealJS’s [Moving to Production](https://stealjs.com/docs/StealJS.moving-to-prod.html)
-guide has instructions for how to create a production build.
-
-## webpack and npm
-
-> Get started with CanJS and [webpack](https://webpack.js.org) by [cloning this example repo on GitHub](https://github.com/canjs/webpack-example).
-
-Install [can-core CanJS’s core modules] and webpack (with `raw-loader`) with npm:
+First, install [webpack](https://webpack.js.org)
+(with [raw-loader](https://www.npmjs.com/package/raw-loader)) from npm:
 
 ```
-npm install can-component can-connect can-define can-route can-route-pushstate can-set can-stache can-stache-bindings --save
-npm install webpack raw-loader --save-dev
+npm install webpack webpack-cli raw-loader --save-dev
 ```
 
-Next, create a `main.stache` template for your app:
+Next, create an `app.stache` template for your app:
 
 ```html
-<!-- main.stache -->
+{{! app.stache }}
 <h1>{{message}}</h1>
 ```
 
-Next, create a `main` module for your application. Import [can-define/map/map], [can-stache], and your template to say “Hello World”:
+Next, create an `index.js` module for your application. Import [can-component]
+and your template to say “Hello World”:
 
 ```js
-// main.js
-import DefineMap from 'can-define/map/map';
-import stache from 'can-stache';
-import rawTemplate from 'raw-loader!./main.stache';
+// index.js
+import Component from "can-component";
+import template from "raw-loader!./app.stache";
 
-const data = new DefineMap({message: "Hello World"});
-const template = stache(rawTemplate);
-
-document.body.appendChild(template(data));
+Component.extend({
+  tag: "my-app",
+  view: template,
+  ViewModel: {
+    message: {
+      default: "Hello World"
+    }
+  }
+});
 ```
 
-Next, run webpack from the command line:
+Next, run webpack from your terminal:
 
 ```
-./node_modules/webpack/bin/webpack.js -d main.js -o dist/bundle.js
+./node_modules/webpack/bin/webpack.js -d index.js -o dist/bundle.js
 ```
 
-Finally, create a page that loads `dist/bundle.js`:
+Finally, create an `index.html` page that loads `dist/bundle.js` and includes
+your `<my-app>` component:
 
 ```html
-<html>
-  <body>
-    <script src="./dist/bundle.js" type="text/javascript"></script>
-  </body>
-</html>
+<!doctype html>
+<title>CanJS and webpack</title>
+<script src="./dist/bundle.js" type="text/javascript"></script>
+<my-app></my-app>
 ```
+@highlight 3-4
 
-Optionally you can use the `can` package, allowing [tree shaking](https://developer.mozilla.org/en-US/docs/Glossary/Tree_shaking). See the [guides/advanced-setup experimental guide] for how to do that.
+Now you can load that page in your browser at one of the addresses the HTTP
+server showed you earlier (something like [http://localhost:8080/]). You should
+see “Hello World” on the page—if you don’t, join our
+[Gitter chat](https://gitter.im/canjs/canjs) and we can help you figure out what
+went wrong.
 
-## Browserify and npm
+Ready to build an app with CanJS? Check out our [guides/chat] or one of our
+[guides/recipes]!
 
-> Get started with CanJS and [Browserify](http://browserify.org) by [cloning this example repo on GitHub](https://github.com/canjs/browserify-example).
+> The instructions above show using [can-component]. As of [can@4.2](https://github.com/canjs/canjs/releases/tag/v4.2.0),
+> you can use the `can` package with [tree shaking](https://developer.mozilla.org/en-US/docs/Glossary/Tree_shaking)
+> to `import {Component} from "can"`. See the [guides/advanced-setup experimental guide]
+> for more information.
 
-CanJS works with Browserify. Install [can-core CanJS’s core modules] and Browserify (with `babelify` and `stringify`) with npm:
+### Browserify
+
+> You can skip these instructions by
+> [cloning this example repo on GitHub](https://github.com/canjs/browserify-example).
+
+CanJS works with [Browserify](http://browserify.org). Install [can-component]
+and Browserify (with various plugins) from npm:
 
 ```
-npm install can-component can-connect can-define can-route can-route-pushstate can-set can-stache can-stache-bindings --save
 npm install browserify stringify babelify babel-core babel-preset-env --save-dev
 ```
 
-Next, create a `main.stache` template for your app:
-
-```html
-<!-- main.stache -->
-<h1>{{message}}</h1>
-```
-
-Next, create a `main.js` file for your application. Import [can-define/map/map], [can-stache], and your template to say “Hello World”:
-
-```js
-// main.js
-import DefineMap from "can-define/map/map";
-import stache from "can-stache";
-import rawTemplate from "./main.stache";
-
-const data = new DefineMap({message: "Hello World"});
-const template = stache(rawTemplate);
-
-document.body.appendChild(template(data));
-```
-
-By default, Browserify works with CommonJS modules (with `require()` statements). To use it with ES6 modules (with `import` statements shown above), configure the `babelify` plugin in your `package.json`. We’ll also include the `stringify` configuration for loading [can-stache] templates:
+By default, Browserify works with CommonJS modules (with `require()` statements).
+To use it with ES6 modules (with `import` statements), configure the
+[babelify](https://www.npmjs.com/package/babelify) plugin in your `package.json`.
+We’ll also include the [stringify](https://www.npmjs.com/package/stringify)
+configuration for loading [can-stache] templates:
 
 ```
 {
-  ...
-  "devDependencies": {
-    "babel-core": "^6.26.0",
-    "babel-preset-env": "^1.6.1",
-    "babelify": "^8.0.0",
-    "browserify": "^13.1.1",
-    "stringify": "^5.1.0"
+  "name": "my-canjs-app",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "http-server -c-1",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "browserify": {
+    "transform": [ [ "babelify", { "presets": ["env"] } ] ]
   },
   "stringify": {
     "appliesTo": { "includeExtensions": [".stache"] }
   },
-  "browserify": {
-    "transform": [
-      [
-        "babelify",
-        {
-          "presets": [
-            "env"
-          ]
-        }
-      ]
-    ]
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "can-component": "^4.0.0"
+  },
+  "devDependencies": {
+    "babel-core": "^6.26.0",
+    "babel-preset-env": "^1.6.0",
+    "babelify": "^8.0.0",
+    "browserify": "^16.1.0",
+    "http-server": "^0.11.0",
+    "stringify": "^5.2.0"
   }
 }
 ```
-@highlight 9-23
+@highlight 10-15,only
 
-Next, run Browserify from the command line:
+Next, create an `app.stache` template for your app:
 
-```
-./node_modules/browserify/bin/cmd.js -t stringify -t babelify main.js > dist/bundle.js
-```
-
-Finally, create a page that loads `dist/bundle.js`:
-
-```
-<html>
-  <body>
-    <script src="./dist/bundle.js" type="text/javascript"></script>
-  </body>
-</html>
+```html
+{{! app.stache }}
+<h1>{{message}}</h1>
 ```
 
-## RequireJS
+Next, create an `index.js` module for your application. Import [can-component]
+and your template to say “Hello World”:
 
-RequireJS is no longer supported. If you would like to [guides/contributing/code contribute] the code required for AMD, please look at [this issue](https://github.com/canjs/canjs/issues/2646).
+```js
+// index.js
+import Component from "can-component";
+import template from "./app.stache";
+
+Component.extend({
+  tag: "my-app",
+  view: template,
+  ViewModel: {
+    message: {
+      default: "Hello World"
+    }
+  }
+});
+```
+
+Next, run Browserify from your terminal:
+
+```
+./node_modules/browserify/bin/cmd.js --debug --transform babelify --transform stringify --entry index.js --outfile dist/bundle.js
+```
+
+Finally, create an `index.html` page that loads `dist/bundle.js` and includes
+your `<my-app>` component:
+
+```html
+<!doctype html>
+<title>CanJS and Browserify</title>
+<script src="./dist/bundle.js" type="text/javascript"></script>
+<my-app></my-app>
+```
+@highlight 3-4
+
+Now you can load that page in your browser at one of the addresses the HTTP
+server showed you earlier (something like [http://localhost:8080/]). You should
+see “Hello World” on the page—if you don’t, join our
+[Gitter chat](https://gitter.im/canjs/canjs) and we can help you figure out what
+went wrong.
+
+Ready to build an app with CanJS? Check out our [guides/chat] or one of our
+[guides/recipes]!
 
 ## Script tags
 
 ### npm
 
-You can install CanJS with npm:
+After following the [npm instructions above](#npm), install the
+[can](https://www.npmjs.com/package/can) package from npm:
 
 ```
 npm install can --save
@@ -261,80 +370,65 @@ The `node_modules/can/dist/global/` directory will include two files:
 - `can.all.js`: includes the [can-core core], [can-ecosystem ecosystem], and [can-infrastructure infrastructure] modules
 - `can.js`: includes the [can-core core] and [can-infrastructure infrastructure] modules
 
-With `can` installed, you can use it in an HTML page with a `<script>` tag:
+With `can` installed, use it to create an `index.html` page with a `<script>` tag:
 
 ```html
-<html>
-    <head>
-        <title>CanJS</title>
-    </head>
-    <body>
-        <script src="./node_modules/can/dist/global/can.all.js"></script>
-        <script type='text/stache' id='app'>
-        	<hello-world/>
-        </script>
+<!doctype html>
+<title>My CanJS App</title>
+<script src="./node_modules/can/dist/global/can.all.js"></script>
 
-        <script type="text/javascript">
-            can.Component.extend({
-	            tag: 'hello-world',
-	            view: can.stache("<h1>{{message}}</h1>"),
-	            ViewModel: can.DefineMap.extend({
-		            message: {
-		                type: 'string',
-		                default: 'Hello world'
-	                }
-	            })
-            });
-            document.body.appendChild(
-	            can.stache.from("app")()
-            );
-        </script>
-    </body>
-</html>
+<my-app></my-app>
+
+<script type="text/stache" id="app-template">
+  <h1>{{message}}</h1>
+</script>
+
+<script type="text/javascript">
+  const template = can.stache.from("app-template");
+
+  can.Component.extend({
+    tag: "my-app",
+    view: template,
+    ViewModel: {
+      message: {
+        default: "Hello World"
+      }
+    }
+  });
+</script>
 ```
-@highlight 6-6
+@highlight 3
 
 ### CDN
 
 Another quick way to start locally is by loading CanJS from a CDN:
 
 ```html
-<html>
-    <head>
-        <title>CanJS</title>
-    </head>
-    <body>
-        <script src="https://unpkg.com/can@3/dist/global/can.all.js"></script>
-        <script type='text/stache' id='app'>
-        	<hello-world/>
-        </script>
+<!doctype html>
+<title>My CanJS App</title>
+<script src="https://unpkg.com/can@4/dist/global/can.all.js"></script>
 
-        <script type="text/javascript">
-            can.Component.extend({
-	            tag: 'hello-world',
-	            view: can.stache("<h1>{{message}}</h1>"),
-	            ViewModel: can.DefineMap.extend({
-		            message: {
-		                type: 'string',
-		                default: 'Hello world'
-	                }
-	            })
-            });
-            document.body.appendChild(
-	            can.stache.from("app")()
-            );
-        </script>
-    </body>
-</html>
+<my-app></my-app>
+
+<script type="text/stache" id="app-template">
+  <h1>{{message}}</h1>
+</script>
+
+<script type="text/javascript">
+  const template = can.stache.from("app-template");
+
+  can.Component.extend({
+    tag: "my-app",
+    view: template,
+    ViewModel: {
+      message: {
+        default: "Hello World"
+      }
+    }
+  });
+</script>
 ```
-@highlight 6-6
+@highlight 3
 
-## A note on Promises
-
-CanJS uses native [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise), which means you might see the following error in older browsers:
-
-```
-'Promise' is undefined
-```
-
-You must include a Promise polyfill if you’re targeting browsers that do not have [native support](https://caniuse.com/#feat=promises). If you’re using [StealJS](https://stealjs.com/), [a Promise polyfill](https://github.com/stefanpenner/es6-promise) is included for you.
+Ready to build an app with CanJS? Check out our [guides/chat] or one of our
+[guides/recipes]!


### PR DESCRIPTION
- Restructure the page so a new npm section includes instructions for creating a new project (and using http-server), then goes into the instructions for steal, webpack, etc.
- Update the starter JS Bin
- Fix the instructions for newer versions of Browserify and webpack
- Only show installing can-component
- Drop the mention of steal’s modlet support and building for production
- Drop the RequireJS section
- Remove the paragraph about `system.npmAlgorithm`
- Remove the note about native Promises
- Add a little more info about tree shaking

Closes https://github.com/canjs/canjs/issues/4061
Closes https://github.com/canjs/canjs/issues/4060