### PR TITLE
Clean up the video player guide

### DIFF
--- a/docs/can-guides/commitment/recipes/text-editor/text-editor.md
+++ b/docs/can-guides/commitment/recipes/text-editor/text-editor.md
@@ -72,7 +72,7 @@ I’m sorry; your browser doesn’t support HTML5 video in WebM with VP8/VP9 or 
 
 ### What you need to know
 
-To setup a basic CanJS application, you define a custom element in JavaScript and
+To set up a basic CanJS application, you define a custom element in JavaScript and
 use the custom element in your page’s `HTML`.
 
 To define a custom element, extend [can-component] with a [can-component.prototype.tag]
@@ -86,7 +86,7 @@ can.Component.extend({
 
 Then you can use this tag in your HTML page:
 
-```HTML
+```html
 <rich-text-editor></rich-text-editor>
 ```
 

--- a/docs/can-guides/commitment/recipes/video-player/1-setup.html
+++ b/docs/can-guides/commitment/recipes/video-player/1-setup.html
@@ -1,2 +1,5 @@
-  <video-player src:raw="https://canjs.com/docs/images/tom_jerry.webm"></video-player>
-  <script src="https://unpkg.com/can@4/dist/global/can.js"></script>
+<!doctype html>
+<title>CanJS Video Player</title>
+<script src="https://unpkg.com/can@4/dist/global/can.all.js"></script>
+
+<video-player src:raw="https://canjs.com/docs/images/tom_jerry.webm"></video-player>

--- a/docs/can-guides/commitment/recipes/video-player/1-setup.js
+++ b/docs/can-guides/commitment/recipes/video-player/1-setup.js
@@ -1,11 +1,11 @@
 can.Component.extend({
-  tag: 'video-player',
+  tag: "video-player",
   view: `
     <video controls>
       <source src="{{src}}"/>
     </video>
-    `,
+  `,
   ViewModel: {
-    src: 'string',
+    src: "string",
   }
 });

