### PR TITLE
Upgrade to steal-tools 2.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "steal-qunit": "^1.0.1",
     "steal-socket.io": "^4.0.9",
     "steal-stache": "^4.0.0",
-    "steal-tools": "^2.0.0-pre.9",
+    "steal-tools": "^2.0.4",
     "test-saucelabs": "0.0.6",
     "testee": "^0.8.1",
     "webpack": "^4.12.0",


### PR DESCRIPTION
This fixes the issue with development code not being removed from the ES
module build.

Fixes #4394