### PR TITLE
Group recipes by complexity

### DIFF
--- a/docs/can-guides/commitment/recipes/canvas-clock/canvas-clock.md
+++ b/docs/can-guides/commitment/recipes/canvas-clock/canvas-clock.md
@@ -1,7 +1,7 @@
-@page guides/recipes/canvas-clock Canvas Clock (Simple)
-@parent guides/recipes
+@page guides/recipes/canvas-clock Canvas Clock
+@parent guides/recipes/beginner
 
-@description This guide walks you through building a clock with the
+@description This beginner guide walks you through building a clock with the
 [Canvas API](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API).
 
 

--- a/docs/can-guides/commitment/recipes/credit-card-advanced/credit-card-advanced.md
+++ b/docs/can-guides/commitment/recipes/credit-card-advanced/credit-card-advanced.md
@@ -1,7 +1,7 @@
-@page guides/recipes/credit-card-advanced Credit Card Guide (Advanced)
-@parent guides/recipes
+@page guides/recipes/credit-card-advanced Credit Card
+@parent guides/recipes/advanced
 
-@description This guide walks through building a simple
+@description This advanced guide walks through building a simple
 credit card payment form with validations. It doesn’t use
 [can-define]. Instead it uses `Kefir.js` streams to make a ViewModel.
 [can-kefir] is used to make the Kefir streams observable to [can-stache].

--- a/docs/can-guides/commitment/recipes/credit-card-simple/credit-card-simple.md
+++ b/docs/can-guides/commitment/recipes/credit-card-simple/credit-card-simple.md
@@ -1,7 +1,7 @@
-@page guides/recipes/credit-card-simple Credit Card Guide (Simple)
-@parent guides/recipes
+@page guides/recipes/credit-card-simple Credit Card
+@parent guides/recipes/beginner
 
