### PR TITLE
using mac-os high sierra in saucelabs

### DIFF
--- a/test/test-sauce-labs.js
+++ b/test/test-sauce-labs.js
@@ -17,7 +17,7 @@ var platforms = [/*{
 	idleTimeout: idleTimeout
 }, */{
 	browserName: 'safari',
-	platform: 'OS X 10.12',
+	platform: 'OS X 10.13',
 	version: 'latest',
 	maxDuration: maxDuration,
 	commandTimeout: commandTimeout,


### PR DESCRIPTION
This fixes a `Value is not a sequence` webdriver error that happens in Safari on macOS Sierra during our SauceLabs tests.