### PR TITLE
Fix demos to remove `~` and fix issue with inList demo checkboxes not…

### DIFF
--- a/demos/can-stache-converters/index-to-selected.html
+++ b/demos/can-stache-converters/index-to-selected.html
@@ -4,7 +4,7 @@
 </head>
 <body>
 <script type="text/stache" id="demo-html">
-<select value:bind="index-to-selected(~person, people)">
+<select value:bind="index-to-selected(person, people)">
 
 {{#each(people)}}
   <option value="{{scope.index}}">{{this}}</option>

--- a/demos/can-stache-converters/input-checkbox-binary.html
+++ b/demos/can-stache-converters/input-checkbox-binary.html
@@ -1,7 +1,7 @@
 <div id='out'></div>
 <script type="text/stache" id="demo-html">
 <label>
-	<input type='checkbox' checked:bind='either-or(~pref, "Star Trek", "Star Wars")' />
+	<input type='checkbox' checked:bind='either-or(pref, "Star Trek", "Star Wars")' />
 	Star Trek
 </label>
 <p>Your fandom: {{pref}}</p>

--- a/demos/can-stache-converters/input-checkbox.html
+++ b/demos/can-stache-converters/input-checkbox.html
@@ -2,11 +2,11 @@
 <script type="text/stache" id="demo-html">
 {{#each(items)}}
 	<label>
-		<input type='checkbox' checked:bind='boolean-to-inList(this, person.owns)' />
+		<input type='checkbox' checked:bind='boolean-to-inList(this, ../person.owns)' />
 		{{upper(this)}}
 	</label>
 {{/each}}
-<p>You own: {{ownership}}</p>
+<p>You own: {{ownership()}}</p>
 </script>
 <script src="../../node_modules/steal/steal.js" deps-bundle main="@empty">
 var DefineMap = require("can-define/map/map");

--- a/demos/can-stache-converters/input-radio.html
+++ b/demos/can-stache-converters/input-radio.html
@@ -7,9 +7,9 @@
 </p>
 <br>
 <p>Attending?
-  <input type="radio" checked:bind="equal(~attending, 'yes')" /> Yes
-  <input type='radio' checked:bind="equal(~attending, 'no')" /> No,
-  <input type='radio' checked:bind="equal(~attending, 'maybe')" /> Maybe
+  <input type="radio" checked:bind="equal(attending, 'yes')" /> Yes
+  <input type='radio' checked:bind="equal(attending, 'no')" /> No,
+  <input type='radio' checked:bind="equal(attending, 'maybe')" /> Maybe
 </p>
 <p>You {{attendence}}.</p>
 </script>

--- a/demos/can-stache-converters/selected-to-index.html
+++ b/demos/can-stache-converters/selected-to-index.html
@@ -10,7 +10,7 @@
   {{/each}}
 </select>
 
-<input value:bind="selected-to-index(~index, people)">
+<input value:bind="selected-to-index(index, people)">
 </script>
 <script src="../../node_modules/steal/steal.js" deps-bundle main="@empty">
 var DefineMap = require("can-define/map/map");


### PR DESCRIPTION
… working

Fixes: https://github.com/canjs/can-stache-converters/issues/79