-@description This guide walks through building a very simple
+@description This beginner guide walks through building a very simple
 credit card payment form.  It uses [Stripe.js v2 API](https://stripe.com/docs/stripe.js/v2) to create a token
 which can be used to create a charge.  It also performs
 simple validation on the payment form values.

--- a/docs/can-guides/commitment/recipes/cta-bus-map/cta-bus-map.md
+++ b/docs/can-guides/commitment/recipes/cta-bus-map/cta-bus-map.md
@@ -1,7 +1,7 @@
-@page guides/recipes/cta-bus-map CTA Bus Map (Medium)
-@parent guides/recipes
+@page guides/recipes/cta-bus-map CTA Bus Map
+@parent guides/recipes/intermediate
 
-@description This guide walks you through showing Chicago Transit Authority (CTA) bus locations on a Google Map.  
+@description This intermediate guide walks you through showing Chicago Transit Authority (CTA) bus locations on a Google Map.  
 
 
 @body

--- a/docs/can-guides/commitment/recipes/file-navigator/file-navigator-advanced.md
+++ b/docs/can-guides/commitment/recipes/file-navigator/file-navigator-advanced.md
@@ -1,7 +1,7 @@
-@page guides/recipes/file-navigator-advanced File Navigator Guide (Advanced)
-@parent guides/recipes
+@page guides/recipes/file-navigator-advanced File Navigator
+@parent guides/recipes/advanced
 
-@description This guide walks you through building a file navigation
+@description This advanced guide walks you through building a file navigation
 widget that requests data with fetch. It takes about 45 minutes to complete.
 
 

--- a/docs/can-guides/commitment/recipes/file-navigator/file-navigator-simple.md
+++ b/docs/can-guides/commitment/recipes/file-navigator/file-navigator-simple.md
@@ -1,7 +1,7 @@
-@page guides/recipes/file-navigator-simple File Navigator Guide (Simple)
-@parent guides/recipes
+@page guides/recipes/file-navigator-simple File Navigator
+@parent guides/recipes/beginner
 
-@description This guide walks you through building a simple file navigation
+@description This beginner guide walks you through building a simple file navigation
 widget.  It takes about 25 minutes to complete.  It was written with
 CanJS 5.22.0. Check out the [guides/recipes/file-navigator-advanced]
 for an example that makes AJAX requests for its data and uses [can-component].

--- a/docs/can-guides/commitment/recipes/modals/modals.md
+++ b/docs/can-guides/commitment/recipes/modals/modals.md
@@ -1,7 +1,7 @@
-@page guides/recipes/modals Multiple Modals (Medium)
-@parent guides/recipes
+@page guides/recipes/modals Multiple Modals
+@parent guides/recipes/intermediate
 
-@description This guide shows how to create a multiple modal form.
+@description This intermediate guide shows how to create a multiple modal form.
 
 @body
 

--- a/docs/can-guides/commitment/recipes/playlist-editor/playlist-editor.md
+++ b/docs/can-guides/commitment/recipes/playlist-editor/playlist-editor.md
@@ -1,9 +1,9 @@
-@page guides/recipes/playlist-editor Playlist Editor (Advanced)
-@parent guides/recipes
+@page guides/recipes/playlist-editor Playlist Editor
+@parent guides/recipes/advanced
 
 @description Learn how to use YouTube’s API to search for videos and make a playlist.  This
 makes authenticated requests with OAuth2. It uses [jQuery++](https://jquerypp.com) for
-drag/drop events. It shows using custom attributes and custom events.  This guide takes
+drag/drop events. It shows using custom attributes and custom events.  This advanced guide takes
 an hour to complete.
 
 @body

--- a/docs/can-guides/commitment/recipes/recipes.md
+++ b/docs/can-guides/commitment/recipes/recipes.md
@@ -1,5 +1,8 @@
 @page guides/recipes recipes
 @parent guides 3
+@group guides/recipes/beginner 1 beginner
+@group guides/recipes/intermediate 2 intermediate
+@group guides/recipes/advanced 3 advanced
 
 @description A listing of small examples that are useful for
 learning CanJS.

--- a/docs/can-guides/commitment/recipes/search-list-details/search-list-details.md
+++ b/docs/can-guides/commitment/recipes/search-list-details/search-list-details.md
@@ -1,7 +1,7 @@
-@page guides/recipes/search-list-details Search, List, Details (Advanced)
-@parent guides/recipes
+@page guides/recipes/search-list-details Search, List, Details
+@parent guides/recipes/advanced
 
-@description This guide walks through building a Search, List, Details flow with lazy-loaded routes.
+@description This advanced guide walks through building a Search, List, Details flow with lazy-loaded routes.
 
 @body
 

--- a/docs/can-guides/commitment/recipes/signup-simple/signup.md
+++ b/docs/can-guides/commitment/recipes/signup-simple/signup.md
@@ -1,7 +1,7 @@
-@page guides/recipes/signup-simple Signup and Login (Simple)
-@parent guides/recipes
+@page guides/recipes/signup-simple Signup and Login
+@parent guides/recipes/beginner
 
-@description This guide walks through building simple signup, login forms and
+@description This beginner guide walks through building simple signup, login forms and
 a logout button.   
 
 @body

--- a/docs/can-guides/commitment/recipes/text-editor/text-editor.md
+++ b/docs/can-guides/commitment/recipes/text-editor/text-editor.md
@@ -1,7 +1,7 @@
-@page guides/recipes/text-editor Text Editor (Medium)
-@parent guides/recipes
+@page guides/recipes/text-editor Text Editor
+@parent guides/recipes/intermediate
 
-@description This guide walks you through building a
+@description This intermediate guide walks you through building a
 basic rich text editor.
 
 

--- a/docs/can-guides/commitment/recipes/tinder-like-carousel/Tinder-Like-Carousel.md
+++ b/docs/can-guides/commitment/recipes/tinder-like-carousel/Tinder-Like-Carousel.md
@@ -1,7 +1,7 @@
-@page guides/recipes/tinder-carousel Tinder Carousel (Medium)
-@parent guides/recipes
+@page guides/recipes/tinder-carousel Tinder Carousel
+@parent guides/recipes/intermediate
 
-@description This guide walks you through building a [Tinder](https://tinder.com/)-like
+@description This intermediate guide walks you through building a [Tinder](https://tinder.com/)-like
 carousel. Learn how to build apps that use dragging user interactions.
 
 @body

--- a/docs/can-guides/commitment/recipes/todomvc-with-steal/todomvc-with-steal.md
+++ b/docs/can-guides/commitment/recipes/todomvc-with-steal/todomvc-with-steal.md
@@ -1,5 +1,5 @@
 @page guides/recipes/todomvc-with-steal TodoMVC with StealJS
-@parent guides/recipes
+@parent guides/experiment 3
 
 @description This tutorial walks through building TodoMVC with
 StealJS. It includes KeyNote presentations

--- a/docs/can-guides/commitment/recipes/video-player/video-player.md
+++ b/docs/can-guides/commitment/recipes/video-player/video-player.md
@@ -1,7 +1,7 @@
-@page guides/recipes/video-player Video Player (Simple)
-@parent guides/recipes
+@page guides/recipes/video-player Video Player
+@parent guides/recipes/beginner
 
-@description This guide walks you through building custom video
+@description This beginner guide walks you through building custom video
 controls around a video element.
 
 

--- a/docs/can-guides/commitment/recipes/weather-report/weather-report-advanced.md
+++ b/docs/can-guides/commitment/recipes/weather-report/weather-report-advanced.md
@@ -1,8 +1,8 @@
-@page guides/recipes/weather-report-advanced Weather Report Guide (Advanced)
-@parent guides/recipes
+@page guides/recipes/weather-report-advanced Weather Report
+@parent guides/recipes/advanced
 @hide
 
-@description This guides you through extending the [guides/recipes/weather-report-simple Simple Weather Report Guide] to
+@description This advanced guides you through extending the [guides/recipes/weather-report-simple Simple Weather Report Guide] to
 remove imperative code and automatically look up the user’s location using the
 browser’s [geolocation API](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/Using_geolocation).  Both of these will be done with event streams.
 

--- a/docs/can-guides/commitment/recipes/weather-report/weather-report.md
+++ b/docs/can-guides/commitment/recipes/weather-report/weather-report.md
@@ -1,8 +1,8 @@
-@page guides/recipes/weather-report-simple Weather Report Guide (Simple)
-@parent guides/recipes
+@page guides/recipes/weather-report-simple Weather Report
+@parent guides/recipes/beginner
 @hide
 
-@description This guide walks you through building a simple weather report
+@description This beginner guide walks you through building a simple weather report
 widget.  It takes about 25 minutes to complete.  It was written with
 CanJS 4.1.
 

--- a/docs/can-guides/upgrade/migrating-to-canjs-3.md
+++ b/docs/can-guides/upgrade/migrating-to-canjs-3.md
@@ -587,7 +587,7 @@ const CarOwner = Map.extend({
 			type: "string"
 		},
 		age: {
-			default: 18
+			value: 18
 		}
 	}
 });
@@ -604,7 +604,7 @@ const CarOwner = DefineMap.extend({
 	color: "string",
 	age: {
 		type: "number",
-		default: 18
+		value: 18
 	}
 });
 ```
@@ -636,7 +636,7 @@ Here’s the example above updated for `can-define/map/map`:
 import DefineMap from 'can-define/map/map';
 
 const Person = DefineMap.extend({
-  name: {default: "Justin"}
+  name: {value: "Justin"}
 });
 ```
 


### PR DESCRIPTION
**Before:**
<img width="268" alt="Screen Shot 2019-04-07 at 8 33 15 PM" src="https://user-images.githubusercontent.com/10070176/55697089-aa50a100-5974-11e9-9c68-dbbed56da5b9.png">

**After:**
<img width="181" alt="Screen Shot 2019-04-07 at 8 33 01 PM" src="https://user-images.githubusercontent.com/10070176/55697095-afadeb80-5974-11e9-90c5-66b13866feb5.png">

Also:

- Fix some examples in the v3 migration guide
- Hide the weather guides (because they don’t work, for now, I know they’re being updated)