--- a/docs/can-guides/commitment/recipes/video-player/2-play-reflects.js
+++ b/docs/can-guides/commitment/recipes/video-player/2-play-reflects.js
@@ -1,5 +1,5 @@
 can.Component.extend({
-  tag: 'video-player',
+  tag: "video-player",
   view: `
     <video controls
       on:play="play()"
@@ -8,12 +8,12 @@ can.Component.extend({
     </video>
     <div>
       <button>
-        {{#if(playing)}}Pause{{else}}Play{{/if}}
+        {{#if(playing)}} Pause {{else}} Play {{/if}}
       </button>
     </div>
-    `,
+  `,
   ViewModel: {
-    src: 'string',
+    src: "string",
     playing: "boolean",
 
     play() {

--- a/docs/can-guides/commitment/recipes/video-player/3-play-mutates.js
+++ b/docs/can-guides/commitment/recipes/video-player/3-play-mutates.js
@@ -1,5 +1,5 @@
 can.Component.extend({
-  tag: 'video-player',
+  tag: "video-player",
   view: `
     <video controls
       on:play="play()"
@@ -8,12 +8,12 @@ can.Component.extend({
     </video>
     <div>
       <button on:click="togglePlay()">
-        {{#if(playing)}}Pause{{else}}Play{{/if}}
+        {{#if(playing)}} Pause {{else}} Play {{/if}}
       </button>
     </div>
-    `,
+  `,
   ViewModel: {
-    src: 'string',
+    src: "string",
     playing: "boolean",
 
     play() {
@@ -26,8 +26,8 @@ can.Component.extend({
       this.playing = !this.playing;
     },
 
-    connectedCallback(element){
-      this.listenTo("playing", function(ev, isPlaying){
+    connectedCallback(element) {
+      this.listenTo("playing", function(event, isPlaying) {
         if (isPlaying) {
           element.querySelector("video").play();
         } else {

--- a/docs/can-guides/commitment/recipes/video-player/4-play-mutates.js
+++ b/docs/can-guides/commitment/recipes/video-player/4-play-mutates.js
@@ -1,5 +1,5 @@
 can.Component.extend({
-  tag: 'video-player',
+  tag: "video-player",
   view: `
     <video controls
       on:play="play()"
@@ -10,14 +10,14 @@ can.Component.extend({
     </video>
     <div>
       <button on:click="togglePlay()">
-        {{#if(playing)}}Pause{{else}}Play{{/if}}
+        {{#if(playing)}} Pause {{else}} Play {{/if}}
       </button>
       <span>{{formatTime(currentTime)}}</span> /
       <span>{{formatTime(duration)}} </span>
     </div>
-    `,
+  `,
   ViewModel: {
-    src: 'string',
+    src: "string",
     playing: "boolean",
     duration: "number",
     currentTime: "number",
@@ -28,14 +28,14 @@ can.Component.extend({
     },
     formatTime(time) {
       if (time === null || time === undefined) {
-        return "--"
+        return "--";
       }
-      const durmins = Math.floor(time / 60);
-      let dursecs = Math.floor(time - durmins * 60);
-      if (dursecs < 10) {
-        dursecs = "0" + dursecs;
+      const minutes = Math.floor(time / 60);
+      let seconds = Math.floor(time - minutes * 60);
+      if (seconds < 10) {
+        seconds = "0" + seconds;
       }
-      return durmins + ":" + dursecs
+      return minutes + ":" + seconds;
     },
     play() {
       this.playing = true;
@@ -47,8 +47,8 @@ can.Component.extend({
       this.playing = !this.playing;
     },
 
-    connectedCallback(element){
-      this.listenTo("playing", function(ev, isPlaying){
+    connectedCallback(element) {
+      this.listenTo("playing", function(event, isPlaying) {
         if (isPlaying) {
           element.querySelector("video").play();
         } else {

--- a/docs/can-guides/commitment/recipes/video-player/5-play-mutates.js
+++ b/docs/can-guides/commitment/recipes/video-player/5-play-mutates.js
@@ -1,5 +1,5 @@
 can.Component.extend({
-  tag: 'video-player',
+  tag: "video-player",
   view: `
     <video controls
       on:play="play()"
@@ -10,16 +10,16 @@ can.Component.extend({
     </video>
     <div>
       <button on:click="togglePlay()">
-        {{#if(playing)}}Pause{{else}}Play{{/if}}
+        {{#if(playing)}} Pause {{else}} Play {{/if}}
       </button>
       <input type="range" value="0" max="1" step="any"
              value:from="percentComplete"/>
       <span>{{formatTime(currentTime)}}</span> /
       <span>{{formatTime(duration)}} </span>
     </div>
-    `,
+  `,
   ViewModel: {
-    src: 'string',
+    src: "string",
     playing: "boolean",
     duration: "number",
     currentTime: "number",
@@ -34,14 +34,14 @@ can.Component.extend({
     },
     formatTime(time) {
       if (time === null || time === undefined) {
-        return "--"
+        return "--";
       }
-      const durmins = Math.floor(time / 60);
-      let dursecs = Math.floor(time - durmins * 60);
-      if (dursecs < 10) {
-        dursecs = "0" + dursecs;
+      const minutes = Math.floor(time / 60);
+      let seconds = Math.floor(time - minutes * 60);
+      if (seconds < 10) {
+        seconds = "0" + seconds;
       }
-      return durmins + ":" + dursecs
+      return minutes + ":" + seconds;
     },
     play() {
       this.playing = true;
@@ -53,8 +53,8 @@ can.Component.extend({
       this.playing = !this.playing;
     },
 
-    connectedCallback(element){
-      this.listenTo("playing", function(ev, isPlaying){
+    connectedCallback(element) {
+      this.listenTo("playing", function(event, isPlaying) {
         if (isPlaying) {
           element.querySelector("video").play();
         } else {

--- a/docs/can-guides/commitment/recipes/video-player/6-play-mutates.js
+++ b/docs/can-guides/commitment/recipes/video-player/6-play-mutates.js
@@ -1,5 +1,5 @@
 can.Component.extend({
-  tag: 'video-player',
+  tag: "video-player",
   view: `
     <video
       on:play="play()"
@@ -10,16 +10,16 @@ can.Component.extend({
     </video>
     <div>
       <button on:click="togglePlay()">
-        {{#if(playing)}}Pause{{else}}Play{{/if}}
+        {{#if(playing)}} Pause {{else}} Play {{/if}}
       </button>
       <input type="range" value="0" max="1" step="any"
              value:bind="percentComplete"/>
       <span>{{formatTime(currentTime)}}</span> /
       <span>{{formatTime(duration)}} </span>
     </div>
-    `,
+  `,
   ViewModel: {
-    src: 'string',
+    src: "string",
     playing: "boolean",
     duration: "number",
     currentTime: "number",
@@ -28,7 +28,7 @@ can.Component.extend({
       return this.currentTime / this.duration;
     },
     set percentComplete(newVal) {
-     this.currentTime = newVal * this.duration;
+      this.currentTime = newVal * this.duration;
     },
 
     updateTimes(videoElement) {
@@ -37,14 +37,14 @@ can.Component.extend({
     },
     formatTime(time) {
       if (time === null || time === undefined) {
-        return "--"
+        return "--";
       }
-      const durmins = Math.floor(time / 60);
-      let dursecs = Math.floor(time - durmins * 60);
-      if (dursecs < 10) {
-        dursecs = "0" + dursecs;
+      const minutes = Math.floor(time / 60);
+      let seconds = Math.floor(time - minutes * 60);
+      if (seconds < 10) {
+        seconds = "0" + seconds;
       }
-      return durmins + ":" + dursecs
+      return minutes + ":" + seconds;
     },
     play() {
       this.playing = true;
@@ -56,16 +56,19 @@ can.Component.extend({
       this.playing = !this.playing;
     },
 
-    connectedCallback(element){
-      this.listenTo("playing", function(ev, isPlaying){
+    connectedCallback(element) {
+      this.listenTo("playing", function(event, isPlaying) {
         if (isPlaying) {
           element.querySelector("video").play();
         } else {
           element.querySelector("video").pause();
         }
       });
-      this.listenTo("currentTime", function(ev, currentTime){
-        element.querySelector("video").currentTime = currentTime;
+      this.listenTo("currentTime", function(event, currentTime) {
+        const videoElement = element.querySelector("video");
+        if (currentTime !== videoElement.currentTime) {
+          videoElement.currentTime = currentTime;
+        }
       });
     }
   }

--- a/docs/can-guides/commitment/recipes/video-player/video-player.md
+++ b/docs/can-guides/commitment/recipes/video-player/video-player.md
@@ -15,19 +15,19 @@ custom video player will:
 
 - Have custom play / pause buttons.
 - Show the current time and duration of the video.
-- Have a `<input type='range'>` slider that can adjust the position of the video.
+- Have a `<input type="range">` slider that can adjust the position of the video.
 
 
 The final widget looks like:
 
-
-<a class="jsbin-embed" href="https://jsbin.com/sekadux/3/embed?html,js,output">JS Bin on jsbin.com</a>
+<a class="jsbin-embed" href="https://jsbin.com/jaliquj/8/embed?html,js,output">
+  CanJS Video Player on jsbin.com
+</a>
 
 The following sections are broken down the following parts:
 
 - __The problem__ — A description of what the section is trying to accomplish.
 - __What you need to know__ — Information about CanJS that is useful for solving the problem.
-- __How to verify it works__ - How to make sure the solution works if it’s not obvious.
 - __The solution__ — The solution to the problem.
 
 ## Setup ##
@@ -36,11 +36,13 @@ __START THIS TUTORIAL BY CLONING THE FOLLOWING JS BIN__:
 
 > Click the `JS Bin` button.  The JS Bin will open in a new window. In that new window, under `File`, click `Clone`.
 
-<a class="jsbin-embed" href="https://jsbin.com/gipisuw/4/edit?html,js,output">CanJS Video Player on jsbin.com</a>
+<a class="jsbin-embed" href="https://jsbin.com/jaliquj/3/embed?html,js,output">
+  CanJS Video Player on jsbin.com
+</a>
 
 This JS Bin:
 
-- Creates a `<video>` element that loads a video. _Right click and select "Show controls" to see the video's controls_.
+- Creates a `<video>` element that loads a video. _Right click and select “Show controls” to see the video’s controls_.
 - Loads CanJS.
 
 
@@ -59,7 +61,7 @@ This JS Bin:
 
 ### What you need to know
 
-To setup a basic CanJS application, you define a custom element in JavaScript and
+To set up a basic CanJS application, you define a custom element in JavaScript and
 use the custom element in your page’s `HTML`.
 
 To define a custom element, extend [can-component] with a [can-component.prototype.tag]
@@ -73,7 +75,7 @@ can.Component.extend({
 
 Then you can use this tag in your HTML page:
 
-```HTML
+```html
 <video-player></video-player>
 ```
 
@@ -83,17 +85,17 @@ property:
 ```js
 can.Component.extend({
   tag: "video-player",
-  view: `<h2>I am a <input value='video'/> player!</h2>`
+  view: `<h2>I am a <input value="video"/> player!</h2>`
 });
 ```
 
-A component's `view` is rendered with its [can-component.prototype.ViewModel]. For example, we can
-make the `<input>` say `"AWESOME VIDEO"` by defining a `src` property and using it in the `view` like:
+A component’s [can-component.prototype.view] is rendered with its [can-component.prototype.ViewModel]. For example, we can
+make the `<input>` say `"AWESOME VIDEO"` by defining a `src` property and using it in the [can-component.prototype.view] like:
 
 ```js
 can.Component.extend({
   tag: "video-player",
-  view: `<h2>I am a <input value='{{src}}'/> player!</h2>`,
+  view: `<h2>I am a <input value="{{src}}"/> player!</h2>`,
   ViewModel: {
     src: {default: "AWESOME VIDEO"}
   }
@@ -101,18 +103,18 @@ can.Component.extend({
 ```
 
 But we want the video player to take a `src` attribute value and use that for the
-`<input>`'s `value`. For example, if
+`<input>`’s `value`. For example, if
 we wanted the input to say `CONFIGURABLE VIDEO` instead of `video`, we would:
 
 1. Update `<video-player>` to pass `"CONFIGURABLE VIDEO"` with [can-stache-bindings.raw]:
    ```html
    <video-player src:raw="CONFIGURABLE VIDEO"/>
    ```
-2. Update the `ViewModel` to define a `src` property like:
+2. Update the [can-component.prototype.ViewModel] to define a `src` property like:
    ```js
    can.Component.extend({
      tag: "video-player",
-     view: `<h2>I am a <input value='video'/> player!</h2>`,
+     view: `<h2>I am a <input value="video"/> player!</h2>`,
      ViewModel: {
        src: "string"
      }
@@ -122,7 +124,7 @@ we wanted the input to say `CONFIGURABLE VIDEO` instead of `video`, we would:
    ```js
    can.Component.extend({
      tag: "video-player",
-     view: `<h2>I am a <input value='{{src}}'/> player!</h2>`,
+     view: `<h2>I am a <input value="{{src}}"/> player!</h2>`,
      ViewModel: {
        src: "string"
      }
@@ -132,7 +134,7 @@ we wanted the input to say `CONFIGURABLE VIDEO` instead of `video`, we would:
 Finally, to have a `<video>` element show the _native_ controls, add a `controls`
 attribute like:
 
-```js
+```html
 <video controls>
 ```
 
@@ -143,10 +145,10 @@ Update the __JavaScript__ tab to:
 @sourceref ./1-setup.js
 @highlight 1-11,only
 
-Update the __HTML__ `<body>` element to:
+Update the __HTML__ to:
 
 @sourceref ./1-setup.html
-@highlight 1,only
+@highlight 5,only
 
 
 
@@ -155,10 +157,10 @@ Update the __HTML__ `<body>` element to:
 ### The problem
 
 When the video is played or paused using the native controls, we want to change the content of a `<button>`
-to say _"Play"_ or _"Pause"_.
+to say _“Play”_ or _“Pause”_.
 
-When the video is played, the button should say _"Pause"_.
-When the video is paused, the button should say _"Play"_.
+When the video is played, the button should say _“Pause”_.
+When the video is paused, the button should say _“Play”_.
 
 We want the button to be within a `<div>` after the video element like:
 
@@ -174,21 +176,20 @@ We want the button to be within a `<div>` after the video element like:
 
 - To change the HTML content of the page, use [can-stache.helpers.if] and [can-stache.helpers.else] like:
   ```html
-  <button>{{#if(playing)}}Pause{{else}}Play{{/if}} </button>
+  <button>{{#if(playing)}} Pause {{else}} Play {{/if}}</button>
   ````
-- The `view` responds to values in the `ViewModel`.  To create a `boolean` value in the `ViewModel` do:
+- The [can-component.prototype.view] responds to values in the [can-component.prototype.ViewModel].  To create a `boolean` value in the [can-component.prototype.ViewModel] do:
   ```js
   ViewModel: {
-    ...
+    // ...
     playing: "boolean",
   }
   ```
-- Methods can be used to change the `ViewModel`.  The following might create methods that  
-  change the `playing` value:
+- Methods can be used to change the [can-component.prototype.ViewModel].  The following might create methods that change the `playing` value:
 
   ```js
   ViewModel: {
-    ...
+    // ...
     play() {
       this.playing = true;
     },
@@ -204,8 +205,8 @@ We want the button to be within a `<div>` after the video element like:
   <div on:click="doSomething()">
   ```
 
-  `<video>` elements have a variety of useful [events](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement), including a `play` and
-  `pause` event that is emitted when the video is played or paused.
+  `<video>` elements have a variety of useful [events](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement), including [play](https://developer.mozilla.org/en-US/docs/Web/Events/play) and
+  [pause](https://developer.mozilla.org/en-US/docs/Web/Events/pause) events that are emitted when the video is played or paused.
 
 ### The solution
 
@@ -224,15 +225,15 @@ either play or pause the video.
 
 ### What you need to know
 
-CanJS prefers to manage the state of your application in `ViewModel`. The `<video>` player has state such as
+CanJS prefers to manage the state of your application in [can-component.prototype.ViewModel]. The `<video>` player has state, such as
 if the video is `playing`.  When the _play/pause_ button is clicked, we want to update the state
-of the `ViewModel` and have the `ViewModel` update the state of the video player as a side effect.
+of the [can-component.prototype.ViewModel] and have the [can-component.prototype.ViewModel] update the state of the video player as a side effect.
 
 What this means is that instead of something like:
 
 ```js
-togglePlay(){
-  if( videoElement.paused ) {
+togglePlay() {
+  if ( videoElement.paused ) {
     videoElement.play()
   } else {
     videoElement.pause()
@@ -243,7 +244,7 @@ togglePlay(){
 We update the state like:
 
 ```js
-togglePlay(){
+togglePlay() {
   this.playing = !this.playing;
 }
 ```
@@ -251,8 +252,8 @@ togglePlay(){
 And listen to when `playing` changes and update the `video` element like:
 
 ```js
-viewModel.listenTo("playing", function(ev, isPlaying){
-  if( isPlaying ) {
+viewModel.listenTo("playing", function(event, isPlaying) {
+  if ( isPlaying ) {
     videoElement.play()
   } else {
     videoElement.pause()
@@ -263,33 +264,33 @@ viewModel.listenTo("playing", function(ev, isPlaying){
 
 This means that you need to:
 
-1. Listen to when the `<div>` is clicked and call a ViewModel method that updates the `playing` state.
+1. Listen to when the `<button>` is clicked and call a ViewModel method that updates the `playing` state.
 2. Listen to when the `playing` state changes and update the state of the `<video>` element.
 
 You already know everything you need to know for step __#1__.  
 
 For step __#2__, you need to use the [can-component/connectedCallback] lifecycle hook. This
-hook gives you access to the component's element and is a good place to do side-effects. Its use looks
+hook gives you access to the component’s element and is a good place to do side-effects. Its use looks
 like this:
 
 ```js
 ViewModel: {
-  ...
+  // ...
   connectedCallback(element) {
     // perform mischief
   }
 }
 ```
 
-`connectedCallback` gets called once the component's `element` is in the page. You can use
-[can-event-queue/map/map.listenTo] to listen to changes in the `ViewModel`'s properties and
+`connectedCallback` gets called once the component’s `element` is in the page. You can use
+[can-event-queue/map/map.listenTo] to listen to changes in the [can-component.prototype.ViewModel]’s properties and
 perform side-effects. The following listens to when `playing` changes:
 
 ```js
 ViewModel: {
-  ...
+  // ...
   connectedCallback(element) {
-    this.listenTo("playing", function(ev, isPlaying){
+    this.listenTo("playing", function(event, isPlaying) {
 
     })
   }
@@ -302,7 +303,7 @@ Use `querySelector` to get the `<video>` element from the `<video-player>` like:
 element.querySelector("video")
 ```
 
-`<video>` elements have a [.play()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play) and `.pause()` methods that can start and stop a video.
+`<video>` elements have a [.play()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play) and [.pause()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/pause) methods that can start and stop a video.
 
 
 ### The solution
@@ -330,7 +331,7 @@ formatted like: `mm:SS`. They should be presented within two spans like:
 
 1. Methods can be used to format values in [can-stache]. For example, you can uppercase values like  this:
 
-   ```HTML
+   ```html
    <span>{{upper(value)}}</span>
    ```
 
@@ -338,8 +339,8 @@ formatted like: `mm:SS`. They should be presented within two spans like:
 
    ```js
    ViewModel: {
-     ...
-     upper(value){
+     // ...
+     upper(value) {
        return value.toString().toUpperCase();
      }
    }
@@ -350,39 +351,37 @@ formatted like: `mm:SS`. They should be presented within two spans like:
    ```js
    formatTime(time) {
        if (time === null || time === undefined) {
-         return "--"
+         return "--";
        }
-       const durmins = Math.floor(time / 60);
-       let dursecs = Math.floor(time - durmins * 60);
-       if (dursecs < 10) {
-         dursecs = "0" + dursecs;
+       const minutes = Math.floor(time / 60);
+       let seconds = Math.floor(time - minutes * 60);
+       if (seconds < 10) {
+         seconds = "0" + seconds;
        }
-       return durmins + ":" + dursecs
+       return minutes + ":" + seconds;
    }
    ```
 
 2. Time is given as a number. Use the following to create a number property on
-   the `ViewModel`:
+   the [can-component.prototype.ViewModel]:
 
    ```js
    ViewModel: {
-     ...
+     // ...
      duration: "number",
      currentTime: "number"
    }
    ```
 
-3. `<video>` elements emit a `loadmetadata` event when they know how long
-   the video is. They also emit a `timeupdate` event when the video's current play position
+3. `<video>` elements emit a [loadmetadata event](https://developer.mozilla.org/en-US/docs/Web/Events/loadedmetadata) when they know how long
+   the video is. They also emit a [timeupdate event](https://developer.mozilla.org/en-US/docs/Web/Events/timeupdate) when the video’s current play position
    changes.
+   - `videoElement.duration` reads the duration of a video.
+   - `videoElement.currentTime` reads the current play position of a video.
 
-   `videoElement.duration` reads the duration of a video.
+4. You can get the element in an stache `on:event` binding with [can-stache/keys/scope#scope_element scope.element] like:
 
-   `videoElement.currentTime` reads the current play position of a video.
-
-4. You can get the element in an stache `on:event` binding with [can-stache/keys/scope].element like:
-
-   ```HTML
+   ```html
    <video on:timeupdate="updateTimes(scope.element)"/>
    ```
 
@@ -411,13 +410,14 @@ The `<input type="range"/>` element should be after the `<button>` and before th
 <input type="range"/>
 <span>{{formatTime(currentTime)}}</span> /
 ```
+@highlight 2
 
 ### What you need to know
 
 - The range input can have an initial value, max value, and step size
   specified like:
 
-  ```HTML
+  ```html
   <input type="range" value="0" max="1" step="any"/>
   ```
 
@@ -426,14 +426,14 @@ The `<input type="range"/>` element should be after the `<button>` and before th
 
   ```js
   ViewModel: {
-    ...
+    // ...
     get percentComplete() {
       return this.currentTime / this.duration;
     },
   }
   ```
 
-- Use [can-stache-bindings.toChild] to update a value from a ViewModel property like:
+- Use [can-stache-bindings.toChild] to update a value from a [can-component.prototype.ViewModel] property like:
   ```html
   <input value:from="percentComplete"/>
   ```
@@ -452,32 +452,32 @@ Update the __JavaScript__ tab to:
 
 In this section we will:
 
-- Remove the native controls from the video player.  We don't need them anymore!
+- Remove the native controls from the video player.  We don’t need them anymore!
 - Make it so when a user moves the range slider, the video position updates.
 
 ### What you need to know
 
 Similar to when we [made the play/pause button play or pause the video](#Makeclickingtheplay_pausebuttonplayorpausethevideo), we will want to update the
 `currentTime` property and then listen to when `currentTime` changes and update the  `<video>`
-element's `currentTime` as a _side-effect_.
+element’s `currentTime` as a _side-effect_.
 
 This time, we need to translate the sliders values between 0 and 1 to `currentTime`
 values. We can do this by creating a `percentComplete` [can-define.types.set setter] that updates `currentTime` like:
 
 ```js
-ViewModel:{
-  ...
+ViewModel: {
+  // ...
   get percentComplete() {
     return this.currentTime / this.duration;
   },
   set percentComplete(newVal) {
     this.currentTime = newVal * this.duration;
   },
-  ...
+  // ...
 }
 ```
 
-Use [can-stache-bindings.twoWay] to two-way bind a value to a `ViewModel` property:
+Use [can-stache-bindings.twoWay] to two-way bind a value to a [can-component.prototype.ViewModel] property:
 
 ```html
 <input value:bind="someViewModelProperty"/>
@@ -489,7 +489,14 @@ Use [can-stache-bindings.twoWay] to two-way bind a value to a `ViewModel` proper
 Update the __JavaScript__ tab to:
 
 @sourceref ./6-play-mutates.js
-@highlight 4,16,30-32,67-69,only
+@highlight 4,16,30-32,67-72,only
 
+## Result
 
-<script src="https://static.jsbin.com/js/embed.min.js?4.1.2"></script>
+When finished, you should see something like the following JS Bin:
+
+<a class="jsbin-embed" href="https://jsbin.com/jaliquj/8/embed?html,js,output">
+  CanJS Video Player on jsbin.com
+</a>
+
+<script src="https://static.jsbin.com/js/embed.min.js?4.1.4"></script>

--- a/docs/can-guides/introduction/comparison.md
+++ b/docs/can-guides/introduction/comparison.md
@@ -36,7 +36,7 @@ Suddenly, the strict unidirectional data flow, is no longer that easy to follow,
 
 ```javascript
 const ViewModel = DefineMap.extend({
-  subreddit: 'string',
+  subreddit: "string",
   posts: {
     get(lastSetValue, resolve) {
       this.postPromise
@@ -131,8 +131,8 @@ One-Way data flow may be simpler to follow, but you end up writing a lot more co
 ```javascript
 // Binding to a Todo models completed property
 const Todo = DefineMap.extend({
-  name: 'string',
-  completed: 'boolean'
+  name: "string",
+  completed: "boolean"
 });
 
 // In stache


### PR DESCRIPTION
- Fix a perf issue with updating the video’s current time
- Various little fixes, like consistently using double quotes, fixing the highlighting for some code blocks, etc.