### PR TITLE
Reorder the Guides better for first-time visitors

### DIFF
--- a/docs/can-guides/Guides.md
+++ b/docs/can-guides/Guides.md
@@ -1,12 +1,13 @@
 @page guides Guides
 @parent canjs 1
-@group guides/essentials 2 essentials
+@group guides/getting-started 1 getting started
+@group guides/topics 2 topics
 @group guides/experiment 3 app guides
 @group guides/recipes/beginner 4 beginner recipes
 @group guides/recipes/intermediate 5 intermediate recipes
 @group guides/recipes/advanced 6 advanced recipes
 @group guides/upgrade 7 upgrade
-@group guides/getting-started 8 other
+@group guides/other 8 other
 @templateRender <% %>
 @subchildren
 

--- a/docs/can-guides/api-guide.md
+++ b/docs/can-guides/api-guide.md
@@ -1,5 +1,5 @@
-@page guides/api Reading the Docs (API Guide)
-@parent guides/getting-started 2
+@page guides/api Reading the API Docs
+@parent guides/other 2
 
 @description This page walks through how to use and understand CanJS’s API documentation.  
 

--- a/docs/can-guides/experiment/crud-beginner/crud-beginner.md
+++ b/docs/can-guides/experiment/crud-beginner/crud-beginner.md
@@ -1,5 +1,5 @@
 @page guides/crud-beginner CRUD Guide
-@parent guides/experiment 0
+@parent guides/getting-started 1
 @templateRender <% %>
 @description Learn how to build a basic CRUD app with CanJS in 30 minutes.
 

--- a/docs/can-guides/experiment/technology/html.md
+++ b/docs/can-guides/experiment/technology/html.md
@@ -1,5 +1,5 @@
 @page guides/html HTML
-@parent guides/essentials 3
+@parent guides/topics 3
 @outline 2
 
 @description Learn how to update HTML and listen to user interactions.

--- a/docs/can-guides/experiment/technology/routing.md
+++ b/docs/can-guides/experiment/technology/routing.md
@@ -1,5 +1,5 @@
 @page guides/routing Routing
-@parent guides/essentials 3
+@parent guides/topics 3
 @outline 2
 
 @description Learn how to make your application respond to changes in the URL and

--- a/docs/can-guides/experiment/technology/technology.md
+++ b/docs/can-guides/experiment/technology/technology.md
@@ -1,5 +1,5 @@
 @page guides/technology-overview Technology Overview
-@parent guides/essentials 1
+@parent guides/getting-started 3
 @outline 2
 
 @description Learn the basics of CanJS’s technology.

--- a/docs/can-guides/setup/setting-up-canjs.md
+++ b/docs/can-guides/setup/setting-up-canjs.md
@@ -1,5 +1,5 @@
 @page guides/setup Setting Up CanJS
-@parent guides/essentials 2
+@parent guides/getting-started 2
 @outline 2
 
 @description Learn how to install CanJS in your environment.

--- a/docs/can-guides/topics/data/data.md
+++ b/docs/can-guides/topics/data/data.md
@@ -1,5 +1,5 @@
 @page guides/data Service Layer
-@parent guides/essentials 4
+@parent guides/topics 4
 @outline 0
 
 @description Learn how to use [can-connect] to integrate service layer APIs into your CanJS application.

--- a/docs/can-guides/topics/debugging.md
+++ b/docs/can-guides/topics/debugging.md
@@ -1,5 +1,5 @@
 @page guides/debugging Debugging
-@parent guides/essentials 6
+@parent guides/topics 6
 @outline 2
 
 @description Learn how to debug CanJS applications.

--- a/docs/can-guides/topics/forms.md
+++ b/docs/can-guides/topics/forms.md
@@ -1,5 +1,5 @@
 @page guides/forms Forms
-@parent guides/essentials 7
+@parent guides/topics 7
 @outline 3
 
 @description Learn how to create amazing `<form>`s with CanJS.

--- a/docs/can-guides/topics/logic.md
+++ b/docs/can-guides/topics/logic.md
@@ -1,5 +1,5 @@
 @page guides/logic Logic
-@parent guides/essentials 9
+@parent guides/topics 9
 @outline 2
 
 @description Learn how to write observables in an organized, maintainable, and testable way.

--- a/docs/can-guides/topics/testing.md
+++ b/docs/can-guides/topics/testing.md
@@ -1,5 +1,5 @@
 @page guides/testing Testing
-@parent guides/essentials 8
+@parent guides/topics 8
 @outline 2
 
 @description Learn how to test CanJS applications.


### PR DESCRIPTION
- Add a “getting started” section that includes the CRUD guide, Setting Up CanJS, and Technology Overview
- Group the rest of the “essentials” as “topics”
- Rename the API Guide to a shorter title (so the sidebar doesn’t have to be as wide)

Closes https://github.com/canjs/canjs/issues/5026

## Before
<img width="175" alt="Screen Shot 2019-06-24 at 4 12 31 PM" src="https://user-images.githubusercontent.com/10070176/60057952-4dbf7100-969b-11e9-9676-81793ae95160.png">

## After
<img width="175" alt="Screen Shot 2019-06-24 at 4 12 38 PM" src="https://user-images.githubusercontent.com/10070176/60057957-51eb8e80-969b-11e9-8725-7b9d64d038b2.png">
