### PR TITLE
Add a “Why Upgrade” section to the CanJS 3 migration guide

### DIFF
--- a/docs/can-guides/upgrade/migrating-to-canjs-3.md
+++ b/docs/can-guides/upgrade/migrating-to-canjs-3.md
@@ -12,11 +12,35 @@ Use this guide alone or with the [guides/upgrade/using-codemods] guide, which sh
 
 This guide goes over:
 
+* [Why you should upgrade](#WhyUpgrade)
 * [*Pre-migration preparation*](#Pre_migrationpreparation) you can do in your current 2.x project to more easily move to 3.x in the future.
 * [The *minimal migration path*](#Minimalmigrationpath), which includes the fewest changes required to upgrade from 2.x to 3.x.
 * [The *modernized migration path*](#Modernizedmigrationpath), which includes upgrading your code to match more modern conventions (such as using the new npm packages).
 * [The *latest & greatest migration path*](#Latest_greatestmigrationpath), which uses all of the modern libraries we are most excited about (such as [can-define]).
 * [How to *avoid future deprecations & removals*](#Avoidfuturedeprecations_removals) in releases after 3.x
+
+## Why Upgrade
+
+- Security: XSS vulnerability fixes in [v3.3.1](https://github.com/canjs/canjs/releases/tag/v3.3.1) and [v3.14.0](https://github.com/canjs/canjs/releases/tag/v3.14.0).
+- [can-stache-bindings](https://canjs.com/doc/can-stache-bindings.html) has new intuitive syntaxes for event, one-way bindings, and two-way bindings:
+	- `on:event="key()"` for event binding.
+	- `prop:from="key"` for one-way parent-to-child binding.
+	- `prop:to="key"` for one-way child-to-parent binding.
+	- `prop:bind="key"` for two-way binding.
+- [can-define/map/map] is faster, removes the need for writing `.attr()`, and allows nice syntax conventions like getters and will give warnings when setting properties that aren't defined.
+- Support for real-time with [can-connect]’s [can-connect/real-time/real-time] module.
+- [Much improved API docs.](https://v3.canjs.com/doc/api.html)
+- [More guides/recipes.](https://v3.canjs.com/doc/guides/recipes.html)
+- [{{debugger}} stache helper will break at the given point in the template so you can inspect the current scope in the browser’s console.](https://canjs.com/doc/can-stache.helpers.debugger.html)
+- [Named inline partials (define reusable partials inside your templates).](https://canjs.com/doc/can-stache.tags.named-partial.html)
+- Support for slots & templates via [can-component/can-slot `<can-slot>`] and [can-component/can-template `<can-template>`].
+- [can-stache-converters] for two-way binding with form elements.
+- [Control whitespace in stache templates.](https://v3.canjs.com/doc/can-stache.Whitespace.html)
+- New validation packages: [can-validate] and [can-validate-validatejs].
+- Support for FeathersJS with [can-connect-feathers].
+- NDJSON support: [can-connect-ndjson] and [can-ndjson-stream].
+- No dependency on jQuery/Mootools/Dojo/etc. [Integration with jQuery is still as easy as ever.](http://v3.canjs.com/doc/can-jquery.html)
+- Hundreds of other bug fixes and new features.
 
 ## Pre-migration preparation
 

--- a/docs/can-guides/upgrade/migrating-to-canjs-4.md
+++ b/docs/can-guides/upgrade/migrating-to-canjs-4.md
@@ -14,14 +14,17 @@ CanJS 4 is an improvement on much of the core infrastructure in CanJS 3. Keeping
 CanJS 4 is a big step forward in simplifying CanJS and enhancing your understanding of your
 application. Read more details about it [CanJS 4.0's release article](https://www.bitovi.com/blog/canjs-4.0).  The following are some highlights:
 
-- Debugging Tools - CanJS 4.0 makes it easier to discover how your code works (or doesn't)
-  and fix it.  It works with [CanJS’s Chrome Debugger Tools](https://chrome.google.com/webstore/detail/hhdfadlgplkpapjfehnjhcebebgmibcb)
-- Simplified Stache Templates - Most of [can-stache]’s quirks have been eliminated or simplified.
+- Debugging Tools - CanJS 4 makes it easier to discover how your code works (or doesn’t)
+  and fix it.  It works with [CanJS’s Chrome Debugger Tools](https://chrome.google.com/webstore/detail/hhdfadlgplkpapjfehnjhcebebgmibcb).
+- Simplified Stache Templates - Most of [can-stache]’s quirks have been eliminated or simplified. [can-stache-bindings.raw `key:raw="string"`] makes it easier to bind to string values.
 - Streaming property definitions - Contain the behavior of a stateful property within a single streaming property definition.  
 - Determinism and Performance with Queues - CanJS’s new queuing system makes callback ordering
   deterministic, eliminating odd corner cases, improving debuggability and performance.
-- Upgradability - CanJS 4.0 is much easier to upgrade to than 3.0.
-
+- [Tree-shaking](https://v4.canjs.com/doc/guides/advanced-setup.html) — Works with StealJS and webpack.
+- Compatibility — [Improved compatibility with how webpack strips out dev code.](https://github.com/canjs/canjs/issues/4011)
+- New APIs for routing and testing — [Components can be programmatically instantiated with new.](https://v4.canjs.com/doc/can-component.html#newComponent__options__)
+- Upgradability - CanJS 4.0 is much easier to upgrade to than 3.0!
+- Guides — [More recipes](https://v4.canjs.com/doc/guides/recipes.html) and guides on [guides/debugging] and [guides/forms].
 
 ## CanJS 4 Upgrade Video
 

--- a/docs/can-guides/upgrade/migrating-to-canjs-5.md
+++ b/docs/can-guides/upgrade/migrating-to-canjs-5.md
@@ -135,7 +135,19 @@ CanJS 5.0:
     There's [can-query-logic#Configuration detailed documentation] on how
     to configure a `new QueryLogic()` for any circumstances.
     @highlight 21-38,43,only
-
+- Includes guides on [guides/html], [guides/routing], [guides/data], [guides/testing], [guides/logic], and [guides/data-extreme].
+- Includes hundreds of other bug fixes and new features, including:
+  - New stache helpers for logic: [can-stache.helpers.and and()], [can-stache.helpers.or or()], and [can-stache.helpers.not not()].
+  - [can-stache.helpers.let #let stache helper] for creating block-level variables.
+  - [can-stache.helpers.for-of #for(of) stache helper] for looping through lists without creating new contexts.
+  - [can-stache.portal #portal stache helper] for inserting a section of a template into another element.
+  - [can-stache/keys/scope/key scope/key] syntax for scope walking within a stache template.
+  - [Component elements now have a `.viewModel` property.](https://github.com/canjs/can-component/releases/tag/v4.3.0)
+  - [Slots are able to pass individual values.](https://github.com/canjs/can-component/releases/tag/v4.4.0)
+  - Support for [can-stache-bindings.event#on_VIEW_MODEL_OR_DOM_EVENT__KEY_VALUE_ setting properties within event handlers in stache] (e.g. `on:click="this.prop = value"`).
+  - Security: XSS vulnerability fix in [v5.13.0](https://github.com/canjs/canjs/releases/tag/v5.13.0).
+  - New packages: [can-map-compat] and [can-route-mock].
+  - Internet Explorer 11 support
 
 ## Breaking Changes
 


### PR DESCRIPTION
Also add more features to the v4 and v5 guides.

## v3

This section is brand new:

<img width="750" alt="Screen Shot 2019-04-17 at 4 58 08 PM" src="https://user-images.githubusercontent.com/10070176/56328113-4f683800-6132-11e9-9d89-b668212b38aa.png">

## v4

Minor changes here:

<img width="779" alt="Screen Shot 2019-04-17 at 4 58 22 PM" src="https://user-images.githubusercontent.com/10070176/56328111-4d05de00-6132-11e9-8bb2-3e5d3958631d.png">

## v5

Added new items to the end of the list that’s already there:

<img width="830" alt="Screen Shot 2019-04-17 at 4 59 10 PM" src="https://user-images.githubusercontent.com/10070176/56328108-48d9c080-6132-11e9-9c8f-5d7a9f4dd770.png">
