### PR TITLE
Copy the global builds over

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,13 @@
     "release:patch": "npm version patch && npm run build && npm publish",
     "release:minor": "npm version minor && npm run build && npm publish",
     "release:major": "npm version major && npm run build && npm publish",
-    "build": "node build.js",
+    "build": "node build.js && npm run make-copy-of-globals-for-can4-compat",
     "build-tests": "node test/build.js",
     "build-webpack-test": "webpack -o test/builders/webpack/bundle.js test/builders/webpack/index.js",
     "document": "npm run deps-bundle && bit-docs",
     "document:force": "npm run deps-bundle && bit-docs -fd",
-    "deps-bundle": "node build-dev-bundle"
+    "deps-bundle": "node build-dev-bundle",
+    "make-copy-of-globals-for-can4-compat": "echo 'console.warn(\"This build is deprecated. Please update your URLs to the version of CanJS you intend to use, such as https://unpkg.com/can@4/dist/global/can.js\");' | cat - dist/global/core.js > dist/global/can.js && echo 'console.warn(\"This build is deprecated. Please update your URLs to the version of CanJS you intend to use, such as https://unpkg.com/can@4/dist/global/can.all.js\");' | cat - dist/global/ecosystem.js > dist/global/can.all.js"
   },
   "title": "CanJS",
   "description": "MIT-licensed, client-side, JavaScript framework that makes building rich web applications easy.",


### PR DESCRIPTION
This makes a copy of the global builds for can4 compat and adds a warning to the top. Closes #4295