### PR TITLE
Exit with an error when the deps-bundle script fails

### DIFF
--- a/build-dev-bundle.js
+++ b/build-dev-bundle.js
@@ -1,9 +1,12 @@
 var path = require("path");
 var stealTools = require("steal-tools");
 
-var promise = stealTools.bundle({
+stealTools.bundle({
   config: path.join(__dirname, "package.json!npm")
 }, {
   filter: [ "**/*", "package.json" ],
   minify: true
+}).catch(function(error) {
+  console.error(error);
+  process.exit(1);
 });


### PR DESCRIPTION
Previously, if you ran the deps-bundle script and steal-tools reported an error, the script would still exit successfully and the next script would run (e.g. when building the site/docs). This would leave you with an out-of-date (or non-existent) dev-bundle.

This fixes the issue by catching any errors reported by steal-tools and exiting the script in a way that will make Node report the error and stop.