### PR TITLE
Fix a bunch of the can-component demos

### DIFF
--- a/demos/can-component/accordion.html
+++ b/demos/can-component/accordion.html
@@ -88,17 +88,16 @@ Component.extend({
 			type: "boolean",
 			default: false
 		},
-		title: "string"
-	}),
-	events: {
-		inserted: function(){
-			var vm = this.parentViewModel = canViewModel(this.element.parentNode);
-			vm.addPanel(this.viewModel);
-		},
-		removed: function(){
-			this.parentViewModel.removePanel(this.viewModel);
+		title: "string",
+		connectedCallback: function(element) {
+			var panel = this;
+			var parentViewModel = canViewModel(element.parentNode);
+			parentViewModel.addPanel(panel);
+			return function() {
+				parentViewModel.removePanel(panel);
+			};
 		}
-	}
+	})
 });
 
 var out = document.getElementById("out");

--- a/demos/can-component/my_greeting_full.html
+++ b/demos/can-component/my_greeting_full.html
@@ -19,7 +19,7 @@ Component.extend({
 	view: stache("<h1><content/> - {{title}}</h1>"),
 	ViewModel: DefineMap.extend({
 		title: {
-			value: "can-component"
+			default: "can-component"
 		}
 	})
 });

--- a/demos/can-component/paginate_events_next.html
+++ b/demos/can-component/paginate_events_next.html
@@ -10,10 +10,10 @@ var DefineMap = require("can-define/map/map");
 
 var ViewModel = DefineMap.extend({
 	offset: {
-		value: 0
+		default: 0
 	},
 	limit: {
-		value: 20
+		default: 20
 	},
 	page: {
 		get: function(){

--- a/demos/can-component/paginate_next.html
+++ b/demos/can-component/paginate_next.html
@@ -10,10 +10,10 @@ var DefineMap = require("can-define/map/map");
 
 var ViewModel = DefineMap.extend({
 	offset: {
-		value: 0
+		default: 0
 	},
 	limit: {
-		value: 20
+		default: 20
 	},
 	next: function(){
 		this.offset = this.offset + this.limit;

--- a/demos/can-component/paginate_next_event.html
+++ b/demos/can-component/paginate_next_event.html
@@ -10,7 +10,7 @@
   <ul>
   	{{#each(players, player=value)}}
   		<li {{#scope.root.isEditing(player)}}class="editing"{{/isEditing}}
-  			on:click='editPlayer(player)'>{{player.name}}</li>
+  			on:click='scope.root.editPlayer(player)'>{{player.name}}</li>
   	{{/each}}
   </ul>
   <player-edit
@@ -19,7 +19,7 @@
 </script>
 <script id="player-edit-stache" type="text/stache">
 	{{#if(player)}}
-		<input default:bind="player.name"/>
+		<input value:bind="player.name"/>
 		<button on:click="close()">X</button>
 	{{/if}}
 </script>

--- a/demos/can-component/tabs.html
+++ b/demos/can-component/tabs.html
@@ -48,10 +48,18 @@ var DefineList = require("can-define/list/list");
 var canViewModel = require("can-view-model");
 var queues = require("can-queues");
 
-var Panel = DefineMap.extend({
+var Panel = DefineMap.extend({seal: false}, {
 	active: {
 		type: "boolean",
-		value: false
+		default: false
+	},
+	connectedCallback: function(element) {
+		var panel = this;
+		var parentViewModel = canViewModel(element.parentNode);
+		parentViewModel.addPanel(panel);
+		return function() {
+			parentViewModel.removePanel(panel);
+		};
 	}
 });
 
@@ -130,16 +138,7 @@ Component.extend({
 Component.extend({
 	view: stache("{{#if(active)}}<content></content>{{/if}}"),
 	tag:"my-panel",
-	ViewModel: Panel,
-	events: {
-		inserted: function(){
-			var vm = this.parentViewModel = canViewModel(this.element.parentNode);
-			vm.addPanel(this.viewModel);
-		},
-		removed: function(){
-			this.parentViewModel.removePanel(this.viewModel);
-		}
-	}
+	ViewModel: Panel
 });
 
 var foodTypes = new DefineList([

--- a/demos/can-component/tabs.html
+++ b/demos/can-component/tabs.html
@@ -48,7 +48,7 @@ var DefineList = require("can-define/list/list");
 var canViewModel = require("can-view-model");
 var queues = require("can-queues");
 
-var Panel = DefineMap.extend({seal: false}, {
+var Panel = DefineMap.extend("Panel", {
 	active: {
 		type: "boolean",
 		default: false

--- a/demos/can-component/treecombo.html
+++ b/demos/can-component/treecombo.html
@@ -43,17 +43,17 @@
   <ul class='breadcrumb'>
     <li on:click='emptyBreadcrumb()'>{{title}}</li>
     {{#each(breadcrumb)}}
-      <li on:click='updateBreadcrumb(this)'>{{title}}</li>
+      <li on:click='scope.root.updateBreadcrumb(this)'>{{title}}</li>
     {{/each}}
   </ul>
   <ul class='options'>
     <content>
       {{#selectableItems}}
-        <li {{#scope.root.isSelected(this)}}class='active'{{/isSelected}} on:click='toggle(this)'>
+        <li {{#scope.root.isSelected(this)}}class='active'{{/isSelected}} on:click='scope.root.toggle(this)'>
           <input type='checkbox' {{#scope.root.isSelected(this)}}checked{{/isSelected}}/>
             {{title}}
           {{#if(children.length)}}
-            <button class='showChildren' on:click='showChildren(.,scope.event)'>+</button>
+            <button class='showChildren' on:click='scope.root.showChildren(.,scope.event)'>+</button>
           {{/if}}
         </li>
       {{/selectableItems}}


### PR DESCRIPTION
Some of them were still using the inserted & removed events; others were still trying to rely on scope walking.

I realize the use of `scope.root` is deprecated; I opened up an issue to update everything after 4.3 is released: https://github.com/canjs/canjs/issues/4157