### PR TITLE
use jquery and jquery-ui from cdn

### DIFF
--- a/demos/can-view-callbacks/dynamic_tooltip.html
+++ b/demos/can-view-callbacks/dynamic_tooltip.html
@@ -6,8 +6,8 @@
 </style>
 <my-demo></my-demo>
 <link rel="stylesheet" href="../../node_modules/jquery-ui/themes/base/all.css" />
-<script src="//code.jquery.com/jquery-3.3.1.min.js"></script>
-<script src="//code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
+<script type="text/javascript" src="//code.jquery.com/jquery-3.3.1.min.js"></script>
+<script type="text/javascript" src="//code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
 <script src="../../node_modules/steal/steal.js" dev-bundle main="@empty">
 
 import { Component, viewCallbacks, domMutate } from "can";

--- a/demos/can-view-callbacks/fade_in_when.html
+++ b/demos/can-view-callbacks/fade_in_when.html
@@ -1,4 +1,6 @@
 <link rel="stylesheet" href="../../node_modules/jquery-ui/themes/base/all.css" />
+<script type="text/javascript" src="//code.jquery.com/jquery-3.3.1.min.js"></script>
+<script type="text/javascript" src="//code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
 <div id="app"></div>
 <script type="text/stache" id="demo-html">
 <button toggle="showing">
@@ -12,8 +14,6 @@
 <script src="../../node_modules/steal/steal.js" dev-bundle main="@empty">
 import { DefineList, DefineMap, domEvents, SimpleObservable,
 	stache, stacheBindings, viewCallbacks } from "can";
-import $ from "jquery";
-import "jquery-ui/ui/widgets/tooltip";
 
 viewCallbacks.attr("toggle", function(el, attrData) {
 	var attrValue = el.getAttribute("toggle");

--- a/demos/can-view-callbacks/tooltip.html
+++ b/demos/can-view-callbacks/tooltip.html
@@ -8,6 +8,8 @@
 	}
 </style>
 <link rel="stylesheet" href="../../node_modules/jquery-ui/themes/base/all.css" />
+<script type="text/javascript" src="//code.jquery.com/jquery-3.3.1.min.js"></script>
+<script type="text/javascript" src="//code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
 <div id="app"></div>
 <script type="text/stache" id="demo-html">
 <pre>
@@ -22,8 +24,6 @@ canViewCallbacks.attr(<span tooltip="The attribute name to match.">"tooltip"</sp
 
 <script src="../../node_modules/steal/steal.js" dev-bundle main="@empty">
 import { stache, viewCallbacks } from "can";
-import $ from "jquery";
-import "jquery-ui/ui/widgets/tooltip";
 
 viewCallbacks.attr("tooltip", (el, attrData) => {
 	$(el).tooltip({


### PR DESCRIPTION
Fixes #4726 

### The changes:
This fix jquery and jquery-ui dependency in the `can-view-callbacks.attr` demo by loading them from cdn instead of being imported.