### PR TITLE
Promote steal-stache to being a dependency of can

### DIFF
--- a/docs/can-guides/commitment/recipes/todomvc-with-steal/1-setup/package.json
+++ b/docs/can-guides/commitment/recipes/todomvc-with-steal/1-setup/package.json
@@ -16,11 +16,10 @@
   },
   "steal": {
     "plugins": [
-      "steal-css","steal-stache"
+      "steal-css","can"
     ]
   },
   "dependencies": {
-    "can": "^5.2.2",
-    "steal-stache": "^4.1.2"
+    "can": "^5.2.2"
   }
 }

--- a/docs/can-guides/setup/setting-up-canjs.md
+++ b/docs/can-guides/setup/setting-up-canjs.md
@@ -381,10 +381,10 @@ __Model Example__
 
 </div>
 
-[After setting up Node.js and npm](#Node_jsandnpm), install `can`, [StealJS](https://stealjs.com) and the [steal-stache] plugin from npm:
+[After setting up Node.js and npm](#Node_jsandnpm), install `can` and [StealJS](https://stealjs.com) from npm:
 
 ```
-npm install can@5 steal@2 steal-stache@4 --save
+npm install can@5 steal@2 --save
 ```
 
 Next, add the following [steal configuration](https://stealjs.com/docs/StealJS.configuration.html)
@@ -401,15 +401,14 @@ to your `package.json`:
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "steal": {
-    "plugins": ["steal-stache"]
+    "plugins": ["can"]
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
     "can": "^5.0.0",
-    "steal": "^2.0.0",
-    "steal-stache": "^4.1.0"
+    "steal": "^2.0.0"
   },
   "devDependencies": {
     "http-server": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -142,7 +142,8 @@
     "can-view-nodelist": "4.3.2",
     "can-view-parser": "4.1.2",
     "can-view-scope": "4.13.0",
-    "can-view-target": "4.1.2"
+    "can-view-target": "4.1.2",
+    "steal-stache": "4.1.2"
   },
   "devDependencies": {
     "bit-docs": "0.0.11",
@@ -171,7 +172,6 @@
     "steal-css": "^1.2.4",
     "steal-qunit": "^1.0.1",
     "steal-socket.io": "^4.0.9",
-    "steal-stache": "^4.0.0",
     "steal-tools": "^2.0.6",
     "test-saucelabs": "0.0.6",
     "testee": "^0.8.1",
@@ -209,6 +209,9 @@
     },
     "configDependencies": [
       "./node_modules/steal-conditional/conditional.js"
+    ],
+    "plugins": [
+      "steal-stache"
     ]
   },
   "bit-docs": {

--- a/test/builders/steal/main.js
+++ b/test/builders/steal/main.js
@@ -1,0 +1,13 @@
+import view from "./template.stache";
+
+steal.import("can-component").then(function(Component) {
+	Component.extend({
+		tag: "my-app",
+		view: view,
+		ViewModel: {}
+	});
+
+	if(window.DONE) {
+		window.DONE();
+	}
+});

--- a/test/builders/steal/site.html
+++ b/test/builders/steal/site.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<title>steal-stache smoke test</title>
+
+<my-app></my-app>
+
+<script src="../../../node_modules/steal/steal.js"
+	data-main="~/test/builders/steal/main"></script>
+
+<script>
+(function(){
+	var QUnit = window.parent.QUnit;
+	var removeMyself = window.parent.removeMyself;
+
+	window.DONE = function() {
+		var myApp = document.querySelector('my-app');
+
+		if(QUnit) {
+			QUnit.equal(myApp.textContent.trim(), "Hello world");
+			removeMyself();
+		}
+	};
+})();
+</script>

--- a/test/builders/steal/template.stache
+++ b/test/builders/steal/template.stache
@@ -1,0 +1,1 @@
+Hello world

--- a/test/builders/test.js
+++ b/test/builders/test.js
@@ -20,3 +20,9 @@ QUnit.asyncTest("Able to load an app", function(){
 QUnit.asyncTest("Unabled modules are tree-shaken out", function(){
 	makeIframe(__dirname + "/webpack/treeshake.html?" + Math.random());
 });
+
+QUnit.module("steal-stache");
+
+QUnit.asyncTest("Able to load .stache files", function(){
+	makeIframe(__dirname + "/steal/site.html?" + Math.random());
+});


### PR DESCRIPTION
This will be a minor release. This adds `steal-stache` as a dependency
of can. This prevents the need to separately install steal-stache and
prevents issues when upgrading can but not steal-stache.

After this change users should remove `steal-stache` from their
dependencies and change their package.json from:

```js
{
  ...
  "steal": {
    "plugins": [
      "steal-stache"
    ]
  }
}
```

to:

```js
{
  ...
  "steal": {
    "plugins": [
      "can"
    ]
  }
}
```