### PR TITLE
Update can-define.js

### DIFF
--- a/es/can-define.js
+++ b/es/can-define.js
@@ -1,3 +1,3 @@
-export { default as define } from "can-define";
+export { default as define, default } from "can-define";
 export { default as DefineMap } from "can-define/map/map";
 export { default as DefineList } from "can-define/list/list";


### PR DESCRIPTION
can-define needs still a default export because of EMCA Loader Specs else it gets harder to require it