### PR TITLE
Adds can-connect-ndjson as an ecosystem package

### DIFF
--- a/ecosystem.js
+++ b/ecosystem.js
@@ -21,6 +21,7 @@ export { default as connectFeathers } from "./es/can-connect-feathers";
 export { default as connectTag } from "./es/can-connect-tag";
 export { default as fixtureSocket } from "./es/can-fixture-socket";
 export { default as ndjsonStream } from "./es/can-ndjson-stream";
+export { default as connectNDJSON } from "./es/can-connect-ndjson";
 
 
 // Routing

--- a/es/can-connect-ndjson.js
+++ b/es/can-connect-ndjson.js
@@ -1,0 +1,1 @@
+export {default} from "can-connect-ndjson";

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "can-compute": "4.1.0",
     "can-connect": "3.0.2",
     "can-connect-feathers": "5.0.0",
+    "can-connect-ndjson": "1.0.0",
     "can-connect-tag": "1.0.0",
     "can-construct": "3.5.1",
     "can-construct-super": "3.2.0",


### PR DESCRIPTION
This adds back can-connect-ndjson, which is now compatible with canjs 5.