### PR TITLE
add stealjs example repo

### DIFF
--- a/docs/can-guides/setup/setting-up-canjs.md
+++ b/docs/can-guides/setup/setting-up-canjs.md
@@ -373,13 +373,8 @@ __Model Example__
 
 ## StealJS
 
-<div style="display:none">
-
 > You can skip these instructions by
 > [cloning this example repo on GitHub](https://github.com/canjs/stealjs-example).
-
-
-</div>
 
 [After setting up Node.js and npm](#Node_jsandnpm), install `can` and [StealJS](https://stealjs.com) from npm:
 


### PR DESCRIPTION
This fixes #4679

### The changes:
The needed part was in the markdown document but wrapped in ```<div style="display:none">...</div>``` the change I made is removing the wrapping ```div```.