### PR TITLE
Increase migrate-can4 TOC

### DIFF
--- a/docs/can-guides/upgrade/migrating-to-canjs-4.md
+++ b/docs/can-guides/upgrade/migrating-to-canjs-4.md
@@ -1,6 +1,7 @@
 @page migrate-4 Migrating to CanJS 4
 @parent guides/upgrade 1
 @templateRender <% %>
+@outline 2
 @description This guide walks you through the step-by-step process to upgrade a 3.x app to CanJS 4.
 
 


### PR DESCRIPTION
This increases [Migrating to CanJS 4](https://canjs.com/doc/migrate-4.html) page TOC to `@outline2`, it is needed by the `can-component` [deprecation PR ](https://github.com/canjs/can-component/pull/337)

The new TOC screenshot

<img width="525" alt="Screen Shot 2019-04-04 at 7 56 30 PM" src="https://user-images.githubusercontent.com/109013/55581546-0ddc9380-5715-11e9-9297-5a19d3619242.png">
