### PR TITLE
fix typos in Routing guide code

### DIFF
--- a/docs/can-guides/experiment/technology/routing.md
+++ b/docs/can-guides/experiment/technology/routing.md
@@ -733,9 +733,9 @@ Component.extend({
                     });
             }
 
-            return import(`can/demos/technology-overview/page-${this.page}`)
+            return import(`can/demos/technology-overview/page-${this.routeData.page}`)
                 .then((module) => {
-                    switch(this.page) {
+                    switch(this.routeData.page) {
                         case "home":
                             return new module.default({
                                 viewModel: {
@@ -746,7 +746,7 @@ Component.extend({
                         case "tasks":
                             return new module.default({
                                 viewModel: {
-                                    id: value.from(this, "taskId"),
+                                    id: value.from(this.routeData, "taskId"),
                                     logout: this.logout.bind(this)
                                 }
                             });


### PR DESCRIPTION
This fixes 2 typos in the Routing guide code for the last snippets:
```js
return import(`can/demos/technology-overview/page-${this.routeData.page}`)
```
instead of : 
```js
return import(`can/demos/technology-overview/page-${this.page}`)
```

And :
```js
case "tasks":
    return new module.default({
         viewModel: {
             id: value.from(this.routeData, "taskId"),
             logout: this.logout.bind(this)
         }
});
```

Instead of:
```js
case "tasks":
    return new module.default({
         viewModel: {
             id: value.from(this, "taskId"),
             logout: this.logout.bind(this)
         }
});
```
