### PR TITLE
Upgrade bit-docs-generate-html

### DIFF
--- a/package.json
+++ b/package.json
@@ -230,7 +230,7 @@
       "bit-docs-dev": "^0.0.3",
       "bit-docs-js": "^0.0.6",
       "bit-docs-tag-sourceref": "^0.0.3",
-      "bit-docs-generate-html": "^0.8.0",
+      "bit-docs-generate-html": "^0.11.0",
       "bit-docs-generate-searchmap": "^0.2.0",
       "bit-docs-html-canjs": "^2.4.1",
       "bit-docs-prettify": "^0.3.0",


### PR DESCRIPTION
This fixes the issue with `<content>` not showing up correctly in the docs.

Before:
<img width="436" alt="before" src="https://user-images.githubusercontent.com/10070176/43730222-8733a350-995f-11e8-8ee2-d4087d2917d1.png">

After:
<img width="515" alt="after" src="https://user-images.githubusercontent.com/10070176/43730228-8b919286-995f-11e8-9d71-b93b5be785e5.png">

Closes https://github.com/canjs/canjs/issues/4142