### PR TITLE
Fix can-event-queue exports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,15 +17,6 @@ publish-docs:
 	git add -f node_modules/funcunit
 	git add -f node_modules/syn
 	git add -f node_modules/kefir
-	# React Deps Start
-	git add -f node_modules/react
-	git add -f node_modules/react-dom
-	git add -f node_modules/react-view-model
-	git add -f node_modules/fbjs
-	git add -f node_modules/loose-envify
-	git add -f node_modules/object-assign
-	git add -f node_modules/prop-types
-	# React Deps End
 	# git add -f node_modules/socket.io-client
 	# git add -f node_modules/feathers/package.json
 	# git add -f node_modules/feathers-authentication-client/package.json

--- a/core.js
+++ b/core.js
@@ -9,7 +9,7 @@ export { default as SimpleMap } from "./es/can-simple-map";
 
 // -> Infrastruture
 export { default as bind } from "./es/can-bind";
-export { default as eventQueue } from "./es/can-event-queue";
+export { mapEventBindings, valueEventBindings } from "./es/can-event-queue";
 export { default as SimpleObservable } from "./es/can-simple-observable";
 
 

--- a/es/can-event-queue.js
+++ b/es/can-event-queue.js
@@ -1,1 +1,2 @@
-export {default} from "can-event-queue";
+export {default as mapEventBindings} from "can-event-queue/map/map";
+export {default as valueEventBindings} from "can-event-queue/value/value";


### PR DESCRIPTION
This fixes these particular exports to use their inner modules rather
than importing directly from can-event-queue which gives a warning.

This is part of #4241