### PR TITLE
Clean up the Canvas Clock guide

### DIFF
--- a/docs/can-guides/commitment/recipes/canvas-clock/1-setup.js
+++ b/docs/can-guides/commitment/recipes/canvas-clock/1-setup.js
@@ -1,23 +1,21 @@
-const ClockControlsVM = can.DefineMap.extend("ClockControlsVM", {
-  time: {
-    value({ resolve }) {
-      const intervalID = setInterval(() => {
-        resolve( new Date() );
-      },1000);
-
-      resolve( new Date() );
-
-      return () => clearInterval(intervalID);
-    }
-  }
-});
-
 can.Component.extend({
   tag: "clock-controls",
-  ViewModel: ClockControlsVM,
-  view: can.stache(`
+  ViewModel: {
+    time: {
+      value({ resolve }) {
+        const intervalID = setInterval(() => {
+          resolve( new Date() );
+        }, 1000);
+
+        resolve( new Date() );
+
+        return () => clearInterval(intervalID);
+      }
+    }
+  },
+  view: `
     <p>{{time}}</p>
     <digital-clock time:from="time"/>
     <analog-clock time:from="time"/>
-  `)
+  `
 });

--- a/docs/can-guides/commitment/recipes/canvas-clock/2-digital-clock.js
+++ b/docs/can-guides/commitment/recipes/canvas-clock/2-digital-clock.js
@@ -1,43 +1,39 @@
-const DigitalClockVM = can.DefineMap.extend("DigitalClockVM",{
-  time: Date,
-  hh(){
-    const hr = this.time.getHours() % 12;
-    return hr === 0 ? 12 : hr;
-  },
-  mm(){
-    return this.time.getMinutes().toString().padStart(2,"00");
-  },
-  ss(){
-    return this.time.getSeconds().toString().padStart(2,"00");
-  }
-});
-
 can.Component.extend({
   tag: "digital-clock",
-  view: can.stache(`{{hh()}}:{{mm()}}:{{ss()}}`),
-  ViewModel: DigitalClockVM
-});
-
-const ClockControlsVM = can.DefineMap.extend("ClockControlsVM",{
-  time: {
-    value({ resolve }) {
-      const intervalID = setInterval(() => {
-        resolve( new Date() );
-      },1000);
-
-      resolve( new Date() );
-
-      return () => clearInterval(intervalID);
+  view: "{{hh()}}:{{mm()}}:{{ss()}}",
+  ViewModel: {
+    time: Date,
+    hh() {
+      const hr = this.time.getHours() % 12;
+      return hr === 0 ? 12 : hr;
+    },
+    mm() {
+      return this.time.getMinutes().toString().padStart(2, "00");
+    },
+    ss() {
+      return this.time.getSeconds().toString().padStart(2, "00");
     }
   }
 });
 
 can.Component.extend({
   tag: "clock-controls",
-  ViewModel: ClockControlsVM,
-  view: can.stache(`
+  ViewModel: {
+    time: {
+      value({ resolve }) {
+        const intervalID = setInterval(() => {
+          resolve( new Date() );
+        }, 1000);
+
+        resolve( new Date() );
+
+        return () => clearInterval(intervalID);
+      }
+    }
+  },
+  view: `
     <p>{{time}}</p>
     <digital-clock time:from="time"/>
     <analog-clock time:from="time"/>
-  `)
+  `
 });

--- a/docs/can-guides/commitment/recipes/canvas-clock/3-circle.js
+++ b/docs/can-guides/commitment/recipes/canvas-clock/3-circle.js
@@ -1,9 +1,9 @@
 can.Component.extend({
   tag: "analog-clock",
-  view: can.stache(`<canvas id="analog"  width="255" height="255"></canvas>`),
+  view: '<canvas id="analog" width="255" height="255"></canvas>',
   ViewModel: {
     connectedCallback(element) {
-      const canvas = element.firstChild.getContext('2d');
+      const canvas = element.firstChild.getContext("2d");
       const diameter = 255;
       const radius = diameter/2 - 5;
       const center = diameter/2;
@@ -18,46 +18,42 @@ can.Component.extend({
   }
 });
 
-const DigitalClockVM = can.DefineMap.extend("DigitalClockVM",{
-  time: Date,
-  hh(){
-    const hr = this.time.getHours() % 12;
-    return hr === 0 ? 12 : hr;
-  },
-  mm(){
-    return this.time.getMinutes().toString().padStart(2,"00");
-  },
-  ss(){
-    return this.time.getSeconds().toString().padStart(2,"00");
-  }
-});
-
 can.Component.extend({
   tag: "digital-clock",
-  view: can.stache(`{{hh()}}:{{mm()}}:{{ss()}}`),
-  ViewModel: DigitalClockVM
-});
-
-const ClockControlsVM = can.DefineMap.extend("ClockControlsVM",{
-  time: {
-    value({ resolve }) {
-      const intervalID = setInterval(() => {
-        resolve( new Date() );
-      },1000);
-
-      resolve( new Date() );
-
-      return () => clearInterval(intervalID);
+  view: "{{hh()}}:{{mm()}}:{{ss()}}",
+  ViewModel: {
+    time: Date,
+    hh() {
+      const hr = this.time.getHours() % 12;
+      return hr === 0 ? 12 : hr;
+    },
+    mm() {
+      return this.time.getMinutes().toString().padStart(2, "00");
+    },
+    ss() {
+      return this.time.getSeconds().toString().padStart(2, "00");
     }
   }
 });
 
 can.Component.extend({
   tag: "clock-controls",
-  ViewModel: ClockControlsVM,
-  view: can.stache(`
+  ViewModel: {
+    time: {
+      value({ resolve }) {
+        const intervalID = setInterval(() => {
+          resolve( new Date() );
+        }, 1000);
+
+        resolve( new Date() );
+
+        return () => clearInterval(intervalID);
+      }
+    }
+  },
+  view: `
     <p>{{time}}</p>
     <digital-clock time:from="time"/>
     <analog-clock time:from="time"/>
-  `)
+  `
 });

--- a/docs/can-guides/commitment/recipes/canvas-clock/4-second-hand.js
+++ b/docs/can-guides/commitment/recipes/canvas-clock/4-second-hand.js
@@ -1,13 +1,13 @@
 // 60 = 2π
 const base60ToRadians = (base60Number) =>
-2 * Math.PI * base60Number / 60;
+  2 * Math.PI * base60Number / 60;
 
 can.Component.extend({
   tag: "analog-clock",
-  view: can.stache(`<canvas id="analog"  width="255" height="255"></canvas>`),
+  view: '<canvas id="analog" width="255" height="255"></canvas>',
   ViewModel: {
     connectedCallback(element) {
-      const canvas = element.firstChild.getContext('2d');
+      const canvas = element.firstChild.getContext("2d");
       const diameter = 255;
       const radius = diameter/2 - 5;
       const center = diameter/2;
@@ -37,9 +37,9 @@ can.Component.extend({
         });
         // draw second hand
         const seconds = time.getSeconds() + this.time.getMilliseconds() / 1000;
-        const size = radius * 0.85,
-          x = center + size * Math.sin(base60ToRadians(seconds)),
-          y = center + size * -1 * Math.cos(base60ToRadians(seconds));
+        const size = radius * 0.85;
+        const x = center + size * Math.sin(base60ToRadians(seconds));
+        const y = center + size * -1 * Math.cos(base60ToRadians(seconds));
         canvas.beginPath();
         canvas.moveTo(center, center);
         canvas.lineTo(x, y);
@@ -50,46 +50,42 @@ can.Component.extend({
   }
 });
 
-const DigitalClockVM = can.DefineMap.extend("DigitalClockVM",{
-  time: Date,
-  hh(){
-    const hr = this.time.getHours() % 12;
-    return hr === 0 ? 12 : hr;
-  },
-  mm(){
-    return this.time.getMinutes().toString().padStart(2,"00");
-  },
-  ss(){
-    return this.time.getSeconds().toString().padStart(2,"00");
-  }
-});
-
 can.Component.extend({
   tag: "digital-clock",
-  view: can.stache(`{{hh()}}:{{mm()}}:{{ss()}}`),
-  ViewModel: DigitalClockVM
-});
-
-const ClockControlsVM = can.DefineMap.extend("ClockControlsVM",{
-  time: {
-    value({ resolve }) {
-      const intervalID = setInterval(() => {
-        resolve( new Date() );
-      },1000);
-
-      resolve( new Date() );
-
-      return () => clearInterval(intervalID);
+  view: "{{hh()}}:{{mm()}}:{{ss()}}",
+  ViewModel: {
+    time: Date,
+    hh() {
+      const hr = this.time.getHours() % 12;
+      return hr === 0 ? 12 : hr;
+    },
+    mm() {
+      return this.time.getMinutes().toString().padStart(2, "00");
+    },
+    ss() {
+      return this.time.getSeconds().toString().padStart(2, "00");
     }
   }
 });
 
 can.Component.extend({
   tag: "clock-controls",
-  ViewModel: ClockControlsVM,
-  view: can.stache(`
+  ViewModel: {
+    time: {
+      value({ resolve }) {
+        const intervalID = setInterval(() => {
+          resolve( new Date() );
+        }, 1000);
+
+        resolve( new Date() );
+
+        return () => clearInterval(intervalID);
+      }
+    }
+  },
+  view: `
     <p>{{time}}</p>
     <digital-clock time:from="time"/>
     <analog-clock time:from="time"/>
-  `)
+  `
 });

--- a/docs/can-guides/commitment/recipes/canvas-clock/5-refactor.js
+++ b/docs/can-guides/commitment/recipes/canvas-clock/5-refactor.js
@@ -1,21 +1,21 @@
 // 60 = 2π
 const base60ToRadians = (base60Number) =>
-2 * Math.PI * base60Number / 60;
+  2 * Math.PI * base60Number / 60;
 
 can.Component.extend({
   tag: "analog-clock",
-  view: can.stache(`<canvas id="analog"  width="255" height="255"></canvas>`),
+  view: '<canvas id="analog" width="255" height="255"></canvas>',
   ViewModel: {
     connectedCallback(element) {
-      const canvas = element.firstChild.getContext('2d');
+      const canvas = element.firstChild.getContext("2d");
       const diameter = 255;
       const radius = diameter/2 - 5;
       const center = diameter/2;
 
       const drawNeedle = (length, base60Distance, styles) => {
         Object.assign(canvas, styles);
-        const x = center + length * Math.sin(base60ToRadians(base60Distance)),
-          y = center + length * -1 * Math.cos(base60ToRadians(base60Distance));
+        const x = center + length * Math.sin(base60ToRadians(base60Distance));
+        const y = center + length * -1 * Math.cos(base60ToRadians(base60Distance));
         canvas.beginPath();
         canvas.moveTo(center, center);
         canvas.lineTo(x, y);
@@ -44,49 +44,47 @@ can.Component.extend({
             lineCap: "round"
           }
         );
-    });
-});
-
-const DigitalClockVM = can.DefineMap.extend("DigitalClockVM",{
-  time: Date,
-  hh(){
-    const hr = this.time.getHours() % 12;
-    return hr === 0 ? 12 : hr;
-  },
-  mm(){
-    return this.time.getMinutes().toString().padStart(2,"00");
-  },
-  ss(){
-    return this.time.getSeconds().toString().padStart(2,"00");
+      });
+    }
   }
 });
 
 can.Component.extend({
   tag: "digital-clock",
-  view: can.stache(`{{hh()}}:{{mm()}}:{{ss()}}`),
-  ViewModel: DigitalClockVM
-});
-
-const ClockControlsVM = can.DefineMap.extend("ClockControlsVM",{
-  time: {
-    value({ resolve }) {
-      const intervalID = setInterval(() => {
-        resolve( new Date() );
-      },1000);
-
-      resolve( new Date() );
-
-      return () => clearInterval(intervalID);
+  view: "{{hh()}}:{{mm()}}:{{ss()}}",
+  ViewModel: {
+    time: Date,
+    hh() {
+      const hr = this.time.getHours() % 12;
+      return hr === 0 ? 12 : hr;
+    },
+    mm() {
+      return this.time.getMinutes().toString().padStart(2, "00");
+    },
+    ss() {
+      return this.time.getSeconds().toString().padStart(2, "00");
     }
   }
 });
 
 can.Component.extend({
   tag: "clock-controls",
-  ViewModel: ClockControlsVM,
-  view: can.stache(`
+  ViewModel: {
+    time: {
+      value({ resolve }) {
+        const intervalID = setInterval(() => {
+          resolve( new Date() );
+        }, 1000);
+
+        resolve( new Date() );
+
+        return () => clearInterval(intervalID);
+      }
+    }
+  },
+  view: `
     <p>{{time}}</p>
     <digital-clock time:from="time"/>
     <analog-clock time:from="time"/>
-  `)
+  `
 });

--- a/docs/can-guides/commitment/recipes/canvas-clock/6-min-hour-hands.js
+++ b/docs/can-guides/commitment/recipes/canvas-clock/6-min-hour-hands.js
@@ -1,21 +1,21 @@
 // 60 = 2π
 const base60ToRadians = (base60Number) =>
-2 * Math.PI * base60Number / 60;
+  2 * Math.PI * base60Number / 60;
 
 can.Component.extend({
   tag: "analog-clock",
-  view: can.stache(`<canvas id="analog"  width="255" height="255"></canvas>`),
+  view: '<canvas id="analog" width="255" height="255"></canvas>',
   ViewModel: {
     connectedCallback(element) {
-      const canvas = element.firstChild.getContext('2d');
+      const canvas = element.firstChild.getContext("2d");
       const diameter = 255;
       const radius = diameter/2 - 5;
       const center = diameter/2;
 
       const drawNeedle = (length, base60Distance, styles) => {
         Object.assign(canvas, styles);
-        const x = center + length * Math.sin(base60ToRadians(base60Distance)),
-          y = center + length * -1 * Math.cos(base60ToRadians(base60Distance));
+        const x = center + length * Math.sin(base60ToRadians(base60Distance));
+        const y = center + length * -1 * Math.cos(base60ToRadians(base60Distance));
         canvas.beginPath();
         canvas.moveTo(center, center);
         canvas.lineTo(x, y);
@@ -66,45 +66,43 @@ can.Component.extend({
             strokeStyle: "#42F",
             lineCap: "round"
           }
-        );	
-    });
-});
-
-const DigitalClockVM = can.DefineMap.extend("DigitalClockVM",{
-  time: Date,
-  hh(){
-    const hr = this.time.getHours() % 12;
-    return hr === 0 ? 12 : hr;
-  },
-  mm(){
-    return this.time.getMinutes().toString().padStart(2,"00");
-  },
-  ss(){
-    return this.time.getSeconds().toString().padStart(2,"00");
+        );
+      });
+    }
   }
 });
 
 can.Component.extend({
   tag: "digital-clock",
-  view: can.stache(`{{hh()}}:{{mm()}}:{{ss()}}`),
-  ViewModel: DigitalClockVM
-});
-
-const ClockControlsVM = can.DefineMap.extend("ClockControlsVM",{
-  time: {Default: Date, Type: Date},
-  init(){
-    setInterval(() => {
-      this.time = new Date();
-    },1000);
+  view: "{{hh()}}:{{mm()}}:{{ss()}}",
+  ViewModel: {
+    time: Date,
+    hh() {
+      const hr = this.time.getHours() % 12;
+      return hr === 0 ? 12 : hr;
+    },
+    mm() {
+      return this.time.getMinutes().toString().padStart(2, "00");
+    },
+    ss() {
+      return this.time.getSeconds().toString().padStart(2, "00");
+    }
   }
 });
 
 can.Component.extend({
   tag: "clock-controls",
-  ViewModel: ClockControlsVM,
-  view: can.stache(`
+  ViewModel: {
+    time: {Default: Date, Type: Date},
+    init() {
+      setInterval(() => {
+        this.time = new Date();
+      }, 1000);
+    }
+  },
+  view: `
     <p>{{time}}</p>
     <digital-clock time:from="time"/>
     <analog-clock time:from="time"/>
-  `)
+  `
 });

--- a/docs/can-guides/commitment/recipes/canvas-clock/canvas-clock.md
+++ b/docs/can-guides/commitment/recipes/canvas-clock/canvas-clock.md
@@ -1,7 +1,8 @@
 @page guides/recipes/canvas-clock Canvas Clock (Simple)
 @parent guides/recipes
 
-@description This guide walks you through building a canvas clock.  
+@description This guide walks you through building a clock with the
+[Canvas API](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API).
 
 
 @body
@@ -13,22 +14,26 @@ In this guide you will learn how to:
 
 The final widget looks like:
 
-<a class="jsbin-embed" href="https://jsbin.com/zefajic/14/embed?output&height=400px">JS Bin on jsbin.com</a>
+<a class="jsbin-embed" href="https://jsbin.com/jeligek/3/embed?output">
+  CanJS Canvas Clock on jsbin.com
+</a>
 
 The following sections are broken down the following parts:
 
 - __The problem__ — A description of what the section is trying to accomplish.
 - __What you need to know__ — Information about CanJS that is useful for solving the problem.
-- __How to verify it works__ - How to make sure the solution works if it's not obvious.
+- __How to verify it works__ - How to make sure the solution works (if it’s not obvious).
 - __The solution__ — The solution to the problem.
 
 ## Setup ##
 
-__START THIS TUTORIAL BY CLONING THE FOLLOWING JS Bin__:
+__START THIS TUTORIAL BY CLONING THE FOLLOWING JS BIN__:
 
-> Click the `JS Bin` button.  The JSBin will open in a new window. In that new window, under `File`, click `Clone`.
+> Click the **JS Bin** button.  The JS Bin will open in a new window. In that new window, under `File`, click `Clone`.
 
-<a class="jsbin-embed" href="https://jsbin.com/zomefef/7/embed?html,js,output">CanJS Bus Demo on jsbin.com</a>
+<a class="jsbin-embed" href="https://jsbin.com/jeligek/1/embed?html,css,js,output">
+  CanJS Canvas Clock on jsbin.com
+</a>
 
 This JS Bin has initial prototype HTML, CSS, and JS to bootstrap a basic CanJS application.
 
@@ -37,69 +42,39 @@ This JS Bin has initial prototype HTML, CSS, and JS to bootstrap a basic CanJS a
 
 ### What you need to know
 
-There's nothing to do in this step. The JSBin is already setup with:
+There’s nothing to do in this step. The JS Bin is already setup with:
 
 - A _basic_ CanJS setup.
 - A `<clock-controls>` custom element that:
   - updates a `time` property every second
-  - passes the `time` value to a `<digital-clock>` and
-    `<analog-clock>` component that will be defined in future sections.
+  - passes the `time` value to `<digital-clock>` and
+    `<analog-clock>` components that will be defined in future sections.
 
 Please read on to understand the setup.
 
-__A Basic CanJS Setup__
+#### A Basic CanJS Setup
 
 A basic CanJS setup is usually a custom element.  In the `HTML`
-tab, you'll find a `<clock-controls/>` element.  The following code in the `JS` tab
-defines the behavior of the `<clock-controls/>` element:
+tab, you’ll find a `<clock-controls>` element.  The following code in the `JS` tab
+defines the behavior of the `<clock-controls>` element:
 
-```js
-const ClockControlsVM = can.DefineMap.extend("ClockControlsVM",{
-  time: {
-    value({ resolve }) {
-      const intervalID = setInterval(() => {
-        resolve( new Date() );
-      },1000);
+@sourceref ./1-setup.js
 
-      resolve( new Date() );
+[can-component] is used to define the behavior of the  `<clock-controls>`
+element. Components are configured with three main properties that define the
+behavior of the element:
 
-      return () => clearInterval(intervalID);
-    }
-  }
-});
+- [can-component.prototype.tag] is used to specify the name of the custom element
+  (e.g. `"clock-controls"`).
+- [can-component.prototype.view] is used as the HTML content within the custom
+  element; by default, it is a [can-stache] template.
+- [can-component.prototype.ViewModel] provides methods and values to the `view`;
+  by default, the `ViewModel` is a [can-define/map/map].
 
-can.Component.extend({
-  tag: "clock-controls",
-  ViewModel: ClockControlsVM,
-  view: can.stache(`
-    <p>{{time}}</p>
-    <digital-clock time:from="time"/>
-    <analog-clock time:from="time"/>
-  `)
-});
-```
-
-You'll notice the behavior is defined in two parts.  First is the `ClockControlsVM` type.  This
-is an observable constructor function created with [can-define/map/map].  Here, a `time`
-property is defined using the [can-define.types.value value behavior]. This uses `resolve` to set
-the value of `time` to be an instance of a `Date` and then update the value every second to be a
-new `Date`.
-
-One could create an instance of `ClockControlsVM` and explore it's `time` property as follows:
-
-```js
-const vm = new ClockControlsVM();
-vm.time //-> Wed Nov 01 2017 14:31:25 GMT-0500 (CDT)
-```
-
-The next part uses [can-component] to define the behavior of the  `<clock-controls>`
-element. [can-component] has configured properties that define the behavior of the element.
-
-- `tag` is used to specify the name of the custom element. (ex: `"clock-controls"`)
-- `view` is used as the HTML content within the custom element.  It is usually a [can-stache]
-  template.
-- `ViewModel` provides methods and values to the `view`.  `ViewModel`s are usually a typeof
-[can-define/map/map].
+Here, a `time` property is defined using the [can-define.types.value value behavior].
+This uses `resolve` to set the value of `time` to be an instance of a
+[Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date)
+and then update the value every second to be a new `Date`.
 
 ## Create a digital clock component ##
 
@@ -114,32 +89,33 @@ In this section, we will:
 ### What you need to know
 
 - Use [can-component] to create a custom element.
-  - `tag` is used to specify the name of the custom element. (hint: `"digital-clock"`)
-  - `view` is used as the HTML content within the custom element.  It is usually a [can-stache]
-    template.  (hint: `can.stache("Your {{content}}")`).
-  - `ViewModel` provides methods and values to the `view`.  `ViewModel`s are usually a typeof
-    [can-define/map/map].
+  - [can-component.prototype.tag] is used to specify the name of the custom
+    element (hint: `"digital-clock"`).
+  - [can-component.prototype.view] is used as the HTML content within the custom
+    element; by default, it is a [can-stache] template (hint: `"Your {{content}}"`).
+  - [can-component.prototype.ViewModel] provides methods and values to the `view`;
+    by default, the `ViewModel` is a [can-define/map/map] that defines properties
+    and functions like:
+    ```js
+    ViewModel: {
+      property: Type, // hint -> time: Date
+      method() {
+        return // ...
+      }
+    }
+    ```
 - [can-stache] can insert the return value from function calls into the page like:
   ```
   {{method()}}
   ```
   These methods are often functions on the `ViewModel`.
-- Use [can-define/map/map] to define properties and methods like:
-  ```js
-  var DigitalClockVM = can.DefineMap.extend({
-    property: Type, //hint -> time: Date
-    method() {
-        return ...;
-    }
-  })
-  ```
-- The [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) has
-  methods that give you details about that date and time:
-  - `date.getSeconds()`
-  - `date.getMinutes()`
-  - `date.getHours()`
+- [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date)
+  has methods that give you details about that date and time:
+  - [date.getSeconds()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getSeconds)
+  - [date.getMinutes()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMinutes)
+  - [date.getHours()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getHours)
 - Use [padStart](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart)
-  to convert a string like `"1"` into `"01"` like `.padStart(2,"00")`.
+  to convert a string like `"1"` into `"01"` like `.padStart(2, "00")`.
 
 
 ### The solution
@@ -147,7 +123,7 @@ In this section, we will:
 Update the __JavaScript__ tab to:
 
 @sourceref ./2-digital-clock.js
-@highlight 1-19,only
+@highlight 1-17,only
 
 ## Draw a circle in the analog clock component ##
 
@@ -161,13 +137,17 @@ In this section, we will:
 ### What you need to know
 
 - Use another [can-component] to define a `<analog-clock>` component.
-- Define the component's `view` to write out a `<canvas>` element. (hint: `<canvas id="analog"  width="255" height="255"></canvas>`).
-- A component's viewModel can be defined as an object which will be passed to [can-define/map/map.extend DefineMap.extend]. (hint:`ViewModel: {}`)
-- A viewModel's [can-component/connectedCallback] will be called when the component is inserted into the page and will be passed the `element` like:
+- Define the component’s [can-component.prototype.view] to write out a `<canvas>`
+  element (hint: `<canvas id="analog" width="255" height="255"></canvas>`).
+- A component’s [can-component.prototype.ViewModel] can be defined as an object
+  which will be passed to [can-define/map/map.extend DefineMap.extend]
+  (hint:`ViewModel: {}`).
+- A viewModel’s [can-component/connectedCallback] will be called when the
+  component is inserted into the page; it will be passed the `element` like:
   ```js
   can.Component.extend({
     tag: "my-element",
-    view: can.stache(`<h1>first child</h1>`),
+    view: "<h1>first child</h1>",
     ViewModel: {
       connectedCallback(element) {
         element.firstChild //-> <h1>
@@ -176,7 +156,7 @@ In this section, we will:
   });
   ```
 - To get the [canvas rendering context](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D)
-  from a `<canvas>` element use `canvas = canvasElement.getContext('2d')`.
+  from a `<canvas>` element, use `canvas = canvasElement.getContext("2d")`.
 - To draw a line (or curve), you generally set different style properties of the rendering context like:
   ```js
   canvas.lineWidth = 4.0
@@ -189,13 +169,14 @@ In this section, we will:
   Then make [arcs](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D) and [lines](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineTo)
   for your path like:
   ```js
-  canvas.arc(125,125,125,0,Math.PI * 2,true)
+  canvas.arc(125, 125, 125, 0, Math.PI * 2, true)
   ```
   Then close the path like:
   ```js
   canvas.closePath()
   ```
-  Finally, use `stroke` to actually draw the line:
+  Finally, use [stroke](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/stroke)
+  to actually draw the line:
   ```js
   canvas.stroke();
   ```
@@ -222,29 +203,31 @@ In this section, we will:
 - Draw the second hand needle when the `time` value changes
   on the `viewModel`.
 - The needle should be `2` pixels wide, red (`#FF0000`), and 85% of the
-  clock's radius.
+  clock’s radius.
 
 ### What you need to know
 
-- [can-event-queue/map/map.listenTo this.listenTo] can be used in a component's `connectedCallback` to listen to changes in the `ViewModel` like:
+- [can-event-queue/map/map.listenTo this.listenTo] can be used in a component’s
+  [can-component/connectedCallback] to listen to changes in the `ViewModel` like:
   ```js
   can.Component.extend({
     tag: "analog-clock",
-    ...
-	ViewModel: {
-	  connectedCallback() {
-	    this.listenTo("time", (ev, time) => {
-		  ...
-	    });
-	  }
-	}
+    // ...
+    ViewModel: {
+      connectedCallback() {
+        this.listenTo("time", (event, time) => {
+          // ...
+        });
+      }
+    }
   });
   ```
 
 - Use [canvas.moveTo(x1,y1)](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext/moveTo)
   and [canvas.lineTo(x2,y2)](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineTo)
   to draw a line from one position to another.
-- To get the needle point to move around a "unit" circle, you'd want to make the following calls given the number of seconds:
+- To get the needle point to move around a “unit” circle, you’d want to make the
+  following calls given the number of seconds:
   ```
   0s  -> .lineTo(.5,0)
   15s -> .lineTo(1,.5)
@@ -252,11 +235,13 @@ In this section, we will:
   45s -> .lineTo(0,.5)
   ```
 
-- Our friends `Math.sin` and `Math.cos` can help here.  But they take radians.  
+- Our friends [Math.sin](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sin)
+  and [Math.cos](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cos)
+  can help here… but they take radians.
 
   ![Sine and Cosine Graph](https://www.mathsisfun.com/algebra/images/sine-cosine-graph.gif)
 
-  Use the following `base60ToRadians` method to convert a number from 0-60 to one between 0 and 2π:
+  Use the following `base60ToRadians` method to convert a number from 0–60 to one between 0 and 2π:
 
   ```js
   // 60 = 2π
@@ -278,10 +263,10 @@ In this section, we will:
 
 - Clear the canvas before drawing the circle and needle.
 - Refactor the needle drawing code into a `drawNeedle(length, base60Distance, styles)` method where:
-  - `length` - is the length in pixels of the needle.
-  - `base60Distance` - is a number between 0-60 representing how far around the clock the
+  - `length` is the length in pixels of the needle.
+  - `base60Distance` is a number between 0–60 representing how far around the clock the
     needle should be drawn.
-  - `styles` - An object of canvas context style properties and values like:
+  - `styles` is an object of canvas context style properties and values like:
     ```js
     {
       lineWidth: 2.0,
@@ -296,18 +281,19 @@ In this section, we will:
   when the time changes.
 - Use [clearRect(x, y, width, height)](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/clearRect) to clear
   the canvas.
-- Add a function inside the `connectedCallback` that will have access to all the variables created above it like:
+- Add a function inside the [can-component/connectedCallback] that will have
+  access to all the variables created above it like:
   ```js
   ViewModel: {
     connectedCallback() {
-      const canvas = element.firstChild.getContext('2d');
+      const canvas = element.firstChild.getContext("2d");
       const diameter = 255;
       const radius = diameter/2 - 5;
       const center = diameter/2;
 
       const drawNeedle = (length, base60Distance, styles) => {
         canvas // -> the canvas element
-        ...
+        // ...
       };
     }
   }
@@ -327,9 +313,9 @@ Update the __JavaScript__ tab to:
 In this section, we will:
 
 - Draw the minute hand `3` pixels wide, dark gray (`#423`), and 65% of the
-  clock's radius.
+  clock’s radius.
 - Draw the minute hand `4` pixels wide, dark blue (`#42F`), and 45% of the
-  clock's radius.
+  clock’s radius.
 
 ### What you need to know
 
@@ -342,6 +328,12 @@ Update the __JavaScript__ tab to:
 @sourceref ./6-min-hour-hands.js
 @highlight 48-69,only
 
+## Result
 
+When finished, you should see something like the following JS Bin:
 
-<script src="//static.jsbin.com/js/embed.min.js?4.0.4"></script>
+<a class="jsbin-embed" href="https://jsbin.com/jeligek/3/embed?output">
+  CanJS Canvas Clock on jsbin.com
+</a>
+
+<script src="https://static.jsbin.com/js/embed.min.js?4.1.4"></script>


### PR DESCRIPTION
- Don’t show using can.stache or can.DefineMap directly
- Rearrange / reword some of the sections to accommodate the above change
- Fix some of the code examples
- Update the JS Bins to use can@4 instead of a prerelease
- Various minor fixes