### PR TITLE
adding domMutateNode and domMutateDomEvents to ES Module exports

### DIFF
--- a/core.js
+++ b/core.js
@@ -81,7 +81,7 @@ export { default as attributeEncoder } from "./es/can-attribute-encoder";
 export { default as childNodes } from "./es/can-child-nodes";
 export { default as Control } from "./es/can-control";
 export { default as domEvents } from "./es/can-dom-events";
-export { default as domMutate } from "./es/can-dom-mutate";
+export { default as domMutate, domMutateNode, domMutateDomEvents } from "./es/can-dom-mutate";
 export { default as fragment } from "./es/can-fragment";
 
 

--- a/es/can-dom-mutate.js
+++ b/es/can-dom-mutate.js
@@ -1,1 +1,3 @@
 export {default} from "can-dom-mutate";
+export {default as domMutateNode} from "can-dom-mutate/node";
+export {default as domMutateDomEvents} from "can-dom-mutate/dom-events";

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "can-dom-data": "1.0.1",
     "can-dom-data-state": "1.0.1",
     "can-dom-events": "1.3.0",
-    "can-dom-mutate": "1.1.0",
+    "can-dom-mutate": "1.2.0",
     "can-event-dom-enter": "2.2.0",
     "can-event-dom-radiochange": "2.2.0",
     "can-event-queue": "1.1.0",


### PR DESCRIPTION
This allows you to add and use `inserted`/`removed` events like:

```js
import { Component, domEvents, domMutateDomEvents, domMutateNode } from "can";

domEvents.addEvent(domMutateDomEvents.inserted);
domEvents.addEvent(domMutateDomEvents.removed);

...

domMutateNode.appendChild.call(document.body, p); 
```

closes https://github.com/canjs/canjs/issues/4334.