### PR TITLE
fix(package): update can-define-array to version 0.4.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "can-data-types": "1.2.1",
     "can-debug": "2.0.7",
     "can-define": "2.7.18",
-    "can-define-array": "0.4.8",
+    "can-define-array": "0.4.10",
     "can-define-backup": "2.1.2",
     "can-define-lazy-value": "1.1.1",
     "can-define-mixin": "0.2.12",


### PR DESCRIPTION
Closes #5051