### PR TITLE
Add can-map-compat, an ecosystem package

### DIFF
--- a/ecosystem.js
+++ b/ecosystem.js
@@ -7,6 +7,7 @@ export { default as kefir } from "./es/can-kefir";
 export { default as observe } from "./es/can-observe";
 export { default as stream } from "./es/can-stream";
 export { default as streamKefir } from "./es/can-stream-kefir";
+export { default as makeMapCompat } from "./es/can-map-compat";
 
 
 // Views

--- a/es/can-map-compat.js
+++ b/es/can-map-compat.js
@@ -1,0 +1,1 @@
+export {default} from "can-map-compat";

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "can-log": "1.0.0",
     "can-make-map": "1.2.0",
     "can-map": "4.3.3",
+    "can-map-compat": "1.0.1",
     "can-map-define": "4.3.3",
     "can-memory-store": "1.0.0",
     "can-namespace": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "can-log": "1.0.0",
     "can-make-map": "1.2.0",
     "can-map": "4.3.3",
-    "can-map-compat": "1.0.1",
+    "can-map-compat": "1.1.0",
     "can-map-define": "4.3.3",
     "can-memory-store": "1.0.0",
     "can-namespace": "1.0.0",


### PR DESCRIPTION
This adds `can-map-compat`, an ecosystem package that adds `attr()` and
`removeAttr()` to observable map type, for easier migration away from
can-map.