### PR TITLE
fix(package): update can-dom-events to version 1.3.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "can-diff": "1.4.4",
     "can-dom-data": "1.0.1",
     "can-dom-data-state": "1.0.5",
-    "can-dom-events": "1.3.3",
+    "can-dom-events": "1.3.8",
     "can-dom-mutate": "1.3.6",
     "can-event-dom-enter": "2.2.0",
     "can-event-dom-radiochange": "2.2.0",


### PR DESCRIPTION
Closes #4781