### PR TITLE
Tighten up the We have your back section on mobile

### DIFF
--- a/docs/can-canjs/canjs.md
+++ b/docs/can-canjs/canjs.md
@@ -493,8 +493,14 @@ pre[class*=language-].line-numbers.line-numbers code {
   .three-col-wrapper .col-container .content .code-toolbar {
     margin-top: 10px;
   }
+  .social-two-col img {
+    height: 30px;
+  }
   .social .social-two-col .right-col {
-    flex-direction: column;
+    margin-top: 0;
+  }
+  .social .social-two-col .right-col a {
+    margin-bottom: 0;
   }
 }
 </style>


### PR DESCRIPTION
Reduced the margins and sizes of the logos for mobile.

<img width="366" alt="Screen Shot 2019-06-27 at 10 39 44 AM" src="https://user-images.githubusercontent.com/381138/60288035-30bbb580-98c8-11e9-87cf-28855f4d9ae1.png">
