### PR TITLE
Fix SauceLabs badge to only update from canjs/canjs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ before_install:
 - ./firefox-allow-popups.sh
 - "export DISPLAY=:99.0"
 - "sh -e /etc/init.d/xvfb start"
-- if [ "$TRAVIS_BRANCH" != "master" ] || [ "$TRAVIS_PULL_REQUEST" != false ]; then SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY_NOT_MASTER SAUCE_USERNAME=$SAUCE_USERNAME_NOT_MASTER; fi
+# On the line below, you’ll see the canjs-not-master keys being used only for master builds. This is correct. Unfortunately, the username can’t be changed and we’ve already hit the max number of allowed Sauce Labs accounts.
+- if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == false ]; then SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY_NOT_MASTER SAUCE_USERNAME=$SAUCE_USERNAME_NOT_MASTER; fi
 - echo "Sauce Labs username is $SAUCE_USERNAME"
 - |
     if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^docs)|(^demos)/'

--- a/docs/can-canjs/canjs.md
+++ b/docs/can-canjs/canjs.md
@@ -667,7 +667,7 @@ Below is an entire app that shows off some of the best features of CanJS:
   <div class="">
     <h3>Browser support</h3>
     <p>CanJS supports Internet Explorer 11, Chrome, Edge, Firefox, and Safari.</p>
-    <img src="https://saucelabs.com/browser-matrix/canjs.svg" alt="Sauce Test Status" />
+    <img src="https://saucelabs.com/browser-matrix/canjs-not-master.svg" alt="Sauce Test Status" />
   </div>
 </div>
 <div class="gray-callout footer">

--- a/docs/can-guides/contribute/releasing-canjs.md
+++ b/docs/can-guides/contribute/releasing-canjs.md
@@ -24,7 +24,7 @@ All repositories automatically run their tests in [Travis CI](https://travis-ci.
 
 [canjs/canjs](https://github.com/canjs/canjs) also runs the tests of all dependencies in the supported browsers on [Saucelabs](https://saucelabs.com):
 
-[![Sauce Test Status](https://saucelabs.com/browser-matrix/canjs.svg)](https://saucelabs.com/u/canjs)
+[![Sauce Test Status](https://saucelabs.com/browser-matrix/canjs-not-master.svg)](https://saucelabs.com/u/canjs-not-master)
 
 To view Saucelabs test runs and results, request an invite from a Saucelabs user that has access to the `canjs` Saucelabs project (existing users can send invites under [my account](https://saucelabs.com/beta/users/canjs)). Saucelabs tests can be run locally via
 

--- a/docs/can-guides/introduction/technical.md
+++ b/docs/can-guides/introduction/technical.md
@@ -14,7 +14,7 @@ CanJS supports:
  - iOS Safari 11+
  - NodeJS 6+ with [can-vdom] as a document.
 
-[![Sauce Test Status](https://saucelabs.com/browser-matrix/canjs.svg)](https://saucelabs.com/u/canjs)
+[![Sauce Test Status](https://saucelabs.com/browser-matrix/canjs-not-master.svg)](https://saucelabs.com/u/canjs-not-master)
 
 ## Phenomenal Features, Small Size
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # [CanJS](https://canjs.com/)
 
- [![Sauce Test Status](https://saucelabs.com/browser-matrix/canjs.svg)](https://saucelabs.com/u/canjs)
+ [![Sauce Test Status](https://saucelabs.com/browser-matrix/canjs-not-master.svg)](https://saucelabs.com/u/canjs-not-master)
 
 [![Join our Slack](https://img.shields.io/badge/slack-join%20chat-611f69.svg)](https://www.bitovi.com/community/slack?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Join our Discourse](https://img.shields.io/discourse/https/forums.bitovi.com/posts.svg)](https://forums.bitovi.com/?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/test/test-sauce-labs.js
+++ b/test/test-sauce-labs.js
@@ -37,7 +37,7 @@ var platforms = [{
 	idleTimeout: idleTimeout
 }, {
 	browserName: 'Safari',
-	'appium-version': '1.7.1',
+	'appium-version': '1.9.1',
 	platformName: 'iOS',
 	platformVersion: '11.0',
 	deviceName: 'iPhone 8 Simulator',


### PR DESCRIPTION
Previously, any builds that were PRs or not on master would run with the `canjs-not-master` Sauce Labs user so only builds on `master` would be run with the main `canjs` user.

This fixed the Sauce Labs badge for builds within the `canjs` repo, but builds in all the other repos continued to use the `canjs` Sauce Labs user, so they still affected the badge.

This fixes the issue by using the `canjs-not-master` Sauce Labs user only for builds on `master` and using the badge for that user everywhere. Unfortunately, Sauce Labs user names can’t be changed and we can’t add any more users to our main account, so now the `canjs-not-master` user is only used for builds on `master`.

Fixes https://github.com/canjs/canjs/issues/4764