### PR TITLE
Adds can-make-map to dependencies and exports RouteMock

### DIFF
--- a/ecosystem.js
+++ b/ecosystem.js
@@ -22,6 +22,10 @@ export { default as fixtureSocket } from "./es/can-fixture-socket";
 export { default as ndjsonStream } from "./es/can-ndjson-stream";
 
 
+// Routing
+export { default as RouteMock } from "./es/can-route-mock";
+
+
 // Data Validation
 export { default as defineValidateValidatejs } from "./es/can-define-validate-validatejs";
 export { default as validate } from "./es/can-validate";

--- a/es/can-route-mock.js
+++ b/es/can-route-mock.js
@@ -1,0 +1,1 @@
+export {default} from "can-route-mock";

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "can-list": "4.1.0",
     "can-local-store": "1.0.0",
     "can-log": "1.0.0",
+    "can-make-map": "1.0.1",
     "can-map": "4.1.1",
     "can-map-define": "4.2.0",
     "can-memory-store": "1.0.0",
@@ -140,10 +141,8 @@
   },
   "devDependencies": {
     "bit-docs": "0.0.11",
-    "can-make-map": "^1.0.1",
     "can-reflect-tests": "<2.0.0",
     "can-test-helpers": "^1.1.1",
-    "can-route-mock": "<2.0.0",
     "es6-promise-polyfill": "^1.2.0",
     "feathers": "^2.0.3",
     "feathers-authentication-client": "^0.1.6",


### PR DESCRIPTION
This does two things:

1. can-route-mock is not exported as an ecosystem package.
2. can-make-map is pushed to dependencies instead of devDeps.