### PR TITLE
Update releasing-canjs.md

### DIFF
--- a/docs/can-guides/contribute/releasing-canjs.md
+++ b/docs/can-guides/contribute/releasing-canjs.md
@@ -73,7 +73,7 @@ To make a release:
    ```
    git checkout master
    git fetch --all && git rebase
-   npm cache clean
+   npm cache verify
    rm -rf node_modules
    npm install
    ```


### PR DESCRIPTION
`npm cache clean` causes an error, so instead, it's better to use `npm cache verify`
- https://stackoverflow.com/questions/20259492/npm-not-working-after-clearing-cache