### PR TITLE
Updates SVG and how SVG is called into the page

### DIFF
--- a/docs/can-guides/experiment/technology/overview.svg
+++ b/docs/can-guides/experiment/technology/overview.svg
@@ -1,1 +1,116 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 710 710"><defs><style>.cls-2{fill:#509444}.cls-9{font-weight:700}.cls-6,.cls-7{letter-spacing:-.03em}.cls-9{fill:#2e4e85}.cls-12{letter-spacing:-.03em}.cls-13{font-family:OpenSans-Light,Open Sans;letter-spacing:-.02em}.cls-14{letter-spacing:-.03em}.cls-15{letter-spacing:-.02em}.cls-16{letter-spacing:-.03em}.cls-17{letter-spacing:-.01em}.cls-18{letter-spacing:-.02em}.cls-19,.cls-20{letter-spacing:-.03em}.cls-21{letter-spacing:-.02em}.cls-22{letter-spacing:-.01em}.cls-23{letter-spacing:-.05em}.cls-24,.cls-26{letter-spacing:-.03em}.cls-28{letter-spacing:-.04em}.cls-30{letter-spacing:-.01em}.cls-31{letter-spacing:-.02em}.cls-41,.cls-44,.cls-66,.cls-67{letter-spacing:-.03em}.cls-68{letter-spacing:-.05em}.cls-69{letter-spacing:-.03em}.cls-70{letter-spacing:-.02em}.cls-88,.cls-89{letter-spacing:-.03em}</style><linearGradient id="linear-gradient" x1="351.08" y1="134.6" x2="351.08" y2="8.6" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#fff"/><stop offset="1" stop-color="gray"/></linearGradient><radialGradient id="radial-gradient" cx="351.08" cy="71.6" r="55" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#fff"/><stop offset=".96" stop-color="#f0f0f0"/><stop offset="1" stop-color="#fff"/></radialGradient><linearGradient id="linear-gradient-2" x1="93.08" y1="703.4" x2="93.08" y2="577.4" xlink:href="#linear-gradient"/><radialGradient id="radial-gradient-2" cx="93.08" cy="640.4" r="55" xlink:href="#radial-gradient"/><linearGradient id="linear-gradient-3" x1="606.08" y1="703.4" x2="606.08" y2="577.4" xlink:href="#linear-gradient"/><radialGradient id="radial-gradient-3" cx="606.08" cy="640.4" r="55" xlink:href="#radial-gradient"/></defs><g style="isolation:isolate"><g id="Layer_1" data-name="Layer 1"><g id="DOM-group"><circle class="cls-2" cx="351.08" cy="71.6" r="63"/><circle cx="351.08" cy="71.6" r="63" style="mix-blend-mode:multiply" fill="url(#linear-gradient)"/><circle cx="351.08" cy="71.6" r="55" fill="url(#radial-gradient)"/><text transform="translate(322.8 78.49)" letter-spacing="-.03em" font-weight="700" font-family="OpenSans-Semibold,Open Sans" font-size="24">D<tspan class="cls-6" x="16.89" y="0">O</tspan><tspan class="cls-7" x="35.01" y="0">M</tspan></text></g><text transform="translate(372.35 195.77)" letter-spacing="-.01em" font-family="OpenSans-Bold,Open Sans" font-size="21"><tspan class="cls-9">V<tspan x="13.38" y="0" letter-spacing="-.03em">i</tspan><tspan x="19.13" y="0" letter-spacing="-.03em">e</tspan><tspan class="cls-12" x="30.87" y="0">w</tspan></tspan><tspan class="cls-13"><tspan x="0" y="24">c</tspan><tspan class="cls-14" x="9.58" y="24">a</tspan><tspan class="cls-15" x="19.98" y="24">n</tspan><tspan class="cls-16" x="32.01" y="24">-</tspan><tspan class="cls-17" x="38.21" y="24">s</tspan><tspan class="cls-18" x="47.89" y="24">t</tspan><tspan class="cls-19" x="54.58" y="24">a</tspan><tspan class="cls-20" x="65.04" y="24">c</tspan><tspan class="cls-19" x="74.34" y="24">h</tspan><tspan class="cls-21" x="86.06" y="24">e</tspan><tspan x="0" y="48">c</tspan><tspan class="cls-14" x="9.58" y="48">a</tspan><tspan class="cls-15" x="19.98" y="48">n</tspan><tspan class="cls-22" x="32.01" y="48">-</tspan><tspan class="cls-23" x="38.6" y="48">c</tspan><tspan class="cls-24" x="47.63" y="48">o</tspan><tspan x="59.24" y="48" letter-spacing="-.03em">m</tspan><tspan class="cls-26" x="77.06" y="48">p</tspan><tspan class="cls-24" x="88.97" y="48">o</tspan><tspan x="100.58" y="48" letter-spacing="-.03em">n</tspan><tspan class="cls-28" x="112.3" y="48">e</tspan><tspan x="123.08" y="48" letter-spacing="-.03em">n</tspan><tspan class="cls-21" x="134.8" y="48">t</tspan><tspan x="0" y="72">c</tspan><tspan class="cls-14" x="9.58" y="72">a</tspan><tspan class="cls-15" x="19.98" y="72">n</tspan><tspan class="cls-16" x="32.01" y="72">-</tspan><tspan class="cls-17" x="38.21" y="72">s</tspan><tspan class="cls-18" x="47.89" y="72">t</tspan><tspan class="cls-19" x="54.58" y="72">a</tspan><tspan class="cls-20" x="65.04" y="72">c</tspan><tspan class="cls-19" x="74.34" y="72">h</tspan><tspan class="cls-30" x="86.06" y="72">e</tspan><tspan class="cls-31" x="97.31" y="72">-</tspan><tspan x="103.64" y="72" letter-spacing="-.03em">b</tspan><tspan x="115.45" y="72" letter-spacing="-.04em">i</tspan><tspan x="119.43" y="72" letter-spacing="-.03em">n</tspan><tspan x="131.18" y="72" letter-spacing="-.04em">di</tspan><tspan x="146.89" y="72" letter-spacing="-.04em">n</tspan><tspan x="158.5" y="72">g</tspan><tspan class="cls-21" x="169.18" y="72">s</tspan></tspan></text><g id="service-layer-group"><circle class="cls-2" cx="93.08" cy="640.4" r="63"/><circle cx="93.08" cy="640.4" r="63" style="mix-blend-mode:multiply" fill="url(#linear-gradient-2)"/><circle cx="93.08" cy="640.4" r="55" fill="url(#radial-gradient-2)"/><text transform="translate(53.65 636.8)" letter-spacing="-.02em" font-weight="700" font-family="OpenSans-Semibold,Open Sans" font-size="24">S<tspan class="cls-41" x="12.65" y="0">e</tspan><tspan x="25.79" y="0" letter-spacing=".01em">r</tspan><tspan x="36.42" y="0">v</tspan><tspan class="cls-44" x="48.77" y="0">i</tspan><tspan x="54.66" y="0" letter-spacing="-.04em">c</tspan><tspan class="cls-7" x="65.63" y="0">e</tspan><tspan letter-spacing="-.01em"><tspan x="9.18" y="21">L</tspan><tspan x="21.9" y="21" letter-spacing="-.04em">a</tspan><tspan x="34.85" y="21" letter-spacing="-.04em">y</tspan><tspan class="cls-41" x="46.79" y="21">e</tspan><tspan class="cls-7" x="59.93" y="21">r</tspan></tspan></text></g><g id="window.location-group"><circle class="cls-2" cx="606.08" cy="640.4" r="63"/><circle cx="606.08" cy="640.4" r="63" style="mix-blend-mode:multiply" fill="url(#linear-gradient-3)"/><circle cx="606.08" cy="640.4" r="55" fill="url(#radial-gradient-3)"/><text transform="translate(560.3 636.8)" letter-spacing="-.03em" font-weight="700" font-family="OpenSans-Semibold,Open Sans" font-size="24">w<tspan x="18.98" y="0" letter-spacing="-.04em">i</tspan><tspan x="24.81" y="0">n</tspan><tspan x="39.34" y="0">d</tspan><tspan x="53.53" y="0">o</tspan><tspan x="67.37" y="0" letter-spacing="-.06em">w</tspan><tspan x="85.56" y="0" letter-spacing="-.02em">.</tspan><tspan><tspan x="2.08" y="21">l</tspan><tspan x="8.02" y="21">o</tspan><tspan x="22.04" y="21" letter-spacing="-.02em">c</tspan><tspan x="33.34" y="21">at</tspan><tspan class="cls-44" x="55.07" y="21">i</tspan><tspan class="cls-6" x="60.96" y="21">o</tspan><tspan class="cls-7" x="74.85" y="21">n</tspan></tspan></text></g><text transform="translate(525.02 477.67)" letter-spacing="-.04em" font-family="OpenSans-Bold,Open Sans" font-size="21"><tspan class="cls-9">R<tspan x="13.03" y="0" letter-spacing="-.03em">o</tspan><tspan x="25.37" y="0" letter-spacing="-.03em">u</tspan><tspan x="38.46" y="0" letter-spacing="-.03em">t</tspan><tspan class="cls-66" x="46.88" y="0">i</tspan><tspan class="cls-67" x="52.56" y="0">n</tspan><tspan class="cls-21" x="65.74" y="0">g</tspan></tspan><tspan class="cls-13"><tspan x="0" y="24">c</tspan><tspan class="cls-14" x="9.58" y="24">a</tspan><tspan class="cls-15" x="19.98" y="24">n</tspan><tspan class="cls-31" x="32.01" y="24">-</tspan><tspan class="cls-68" x="38.34" y="24">r</tspan><tspan class="cls-69" x="45.56" y="24">o</tspan><tspan class="cls-70" x="57.2" y="24">u</tspan><tspan class="cls-23" x="69.15" y="24">t</tspan><tspan class="cls-21" x="75.23" y="24">e</tspan><tspan x="0" y="48">c</tspan><tspan class="cls-14" x="9.58" y="48">a</tspan><tspan class="cls-15" x="19.98" y="48">n</tspan><tspan class="cls-31" x="32.01" y="48">-</tspan><tspan class="cls-68" x="38.34" y="48">r</tspan><tspan class="cls-69" x="45.56" y="48">o</tspan><tspan class="cls-70" x="57.2" y="48">u</tspan><tspan class="cls-23" x="69.15" y="48">t</tspan><tspan class="cls-30" x="75.23" y="48">e</tspan><tspan x="86.47" y="48" letter-spacing="-.02em">-</tspan><tspan x="92.8" y="48" letter-spacing="-.03em">p</tspan><tspan x="104.64" y="48">u</tspan><tspan x="116.28" y="48">s</tspan><tspan x="125.25" y="48" letter-spacing="-.03em">h</tspan><tspan x="136.96" y="48" letter-spacing="-.01em">s</tspan><tspan class="cls-18" x="146.63" y="48">t</tspan><tspan x="153.33" y="48" letter-spacing="-.03em">a</tspan><tspan class="cls-23" x="163.81" y="48">t</tspan><tspan class="cls-12" x="169.89" y="48">e</tspan></tspan></text><text transform="translate(67.14 477.67)" letter-spacing="-.04em" font-family="OpenSans-Bold,Open Sans" font-size="21"><tspan class="cls-9">D<tspan x="14.75" y="0">a</tspan><tspan x="26.7" y="0" letter-spacing="-.02em">t</tspan><tspan class="cls-21" x="35.38" y="0">a </tspan><tspan x="52.46" y="0" letter-spacing="-.03em">M</tspan><tspan x="71.66" y="0" letter-spacing="-.03em">o</tspan><tspan x="84.12" y="0" letter-spacing="-.03em">d</tspan><tspan x="96.76" y="0" letter-spacing="-.03em">e</tspan><tspan class="cls-66" x="108.61" y="0">li</tspan><tspan class="cls-67" x="119.97" y="0">n</tspan><tspan class="cls-21" x="133.15" y="0">g</tspan></tspan><tspan class="cls-13"><tspan x="0" y="24">c</tspan><tspan class="cls-14" x="9.58" y="24">a</tspan><tspan class="cls-15" x="19.98" y="24">n</tspan><tspan class="cls-22" x="32.01" y="24">-</tspan><tspan class="cls-23" x="38.6" y="24">c</tspan><tspan class="cls-24" x="47.63" y="24">o</tspan><tspan x="59.24" y="24" letter-spacing="-.03em">n</tspan><tspan class="cls-19" x="70.9" y="24">n</tspan><tspan x="82.62" y="24" letter-spacing="-.03em">e</tspan><tspan x="93.56" y="24" letter-spacing=".01em">c</tspan><tspan class="cls-21" x="103.67" y="24">t</tspan><tspan x="0" y="48">c</tspan><tspan class="cls-14" x="9.58" y="48">a</tspan><tspan class="cls-15" x="19.98" y="48">n</tspan><tspan class="cls-16" x="32.01" y="48">-</tspan><tspan class="cls-88" x="38.21" y="48">s</tspan><tspan class="cls-89" x="47.42" y="48">e</tspan><tspan class="cls-12" x="58.31" y="48">t</tspan></tspan></text><g id="observables-group"><path d="M350.08 482.1c-28.33 0-55.07-7.8-75.29-22-21.09-14.76-32.71-34.67-32.71-56s11.62-41.29 32.71-56.05c20.22-14.16 47-21.95 75.29-21.95s55.08 7.79 75.3 21.95c21.09 14.76 32.7 34.66 32.7 56.05s-11.61 41.29-32.7 56c-20.22 14.2-46.96 22-75.3 22z" fill="#666"/><ellipse cx="350.08" cy="404.1" rx="100" ry="70" fill="#fff"/><text transform="translate(290.08 386.27)" letter-spacing="-.03em" font-size="21" font-family="OpenSans-Semibold,Open Sans"><tspan font-weight="700">O<tspan x="15.96" y="0">b</tspan><tspan class="cls-26" x="28.5" y="0">s</tspan><tspan x="38.13" y="0">e</tspan><tspan x="49.65" y="0" letter-spacing=".01em">r</tspan><tspan x="58.98" y="0">v</tspan><tspan x="69.53" y="0">a</tspan><tspan class="cls-26" x="81.01" y="0">b</tspan><tspan class="cls-89" x="93.5" y="0">l</tspan><tspan x="98.73" y="0" letter-spacing="-.02em">e</tspan><tspan class="cls-21" x="110.31" y="0">s</tspan></tspan><tspan class="cls-13"><tspan x="12.82" y="24">c</tspan><tspan class="cls-14" x="22.4" y="24">a</tspan><tspan class="cls-15" x="32.81" y="24">n</tspan><tspan class="cls-22" x="44.83" y="24">-</tspan><tspan x="51.42" y="24">d</tspan><tspan x="63.22" y="24">e</tspan><tspan x="74.14" y="24">fi</tspan><tspan class="cls-19" x="84.46" y="24">n</tspan><tspan class="cls-12" x="96.19" y="24">e</tspan><tspan x="4.71" y="48">c</tspan><tspan class="cls-14" x="14.29" y="48">a</tspan><tspan class="cls-15" x="24.69" y="48">n</tspan><tspan class="cls-22" x="36.71" y="48">-</tspan><tspan class="cls-24" x="43.31" y="48">o</tspan><tspan x="54.92" y="48">b</tspan><tspan class="cls-88" x="66.75" y="48">s</tspan><tspan class="cls-28" x="75.95" y="48">e</tspan><tspan x="86.73" y="48" letter-spacing=".02em">r</tspan><tspan x="95.35" y="48">v</tspan><tspan class="cls-21" x="104.3" y="48">e</tspan></tspan></text></g><path id="arrow01" d="M352.58 162.47h9.97l-12.47-21.59-12.46 21.59h9.96v131.25h-9.96l12.46 21.59 12.47-21.59h-9.97V162.47z"/><path id="arrow03" d="M462.45 471.93l7.04-7.05-24.07-6.45 6.45 24.08 7.04-7.05 92.81 92.81-7.05 7.05 24.08 6.45-6.45-24.08-7.05 7.05-92.8-92.81z"/><path id="arrow03-2" data-name="arrow03" d="M237.72 471.93l-7.05-7.05 24.08-6.45-6.45 24.08-7.05-7.05-92.8 92.81 7.04 7.05-24.08 6.45 6.46-24.08 7.04 7.05 92.81-92.81z"/></g></g></svg>
+<svg viewBox="0 0 700 700" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <style type="text/css">
+        @import url(https://fonts.googleapis.com/css?family=Open+Sans:400,700);
+        .text-reg {
+            font-family: 'Open Sans', sans-serif;
+            font-size: 21px;
+            font-weight: 400;
+            fill: #000000;
+        }
+        .text-bold {
+            font-family: 'Open Sans', sans-serif;
+            font-size: 21px;
+            font-weight: 700;
+            fill: #000000;
+        }
+        .text-small {
+            font-size: 18px;
+        }
+        .color-two {
+            fill: #2E4E85;
+        }
+    </style>
+    <title>CanJS Observables Overview</title>
+    <desc>CanJS Observables Overview</desc>
+    <defs>
+        <linearGradient x1="50%" y1="100%" x2="50%" y2="0%" id="linearGradient-1">
+            <stop stop-color="#FFFFFF" offset="0%"></stop>
+            <stop stop-color="#808080" offset="100%"></stop>
+        </linearGradient>
+        <radialGradient cx="50%" cy="50%" fx="50%" fy="50%" r="50%" id="radialGradient-2">
+            <stop stop-color="#FFFFFF" offset="0%"></stop>
+            <stop stop-color="#F0F0F0" offset="96%"></stop>
+            <stop stop-color="#FFFFFF" offset="100%"></stop>
+        </radialGradient>
+    </defs>
+    <g id="oveview" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="SL-group" transform="translate(31.000000, 571.000000)">
+            <circle id="Oval" fill="#509444" fill-rule="nonzero" cx="63" cy="63" r="63"></circle>
+            <circle id="Oval" fill="url(#linearGradient-1)" fill-rule="nonzero" style="mix-blend-mode: multiply;" cx="63" cy="63" r="63"></circle>
+            <circle id="Oval" fill="url(#radialGradient-2)" fill-rule="nonzero" cx="63" cy="63" r="55"></circle>
+            <text id="Service-Layer" fill="#000000" class="text-bold">
+                <tspan x="24" y="63">Service</tspan>
+                <tspan x="32.315918" y="84">Layer</tspan>
+            </text>
+        </g>
+        <g id="modeling-group" transform="translate(68.000000, 453.000000)">
+            <text id="Data-Modeling" class="text-bold color-two text-small">
+                <tspan x="0" y="19">Data Modeling</tspan>
+            </text>
+            <text id="can-connect" class="text-reg text-small">
+                <tspan x="0" y="43">can-connect</tspan>
+            </text>
+            <text id="can-set" class="text-reg text-small">
+                <tspan x="0" y="67">can-set</tspan>
+            </text>
+        </g>
+        <g id="WL-group" transform="translate(544.000000, 571.000000)">
+            <circle id="Oval" fill="#509444" fill-rule="nonzero" cx="63" cy="63" r="63"></circle>
+            <circle id="Oval" fill="url(#linearGradient-1)" fill-rule="nonzero" style="mix-blend-mode: multiply;" cx="63" cy="63" r="63"></circle>
+            <circle id="Oval" fill="url(#radialGradient-2)" fill-rule="nonzero" cx="63" cy="63" r="55"></circle>
+            <text id="window.-location" fill="#000000" class="text-bold">
+                <tspan x="18" y="63">window.</tspan>
+                <tspan x="19.6098633" y="84">location</tspan>
+            </text>
+        </g>
+        <g id="routing-group" transform="translate(526.000000, 453.000000)">
+            <text id="Routing" class="text-bold text-small color-two">
+                <tspan x="0" y="19">Routing</tspan>
+            </text>
+            <text id="can-route" class="text-reg text-small">
+                <tspan x="0" y="43">can-route</tspan>
+            </text>
+            <text id="can-route-pushstate" class="text-reg text-small">
+                <tspan x="0" y="67">can-route-pushstate</tspan>
+            </text>
+        </g>
+        <g id="observables-group" transform="translate(243.000000, 320.000000)">
+            <path d="M108,156 C79.67,156 52.93,148.2 32.71,134 C11.62,119.24 0,99.33 0,78 C0,56.67 11.62,36.71 32.71,21.95 C52.93,7.79 79.71,0 108,0 C136.29,0 163.08,7.79 183.3,21.95 C204.39,36.71 216,56.61 216,78 C216,99.39 204.39,119.29 183.3,134 C163.08,148.2 136.34,156 108,156 Z" id="Path" fill="#666666" fill-rule="nonzero"></path>
+            <ellipse id="Oval" fill="#FFFFFF" fill-rule="nonzero" cx="108" cy="78" rx="100" ry="70"></ellipse>
+            <text id="Observables" fill="#000000" class="text-bold">
+                <tspan x="43.2209473" y="60">Observables</tspan>
+            </text>
+            <text id="can-define" class="text-reg">
+                <tspan x="56.4638672" y="84">can-define</tspan>
+            </text>
+            <text id="can-observe" class="text-reg">
+                <tspan x="48.2248535" y="108">can-observe</tspan>
+            </text>
+        </g>
+        <g id="view-group" transform="translate(373.000000, 171.000000)" font-size="18">
+            <text id="View" class="text-bold text-small color-two">
+                <tspan x="0" y="19">View</tspan>
+            </text>
+            <text id="can-stache" class="text-reg text-small">
+                <tspan x="0" y="43">can-stache</tspan>
+            </text>
+            <text id="can-component" class="text-reg text-small">
+                <tspan x="0" y="67">can-component</tspan>
+            </text>
+            <text id="can-stache-bindings" class="text-reg text-small">
+                <tspan x="0" y="91">can-stache-bindings</tspan>
+            </text>
+        </g>
+        <g id="DOM-group" transform="translate(289.000000, 2.000000)">
+            <circle id="Oval" fill="#509444" fill-rule="nonzero" cx="63.08" cy="63.6" r="63"></circle>
+            <circle id="Oval" fill="url(#linearGradient-1)" fill-rule="nonzero" style="mix-blend-mode: multiply;" cx="63.08" cy="63.6" r="63"></circle>
+            <circle id="Oval" fill="url(#radialGradient-2)" fill-rule="nonzero" cx="63.08" cy="63.6" r="55"></circle>
+            <text id="DOM" fill="#000000" class="text-bold">
+                <tspan x="37" y="70.49">DOM</tspan>
+            </text>
+        </g>
+        <polygon id="arrow-left" fill="#000000" fill-rule="nonzero" points="239.016945 466.462786 231.986379 459.43222 256 453 249.56778 477.013621 242.537214 469.983055 149.993027 562.537214 157.013621 569.56778 133 576 139.442192 551.986379 146.462786 559.016945"></polygon>
+        <polygon id="arrow-right" fill="#000000" fill-rule="nonzero" points="463.984432 466.462786 471.005595 459.43222 447 453 453.432741 477.013621 460.453904 469.983055 553.015568 562.537214 545.984432 569.56778 570 576 563.567259 551.986379 556.536123 559.016945"></polygon>
+        <polygon id="arrow-top" fill="#000000" fill-rule="nonzero" points="354.002006 156.536777 364 156.536777 351.494986 135 339 156.536777 348.987966 156.536777 348.987966 287.463223 339 287.463223 351.494986 309 364 287.463223 354.002006 287.463223"></polygon>
+    </g>
+</svg>

--- a/docs/can-guides/experiment/technology/technology.md
+++ b/docs/can-guides/experiment/technology/technology.md
@@ -25,6 +25,10 @@ table.panels pre {
     border-bottom: 1px solid #ccc;
     border-left: 1px solid #ccc;
 }
+.object-svg {
+    max-width: 600px;
+    padding-bottom: 15px;
+}
 </style>
 
 ## Overview
@@ -33,9 +37,9 @@ CanJS, at its most simplified, consists of key-value <span class='obs'>observabl
 connected to web browser APIs using various libraries.
 
 
-<img src="../../docs/can-guides/experiment/technology/overview.svg"
-  alt="Observables are the center hub.  They are connected to the DOM by the view layer, the service layer by the data modeling layer, and the window location by the routing layer"
-  class='bit-docs-screenshot' width='600px'/>
+<object type='image/svg+xml' data='../../docs/can-guides/experiment/technology/overview.svg' class='bit-docs-screenshot object-svg'>
+    Observables are the center hub.  They are connected to the DOM by the view layer, the service layer by the data modeling layer, and the window location by the routing layer
+</object>
 
 The general idea is that you create <span class='obs'>observable</span> objects that encapsulate
 the logic and state of your application and connect those <span class='obs'>observable</span>
@@ -293,7 +297,7 @@ the forward (`⇦`) and back (`⇨`) buttons to see the count change:
 @demo demos/technology-overview/route-counter.html
 
 Notice how the URL changes when you click the `+1` button AND the _Count_ changes when the
-forward and back button are clicked.  
+forward and back button are clicked.
 
 
 The following connects the `<my-counter>`’s observable [can-component.prototype.ViewModel]
@@ -325,7 +329,7 @@ Component.extend({
 });
 
 // The `.data` property specifies the observable to cross
-// bind the URL to.  
+// bind the URL to.
 route.data = document.querySelector("my-counter").viewModel;
 route.start();
 </script>


### PR DESCRIPTION
Fonts now working correctly in Safari
<img width="1174" alt="Screen Shot 2019-07-03 at 8 21 05 AM" src="https://user-images.githubusercontent.com/4571457/60595405-f3966e00-9d74-11e9-89db-c1f1bf067824.png">

With a fallback
<img width="1174" alt="Screen Shot 2019-07-03 at 8 29 18 AM" src="https://user-images.githubusercontent.com/4571457/60595435-03ae4d80-9d75-11e9-8dcf-23b39ee251de.png">

BONUS - updated file is 50% smaller than previous
<img width="538" alt="Screen Shot 2019-07-03 at 8 19 34 AM" src="https://user-images.githubusercontent.com/4571457/60595472-158ff080-9d75-11e9-9425-c755780e4ef3.png">
