### PR TITLE
As of NPM, `npm cache clean` is automated

### DIFF
--- a/docs/can-guides/contribute/releasing-canjs.md
+++ b/docs/can-guides/contribute/releasing-canjs.md
@@ -73,7 +73,7 @@ To make a release:
    ```
    git checkout master
    git fetch --all && git rebase
-   npm cache clean
+   npm cache verify
    rm -rf node_modules
    npm install
    ```


### PR DESCRIPTION
Received the following error when following the patch instructions above, updating to `npm cache verify`
```
As of npm@5, the npm cache self-heals from corruption issues and data extracted from the cache is guaranteed to be valid. If you want to make sure everything is consistent, use 'npm cache verify' instead.
```
you can do `npm cache clean --force` but verify seems better