### PR TITLE
Upgrades to can-view-scope 4.9 and can-stache 4.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "can-simple-dom": "1.4.2",
     "can-simple-map": "4.3.0",
     "can-simple-observable": "2.2.0",
-    "can-stache": "4.11.3",
+    "can-stache": "4.12.0",
     "can-stache-bindings": "4.4.0",
     "can-stache-converters": "4.2.4",
     "can-stache-key": "1.4.0",
@@ -141,7 +141,7 @@
     "can-view-model": "4.0.1",
     "can-view-nodelist": "4.3.2",
     "can-view-parser": "4.1.0",
-    "can-view-scope": "4.8.2",
+    "can-view-scope": "4.9.0",
     "can-view-target": "4.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This adds support for the `scope/key` syntax in stache.