### PR TITLE
add domData to core

### DIFF
--- a/core.js
+++ b/core.js
@@ -83,6 +83,7 @@ export { default as Control } from "./es/can-control";
 export { default as domEvents, addJQueryEvents } from "./es/can-dom-events";
 export { default as domMutate, domMutateNode, domMutateDomEvents } from "./es/can-dom-mutate";
 export { default as fragment } from "./es/can-fragment";
+export { default as domData } from "./es/can-dom-data";
 
 
 // __ Data Validation

--- a/core.js
+++ b/core.js
@@ -80,8 +80,8 @@ export { default as ajax } from "./es/can-ajax";
 export { default as attributeEncoder } from "./es/can-attribute-encoder";
 export { default as childNodes } from "./es/can-child-nodes";
 export { default as Control } from "./es/can-control";
-export { default as domEvents, addJQueryEvents } from "./es/can-dom-events";
 export { default as domData } from "./es/can-dom-data";
+export { default as domEvents, addJQueryEvents } from "./es/can-dom-events";
 export { default as domMutate, domMutateNode, domMutateDomEvents } from "./es/can-dom-mutate";
 export { default as fragment } from "./es/can-fragment";
 

--- a/core.js
+++ b/core.js
@@ -81,9 +81,9 @@ export { default as attributeEncoder } from "./es/can-attribute-encoder";
 export { default as childNodes } from "./es/can-child-nodes";
 export { default as Control } from "./es/can-control";
 export { default as domEvents, addJQueryEvents } from "./es/can-dom-events";
+export { default as domData } from "./es/can-dom-data";
 export { default as domMutate, domMutateNode, domMutateDomEvents } from "./es/can-dom-mutate";
 export { default as fragment } from "./es/can-fragment";
-export { default as domData } from "./es/can-dom-data";
 
 
 // __ Data Validation

--- a/es/can-dom-data.js
+++ b/es/can-dom-data.js
@@ -1,0 +1,1 @@
+export { default } from "can-dom-data";


### PR DESCRIPTION
This exports `can-dom-data` from the `canjs/core.js`

Fixes #4777 