### PR TITLE
fix(package): update can-type to version 0.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "can-string-to-any": "1.2.1",
     "can-super-model": "1.1.1",
     "can-symbol": "1.6.5",
-    "can-type": "0.1.6",
+    "can-type": "0.1.9",
     "can-validate": "1.2.1",
     "can-validate-interface": "1.0.3",
     "can-validate-legacy": "2.0.1",


### PR DESCRIPTION
Closes #5067