### PR TITLE
Make code blocks with ellipses valid

### DIFF
--- a/docs/can-canjs/can-api.md
+++ b/docs/can-canjs/can-api.md
@@ -1431,7 +1431,7 @@ GET /api/todos?
       "name": "mow lawn",
       "complete": false
     },
-    ...
+    // ...
   ]
 }
 ```

--- a/docs/can-canjs/can-core.md
+++ b/docs/can-canjs/can-core.md
@@ -190,14 +190,14 @@ import DefineList from 'can-define/list/list';
 import set from 'can-set';
 
 const Todo = DefineMap.extend({
-	...
+	// ...
 });
 const TodosList = DefineMap.extend({
 	"#": Todo,
-	...
+	// ...
 });
 const todosAlgebra = new set.Algebra({
-	...
+	// ...
 });
 
 const connection = baseMap({
@@ -270,12 +270,13 @@ let template = stache(`
 		{{#if(todos.isPending)}}<li>Loading…</li>{{/if}}
 		{{#if(todos.isResolved)}}
 			{{#for(todo of todos.value)}}
-				"<li class='{{#todo.complete}}complete{{/}}'>{{todo.name}}</li>
+				<li class="{{#todo.complete}}complete{{/}}">{{todo.name}}</li>
 			{{else}}
 				<li>No todos</li>
 			{{/for}}
 		{{/if}}
-	</ul>`);
+	</ul>
+`);
 
 // Calls the template with some data
 let fragment = template({

--- a/docs/can-canjs/can-infrastructure.md
+++ b/docs/can-canjs/can-infrastructure.md
@@ -23,8 +23,8 @@ import canEvent from 'can-event';
 import assign from 'can-util/js/assign/assign';
 
 // Create the Person type
-function Person(){ ... };
-Person.prototype.method = function(){ ... };
+function Person(){ /* ... */ };
+Person.prototype.method = function(){ /* ... */ };
 
 // Add event mixin:
 assign(Person.prototype, canEvent);
@@ -33,7 +33,7 @@ assign(Person.prototype, canEvent);
 const me = new Person();
 
 // Now listen and dispatch events!
-me.addEventListener("name", function(){ ... });
+me.addEventListener("name", function(){ /* ... */ });
 
 me.dispatch("name");
 ```

--- a/docs/can-guides/api-guide.md
+++ b/docs/can-guides/api-guide.md
@@ -36,7 +36,7 @@ So understanding CanJS’s API pages are about understanding the relationships b
 - packages and modules and their exports
 - functions, properties, and type definitions (typedefs) related to module exports
 
-... and what’s documented on those pages.  
+…and what’s documented on those pages.  
 
 ### Library Collection pages
 
@@ -172,7 +172,7 @@ more information and examples on what is being documented.
 > a specific piece of CanJS’s API.
 
 
-## How to find what you’re looking for ...
+## How to find what you’re looking for…
 
 1. Get a good understand of the purpose behind each module.  
 2. Start with core modules.

--- a/docs/can-guides/commitment/recipes/canvas-clock/canvas-clock.md
+++ b/docs/can-guides/commitment/recipes/canvas-clock/canvas-clock.md
@@ -274,7 +274,7 @@ In this section, we will:
 
 ### What you need to know
 
-- Move the __draw circle__ into the `this.listenTo("time", ...)` event handler so it is redrawn
+- Move the __draw circle__ into the `this.listenTo("time", /* ... */)` event handler so it is redrawn
   when the time changes.
 - Use [clearRect(x, y, width, height)](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/clearRect) to clear
   the canvas.

--- a/docs/can-guides/commitment/recipes/cta-bus-map/cta-bus-map.md
+++ b/docs/can-guides/commitment/recipes/cta-bus-map/cta-bus-map.md
@@ -553,7 +553,7 @@ We will do this by:
   });
   ```
 
-- To create a google map, use [new google.map.Map(...)](https://developers.google.com/maps/documentation/javascript/reference) once the
+- To create a google map, use [new google.map.Map( /* ... */ )](https://developers.google.com/maps/documentation/javascript/reference) once the
   `googleAPI` has completed loading:
 
   ```js

--- a/docs/can-guides/commitment/recipes/modals/modals.md
+++ b/docs/can-guides/commitment/recipes/modals/modals.md
@@ -116,7 +116,7 @@ in a modal instead of "light DOM".
 
 ### What you need to know
 
-- Use `{default(){ ... }}` to create a default value for a property:
+- Use `{default(){ /* ... */ }}` to create a default value for a property:
 
   ```js
   ViewModel: {

--- a/docs/can-guides/commitment/recipes/search-list-details/3-instantiate-components.js
+++ b/docs/can-guides/commitment/recipes/search-list-details/3-instantiate-components.js
@@ -9,7 +9,7 @@ Component.extend({
     </div>
 
     {{# if(routeComponent.isPending) }}
-      Loading...
+      Loading…
     {{/ if }}
 
     {{# if(routeComponent.isResolved) }}

--- a/docs/can-guides/commitment/recipes/search-list-details/4-bind-properties.js
+++ b/docs/can-guides/commitment/recipes/search-list-details/4-bind-properties.js
@@ -9,7 +9,7 @@ Component.extend({
     </div>
 
     {{# if(routeComponent.isPending) }}
-      Loading...
+      Loading…
     {{/ if }}
 
     {{# if(routeComponent.isResolved) }}

--- a/docs/can-guides/commitment/recipes/search-list-details/search-list-details.md
+++ b/docs/can-guides/commitment/recipes/search-list-details/search-list-details.md
@@ -76,7 +76,7 @@ ViewModel: {
 }
 ```
 
-- Use `new observe.Object({ ... })` to create an [can-observe.Object observable Object].
+- Use `new observe.Object({ /* ... */ })` to create an [can-observe.Object observable Object].
 - Set [can-route.data route.data] to the object you want cross-bound to the URL.
 - `route.register( "{abc}" );` will create a URL matching rule.
 

--- a/docs/can-guides/commitment/recipes/tinder-like-carousel/Tinder-Like-Carousel.md
+++ b/docs/can-guides/commitment/recipes/tinder-like-carousel/Tinder-Like-Carousel.md
@@ -318,7 +318,7 @@ as the user creates a drag motion.
   You can listen to pointer events with [can-event-queue/map/map.listenTo] inside `connectedCallback` like:
 
   ```js
-  this.listenTo(current, "pointerdown", (event) => { ... })
+  this.listenTo(current, "pointerdown", (event) => { /* ... */ })
   ```
 
   As mobile Safari doesn't support pointer events, we have already installed the

--- a/docs/can-guides/commitment/recipes/todomvc-with-steal/todomvc-with-steal.md
+++ b/docs/can-guides/commitment/recipes/todomvc-with-steal/todomvc-with-steal.md
@@ -37,7 +37,7 @@ covering CanJS core libraries.
 
 - If you load StealJS plugins, add them to your _package.json_ configuration like:
 
-  ```
+  ```js
   "steal": {
     "plugins": [
       "steal-css"
@@ -52,7 +52,7 @@ covering CanJS core libraries.
 
   Component.extend({
       tag: "todo-mvc",
-      view: ...,
+      view: "...",
       ViewModel: {
          ...
       }
@@ -314,7 +314,7 @@ QUnit.equal(todos.allComplete, true, "allComplete");
 
   ```js
   list = new ListType([
-    // ...
+    // // ...
   ]);
   list.filter(function(item) {
       return test(item);
@@ -509,14 +509,14 @@ __DELETE /api/todos/{id}__
   fixture("/api/entities", function(request) {
     request.data.folderId //-> "1"
 
-    return {data: [...]}
+    return {data: [ /* ... */ ]}
   })
   ```
 
 - [can-fixture.store can-fixture.store] - can be used to automatically filter records if given a [can-set.Algebra].
 
   ```js
-  const entities = [ .... ];
+  const entities = [ /* ... */ ];
   const entitiesStore = fixture.store( entities, entitiesAlgebra );
   fixture("/api/entities/{id}", entitiesStore);
   ```

--- a/docs/can-guides/commitment/recipes/weather-report/weather-report-advanced.md
+++ b/docs/can-guides/commitment/recipes/weather-report/weather-report-advanced.md
@@ -40,7 +40,7 @@ const WeatherViewModel = can.DefineMap.extend({
       this.place = null;
     }
   },
-  ...
+  // ...
 });
 ```
 
@@ -54,7 +54,7 @@ this:
 
 ```js
 const WeatherViewModel = can.DefineMap.extend({
-  ...
+  // ...
   place: {
     type: "any",
     get: function(lastSet) {
@@ -67,7 +67,7 @@ const WeatherViewModel = can.DefineMap.extend({
       }
     }
   },
-  ...
+  // ...
 });
 ```
 
@@ -227,7 +227,7 @@ We want to define the behavior of `place` so that it becomes `null` when `locati
 
   const nameStream = me.toStream(".name");
 
-  nameStream.onValue(function() { ... })
+  nameStream.onValue(function() { /* ... */ })
   ```
 
 ### The solution
@@ -269,8 +269,8 @@ We will do this by:
 
   ```js
   navigator.geolocation.getCurrentPosition(
-      function(position) {...},
-      function(err) {...});
+      function(position) { /* ... */ },
+      function(err) { /* ... */ });
   ```
 
 - The [geolocation](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/Using_geolocation)
@@ -278,8 +278,8 @@ We will do this by:
 
   ```js
   const watch = navigator.geolocation.watchPosition(
-      function(position) {...},
-      function(err) {...});
+      function(position) { /* ... */ },
+      function(err) { /* ... */ });
   ```
 
   To cancel watching, call:

--- a/docs/can-guides/contribute/making-a-new-package.md
+++ b/docs/can-guides/contribute/making-a-new-package.md
@@ -99,7 +99,7 @@ In order to include the source project's documentation on the CanJS site, the ma
 
 - `PACKAGE_NAME`: is the project name, which should match the `name` property in the source project's `package.json`.
 - `CANJS_PARENT_TARGET`: is the name of the target area in CanJS. For example, if the module is a part of the "Ecosystem", then the value for `@parent` would be `can-ecosystem`. If the target is "Legacy" then the value is `can-legacy`.
-- `PATH_TO_PACKAGE.JSON`: is a relative path from the main document file for the project repo. Considering the following structure...
+- `PATH_TO_PACKAGE.JSON`: is a relative path from the main document file for the project repo. Considering the following structure…
 
 ```
 - docs
@@ -166,8 +166,8 @@ If you can't you might need to:
   ```js
   let ignoreModuleNamesStartingWith = [
   	"jquery",
-	"SOME_OTHER_LIBRARY"
-  	...
+    "SOME_OTHER_LIBRARY"
+  	// ...
   ]
   ```
 
@@ -175,9 +175,9 @@ If you can't you might need to:
 
   ```js
   let exportsMap = {
-      "jquery": "jQuery",
-      "SOME_OTHER_LIBRARY": "SomeOtherLibrary"
-	  ...
+    "jquery": "jQuery",
+    "SOME_OTHER_LIBRARY": "SomeOtherLibrary"
+	  // ...
   };
   ```
 

--- a/docs/can-guides/experiment/technology/routing.md
+++ b/docs/can-guides/experiment/technology/routing.md
@@ -548,7 +548,7 @@ Component.extend({
 ## Register routes
 
 Currently, after the user logs in, the application will show `<h2>Page Missing</h2>` because if the URL hash is empty, `page` property will be undefined. To have `page`
-be `"home"`, one would have to navigate to `"#!&page=home"` ... yuck!
+be `"home"`, one would have to navigate to `"#!&page=home"` … yuck!
 
 We want the `page` property to be `"home"` when the hash is empty. Furthermore,
 we want URLs like `#!tasks` to set the `page` property. We can do that
@@ -705,7 +705,7 @@ Component.extend({
 
 > Note, [can-reflect-promise] also adds `isPending` and `isRejected` properties to promises so that the view can handle these states as well.
 
-Then update the `componentToShow` getter to import the correct module. The value passed to the promise’s [then](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then) method will be a module object with a property for each of the module’s exports. In this example, the component constructor is the default export, so an instance of the component can be created using `new module.default({ ... })`. Returning the instances from the `then` method will set `componentToShow.value` to the component instance:
+Then update the `componentToShow` getter to import the correct module. The value passed to the promise’s [then](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then) method will be a module object with a property for each of the module’s exports. In this example, the component constructor is the default export, so an instance of the component can be created using `new module.default({ /* ... */ })`. Returning the instances from the `then` method will set `componentToShow.value` to the component instance:
 
 ```js
 import { Component, DefineMap, route, stacheRouteHelpers, value } from "can";

--- a/docs/can-guides/introduction/comparison.md
+++ b/docs/can-guides/introduction/comparison.md
@@ -286,7 +286,7 @@ These layers have a simple and inverse API, the Store layer takes actions and re
 
 <img src="../../docs/can-guides/images/introduction/redux-flow.png" style="width:100%;max-width:750px"/>
 
-...and there are layers *within those layers*, like **action creators** and **redux-middleware**.
+…and there are layers *within those layers*, like **action creators** and **redux-middleware**.
 
 This architecture is nice and simple, with discrete lines of interaction and well-defined purpose and interface. The **tradeoff** however, is that to add a feature you need to add **_all_** the individual pieces to each of these layers.
 
@@ -310,7 +310,7 @@ So in your **React-Redux** app, you would at minimum need to import:
 
 <img src="../../docs/can-guides/images/introduction/video-chat-react.png" style="width:100%;max-width:750px"/>
 
-...and wire them all together with code. The wiring up is not free, and though simple, may produce bugs and there is no guarantee the individual bits will work well together.
+…and wire them all together with code. The wiring up is not free, and though simple, may produce bugs and there is no guarantee the individual bits will work well together.
 
 **CanJS** has a more cross-cutting encapsulation strategy. A can-component knows what data it accepts through **attrs**, and can fetch its own data with models as dependencies, and also handles the user interaction, state-changes and display all within the component.
 
@@ -507,7 +507,7 @@ var keyup = Rx.Observable.fromEvent($input, 'keyup')
   .distinctUntilChanged();
 ```
 
-...where data flows through functions, that convert, filter and transform that data and pass it on to callbacks over time.
+…where data flows through functions, that convert, filter and transform that data and pass it on to callbacks over time.
 
 **CanJS** supports a more Object Oriented approach:
 
@@ -538,7 +538,7 @@ let Order = DefineMap.extend({
   }
 });
 ```
-...where data is packaged along with behaviors (methods) in objects that represent domain concepts.
+…where data is packaged along with behaviors (methods) in objects that represent domain concepts.
 
 While **RxJS** offers a **stream** of events and values, **CanJS** offers instances that can be directly acted upon, stored and serialized.
 

--- a/docs/can-guides/introduction/technical.md
+++ b/docs/can-guides/introduction/technical.md
@@ -410,14 +410,14 @@ The following illustrates the signatures of these behaviors:
 ```js
 DefineMap.extend({
     propertyName: {
-        get: function(lastSetValue, resolve){ ... },
-        set: function(newValue, resolve){ ... },
-        type: function(newValue, propertyName){ ... },
+        get: function(lastSetValue, resolve){ /* ... */ },
+        set: function(newValue, resolve){ /* ... */ },
+        type: function(newValue, propertyName){ /* ... */ },
         Type: Constructor,
-        default: function(){ ... },
+        default: function(){ /* ... */ },
         Default: Constructor,
-        serialize: function(){ ... },
-        stream: function(setStream){ ... }
+        serialize: function(){ /* ... */ },
+        stream: function(setStream){ /* ... */ }
     }
 })
 ```
@@ -431,8 +431,8 @@ DefineMap.extend({
     propertyB: String      -> {type: String}
     propertyC: Constructor -> {Type: Constructor}
     propertyD: [PropDefs]  -> {Type: DefineList.extend({"#": PropDefs})>}
-    get propertyE(){...}   -> {get: propertyE(){... }}
-    set propertyF(){...}   -> {get: propertyF(){... }}
+    get propertyE(){ /* ... */ }   -> {get: propertyE(){ /* ... */ }}
+    set propertyF(){ /* ... */ }   -> {get: propertyF(){ /* ... */ }}
     method: Function
 })
 ```
@@ -1031,7 +1031,7 @@ hands when the time changes.
 
 ```js
 Analog = function(element, timer) {
-    ...
+    // ...
     timer.on("time", this.drawClock.bind(this) );
 };
 

--- a/docs/can-guides/setup/setting-up-canjs.md
+++ b/docs/can-guides/setup/setting-up-canjs.md
@@ -58,7 +58,7 @@ any development environment. This section gives technical details on these items
     ```js
     export { default as Component } from "can-component";
     export { default as restModel } from "can-rest-model";
-    ...
+    // ...
     ```
 
     Most module loaders setups with tree-shaking (ex: webpack 2 and StealJS 2)
@@ -1105,7 +1105,7 @@ For example, after installing the packages you need, you can create `my-can.js` 
 // my-can.js
 export { default as Component } from "can-component";
 export { default as restModel } from "can-rest-model";
-...
+// ...
 ```
 
 And then import the named exports from "my-can":

--- a/docs/can-guides/topics/data/configuring-requests.md
+++ b/docs/can-guides/topics/data/configuring-requests.md
@@ -7,12 +7,12 @@
 @body
 
 ## Note to reader
- 
+
 The data guide and its sub-sections are a work in progress and are currently under review. The information provided is accurate; however, it will likely undergo several rounds of revision before being formally published. Feel free to go through these sections to learn about how data-modeling works, and please leave any comments in [this Google Doc](https://docs.google.com/document/d/14egbanRmOqpxw5MJbpBOTFfqkd3sGAN6jurog5l2my8/edit?usp=sharing.
 
 ## Overview
 
-This document describes how to configure [can-connect] for loading model data from a remote server. Every model in your application will have its own connection, and each connection will be able to Create, Read, Update, and Delete (CRUD) model data from the server. There are two sections of this document: 
+This document describes how to configure [can-connect] for loading model data from a remote server. Every model in your application will have its own connection, and each connection will be able to Create, Read, Update, and Delete (CRUD) model data from the server. There are two sections of this document:
 
 1. [Part 1 - Making requests](#making-requests) - configuring your connection for outgoing requests
 2. [Part 2 - Handling the response](#managing-response-data) - parsing and formatting response data for use within your app
@@ -26,7 +26,7 @@ When configuring a connection, the [can-connect/data/url/url data-url behavior] 
 
 ### Understanding the [can-connect/DataInterface]
 
-Each of the CRUD operations maps to one of the functions descibed by the [can-connect/DataInterface]. The `DataInterface` is a lower level interface used for loading **raw data** from a remote data source. This is not the same as the [can-connect/InstanceInterface] which deals with typed data. Understanding the raw `DataInterface` is crucial for making the customizations described below. 
+Each of the CRUD operations maps to one of the functions descibed by the [can-connect/DataInterface]. The `DataInterface` is a lower level interface used for loading **raw data** from a remote data source. This is not the same as the [can-connect/InstanceInterface] which deals with typed data. Understanding the raw `DataInterface` is crucial for making the customizations described below.
 
 > **IMPORTANT:** Whenever loading data within your application, you almost always want to use the [can-connect/InstanceInterface]. The lower level `DataInterface` should be used for customizing how raw data is loaded .
 
@@ -103,7 +103,7 @@ const connection = restModel({
 ```
 
 ### Implementing the DataInterface yourself
-    
+
 Consider a situation where an application loads all incomplete TODOs from a special URL like `/api/todos/incomplete`. In such cases, you can write a custom [can-connect/data/url/url.getListData getListData] function which performs the actual ajax request. You can implement any of the [can-connect/DataInterface] methods in a similar way:
 
 ```js
@@ -114,18 +114,18 @@ const connection = restModel({
     getListData(query) {
       if(query.filter.complete === false) {
         // Load all incomplete TODOs from a separate URL
-        return ajax({ url: '/api/todos/incomplete', data: query, ... });
+        return ajax({ url: '/api/todos/incomplete', data: query, /* ... */ });
       }
-      
+
       // Load all other TODOs from the primary URL
-      return ajax({ url: '/api/todos', data: query, ... });
+      return ajax({ url: '/api/todos', data: query, /* ... */ });
     }
   }
 });
-    
+
 // Loads incomplete TODOs from '/api/todos/incomplete'
 connection.getList({ complete: false });
-    
+
 // Loads all TODOs from '/api/todos'
 connection.getList({});
 ```
@@ -188,15 +188,15 @@ connect.behavior("data/url", function( baseConnection ) {
         data: query
       });
     },
-    getData(query) { return ajax(...) },
-    createData(data) { return ajax(...) },
-    updateData(data) { return ajax(...) },
-    destroyData(data) { return ajax(...) }
+    getData(query) { return ajax( /* ... */ ) },
+    createData(data) { return ajax( /* ... */ ) },
+    updateData(data) { return ajax( /* ... */ ) },
+    destroyData(data) { return ajax( /* ... */ ) }
   };
 });
 ```
 
-### Loading list data 
+### Loading list data
 
 Loading list data is unique because data can be filtered, sorted, and paginated using [can-query-logic]. This is where the real power of [can-connect] becomes available as it enables advanced behaviors such as the [can-connect/constructor/store/store constructor store], [can-connect/real-time/real-time real-time updates], caching, and other goodness. We recommend reading the following documents to become familiar with how to query logic works:
 
@@ -212,34 +212,34 @@ Once raw data is loaded from a server, that data needs to be instantiated into t
 
 ### Understanding how `can-connect` manages Model instances
 
-Many of the behaviors available with [can-connect] are designed to work with instances of Model data for your application. A single [can-connect/constructor/store/store] is used to keep references to instance data and prevent multiple copies of an instance from being used by the application at once. 
+Many of the behaviors available with [can-connect] are designed to work with instances of Model data for your application. A single [can-connect/constructor/store/store] is used to keep references to instance data and prevent multiple copies of an instance from being used by the application at once.
 
 For example, if you have 3 different components which display information about the currently logged in `User`, you can rest easy knowing that all 3 components will receive the same exact instance of that user. If the user gets updated by one component, all other components will receive those updates thanks to the [can-connect/real-time/real-time real-time behavior].
 
 
 ### Customizing how response data his handled
 
-There are two types of response formats expected by the [can-connect/constructor/constructor constructor behavior]: 
+There are two types of response formats expected by the [can-connect/constructor/constructor constructor behavior]:
 
 - **Instance Data:** - The result of most CRUD operations. The full response body is treated as the instance data.
 
-    ```json
+    ```js
     {
       id: 111,
       name: 'Justin',
       email: ...
     }
     ```
-    
+
 - **List Data:** The result of a a call to `getList`. An array of instance data must be on a `data` property in the response body.
 
-    ```json
+    ```js
     {
       count: 3,
       data: [
-        { id: 111, name: 'Justin', ...},
-        { id: 222, name: 'Brian', ...},
-        { id: 333, name: 'Paula', ...}
+        { id: 111, name: 'Justin', /* ... */},
+        { id: 222, name: 'Brian', /* ... */},
+        { id: 333, name: 'Paula', /* ... */}
       ]
     }
     ```

--- a/docs/can-guides/topics/data/customizing-connections/customizing-connections.md
+++ b/docs/can-guides/topics/data/customizing-connections/customizing-connections.md
@@ -493,13 +493,13 @@ div.spaced > ol > li {
 
 1. A user calls [can-connect/can/map/map.prototype.save <code>save</code>] on an instance of one of their [can-connect ]'d models: 
 	```
-	const Todo = DefineMap.extend(...);
+	const Todo = DefineMap.extend( /* ... */ );
 	Todo.connection = restModel({
 		Map: Todo,
 		...
 	});
 	const todoInstance = new Todo({ value: 'say hello to world' });
-	todoInstance.save().then(...)
+	todoInstance.save().then( /* ... */ )
 	```
 	@highlight 7
 	

--- a/docs/can-guides/topics/data/introduction.md
+++ b/docs/can-guides/topics/data/introduction.md
@@ -451,7 +451,7 @@ Component.extend({
                 <input type='date' valueAsDate:bind='todo.dueDate'/>
             </p>
             <button disabled:from="todo.preventSave()">Create Todo</button>
-            {{# if(todo.isSaving()) }}Creating ....{{/ if}}
+            {{# if(todo.isSaving()) }}Creating…{{/ if}}
         </form>
     `,
     ViewModel: {
@@ -773,9 +773,9 @@ The previous _Creating Records_, _Updating Records_ and _Destroying Records_
 examples showed how to listen to when records are mutated:
 
 ```js
-this.listenTo(Todo,"created",   (event, createdTodo)   => { ... })
-this.listenTo(Todo,"updated",   (event, updatedTodo)   => { ... })
-this.listenTo(Todo,"destroyed", (event, destroyedTodo) => { ... })
+this.listenTo(Todo,"created",   (event, createdTodo)   => { /* ... */ })
+this.listenTo(Todo,"updated",   (event, updatedTodo)   => { /* ... */ })
+this.listenTo(Todo,"destroyed", (event, destroyedTodo) => { /* ... */ })
 ```
 
 These listeners can be used to update lists similar to how the _Destroying Records_

--- a/docs/can-guides/topics/debugging.md
+++ b/docs/can-guides/topics/debugging.md
@@ -158,7 +158,7 @@ name your function by passing `.extend` a name as the first argument:
 ```js
 import { DefineMap } from "can";
 
-export default DefineMap.extend("TheNameOfMyType", { ... })
+export default DefineMap.extend("TheNameOfMyType", { /* ... */ })
 ```
 
 #### Label instances
@@ -176,10 +176,10 @@ expressions:
 
 ```js
 // INSTEAD OF THIS:
-map.on("key", function(ev, newVal) { ... })
+map.on("key", function(ev, newVal) { /* ... */ })
 
 // DO THIS:
-map.on("key", function keyChanged(ev, newVal) { ... })
+map.on("key", function keyChanged(ev, newVal) { /* ... */ })
 ```
 
 Similarly, if you create [can-compute]s or [can-observation]s yourself, make sure the function

--- a/docs/can-guides/topics/forms.md
+++ b/docs/can-guides/topics/forms.md
@@ -71,7 +71,7 @@ You can combine Event and Attribute bindings in a [“data down, actions up”](
 
 This example uses `value:from="name"` to set the `value` attribute of both text fields when `name` in the scope changes. It also uses `on:change="handleAction('set', 'name', scope.element.value)"` to listen for `"change"` events on the text fields and call the `handleAction` function with the text field’s [http://localhost/canjs/doc/can-stache/keys/scope#scope_element value].
 
-Data is passed _down_ from the scope to each element using `value:from` and the action of changing the data is passed _up_ through `on:change="handleAction(...)"`, which means that the `value` attribute of the text field is always in sync with the `name` property in the scope.
+Data is passed _down_ from the scope to each element using `value:from` and the action of changing the data is passed _up_ through `on:change="handleAction( /* ... */ )"`, which means that the `value` attribute of the text field is always in sync with the `name` property in the scope.
 
 To see a larger example of this pattern, check out the [guides/forms#Datadown_actionsupwithmultiplecomponents extended example].
 
@@ -334,7 +334,7 @@ Here is an example showing this kind of manual validation for a phone number:
 
 It is also possible to use [https://validatejs.org/#validators validate.js] or another JavaScript validation library through plugins to [can-define] like [can-define-validate-validatejs]. This makes it easy to have consistent validation throughout your application without having to write your own validation rules.
 
-This plugin works by reading `validate: { ... }` behaviors from each [can-define.types.propDefinition PropDefinition] of your view-model and using them to build up [https://validatejs.org/#validators validate.js constraints].
+This plugin works by reading `validate: { /* ... */ }` behaviors from each [can-define.types.propDefinition PropDefinition] of your view-model and using them to build up [https://validatejs.org/#validators validate.js constraints].
 
 It also adds an `errors` method to your view-model for getting a list of invalid properties. The example below also creates a `formatErrors` helper to make working with these errors easier.
 
@@ -596,7 +596,7 @@ This `default` value is initialized the first time the `makes` property is used 
 <select value:bind="makeId"
 	{{# if(makes.isPending) }}disabled{{/ if }}>
 	{{# if(makes.isPending) }}
-	  <option value=''>Loading...</option>
+	  <option value=''>Loading…</option>
 	{{ else }}
 	  {{^ makeId }}
 		<option value=''>Select a Make</option>
@@ -679,7 +679,7 @@ This also means that in order to get the `makes` data, we need to use the `value
 <select value:bind="makeId"
 	{{# if(makes.isPending) }}disabled{{/ if }}>
 	{{# if(makes.isPending) }}
-	  <option value=''>Loading...</option>
+	  <option value=''>Loading…</option>
 	{{ else }}
 	  {{^ makeId }}
 		<option value=''>Select a Make</option>
@@ -759,7 +759,7 @@ this.makesPromise.then(function(makes) {
 });
 ```
 
-> **Note:** when using asynchronous getters, you cannot use the shorthand getter syntax (`get makes() { ... }`) since JavaScript getters [http://whereswalden.com/2010/08/22/incompatible-es5-change-literal-getter-and-setter-functions-must-now-have-exactly-zero-or-one-arguments/ must have only one argument].
+> **Note:** when using asynchronous getters, you cannot use the shorthand getter syntax (`get makes() { /* ... */ }`) since JavaScript getters [http://whereswalden.com/2010/08/22/incompatible-es5-change-literal-getter-and-setter-functions-must-now-have-exactly-zero-or-one-arguments/ must have only one argument].
 
 #### Loading new data
 
@@ -769,7 +769,7 @@ In order to load the correct `models` for a make, a request to the `/models` API
 <select value:bind="makeId"
 	{{# if(makes.isPending) }}disabled{{/ if }}>
 	{{# if(makes.isPending) }}
-	  <option value=''>Loading...</option>
+	  <option value=''>Loading…</option>
 	{{ else }}
 	  {{^ makeId }}
 		<option value=''>Select a Make</option>
@@ -928,7 +928,7 @@ Similar to the `makeId`, the `<select>` for models is bound to the `modelId` pro
 <select value:bind="makeId"
 	{{# if(makes.isPending) }}disabled{{/ if }}>
 	{{# if(makes.isPending) }}
-	  <option value=''>Loading...</option>
+	  <option value=''>Loading…</option>
 	{{ else }}
 	  {{^ makeId }}
 		<option value=''>Select a Make</option>

--- a/docs/can-guides/upgrade/migrating-to-canjs-3.md
+++ b/docs/can-guides/upgrade/migrating-to-canjs-3.md
@@ -57,7 +57,7 @@ For example, you might be using [can-component] like this:
 ```js
 import can from 'can';
 
-can.Component.extend({ ... });
+can.Component.extend({ /* ... */ });
 ```
 
 Update your code to instead look like this:
@@ -65,7 +65,7 @@ Update your code to instead look like this:
 ```js
 import Component from 'can/component/component';
 
-Component.extend({ ... });
+Component.extend({ /* ... */ });
 ```
 
 Use the same pattern for the other modules you are using. Be careful when declaring names for imported modules that share a similar name to native objects like Map.
@@ -159,7 +159,7 @@ It can only lookup the `page` property on `some-component`’s own [can-componen
 ```js
 Component.extend({
 	tag: "some-component",
-	ViewModel: ...,
+	ViewModel: { /* ... */ },
 	leakScope: true
 });
 ```
@@ -177,7 +177,7 @@ This will update your `package.json` to look something like this:
 
 ```js
 {
-  ...
+  // ...
   "dependencies": {
     "can": "^<%canjs.package.version%>"
   }
@@ -464,7 +464,7 @@ You can fix this either by having your helpers handle computes, or by using [can
 Most recently-built applications do not depend on adding to the global namespace, but in case you have code that does:
 
 ```js
-Construct.extend("foo.bar", ...)
+Construct.extend("foo.bar", /* ... */)
 ```
 
 Which sets `window.foo.bar`, this argument is no longer accepted by [can-construct]. If you *really* need to set a global, you can do so yourself using the return value of [can-construct.extend].
@@ -485,11 +485,11 @@ If you’re using StealJS 0.16, you don’t need to do anything else to make you
 
 If you’re using StealJS 1, you also need to add `steal-stache` to the `plugins` configuration in your `package.json`:
 
-```json
+```js
 {
-  ...
+  // ...
   "steal": {
-    ...
+    // ...
     "plugins": ["steal-stache"]
   }
 }
@@ -532,7 +532,7 @@ For example, you might be using [can-component] like either:
 ```js
 import can from 'can';
 
-can.Component.extend({ ... });
+can.Component.extend({ /* ... */ });
 ```
 
 or
@@ -540,7 +540,7 @@ or
 ```js
 import Component from 'can/component/component';
 
-Component.extend({ ... });
+Component.extend({ /* ... */ });
 ```
 
 Regardless of which you are using, update your code to instead look like:
@@ -548,7 +548,7 @@ Regardless of which you are using, update your code to instead look like:
 ```js
 import Component from 'can-component';
 
-Component.extend({ ... });
+Component.extend({ /* ... */ });
 ```
 
 Use the same pattern for the other `can` modules you are using. In general, you should not be using the `can.` properties any more, but rather importing (through your module loader / bundler) only the packages and modules that you are using.

--- a/docs/can-guides/upgrade/migrating-to-canjs-4.md
+++ b/docs/can-guides/upgrade/migrating-to-canjs-4.md
@@ -236,7 +236,7 @@ function Thing(){
 assign(Thing.prototype, canEvent);
 
 let thing = new Thing();
-thing.on("prop", function(){ ... });
+thing.on("prop", function(){ /* ... */ });
 ```
 
 with:
@@ -251,7 +251,7 @@ function Thing(){
 mixinMapBindings(Thing.prototype);
 
 let thing = new Thing();
-thing.on("prop", function(){ ... });
+thing.on("prop", function(){ /* ... */ });
 ```
 
 ### inserted/removed event
@@ -357,7 +357,7 @@ import stache from "can-stache";
 const view = stache.from("my-template");
 view({
 	team: "Dragons",
-	players: [ ... ]
+	players: [ /* ... */ ]
 });
 ```
 

--- a/docs/can-guides/upgrade/migrating-to-canjs-5.md
+++ b/docs/can-guides/upgrade/migrating-to-canjs-5.md
@@ -164,7 +164,7 @@ import set from "can-set";
 import DefineMap from "can-define/map/map";
 import superMap from "can-connect/can/super-map/super-map";
 
-const Todo = DefineMap.extend({ ... });
+const Todo = DefineMap.extend({ /* ... */ });
 
 todoAlgebra = new set.Algebra(
     set.props.id("_id"),
@@ -175,7 +175,7 @@ todoAlgebra = new set.Algebra(
 superMap({
     Map: Todo,
     algebra: todoAlgebra,
-    ...
+    // ...
 })
 ```
 
@@ -187,8 +187,8 @@ import DefineMap from "can-define/map/map";
 import DefineList from "can-define/list/list";
 import superMap from "can-connect/can/super-map/super-map";
 
-const Todo = DefineMap.extend({ ... });
-Todo.List = DefineList.extend({"#": Todo, ...});
+const Todo = DefineMap.extend({ /* ... */ });
+Todo.List = DefineList.extend({"#": Todo, /* ... */});
 
 todoAlgebra = new set.Algebra(
     set.props.id("_id"),
@@ -199,7 +199,7 @@ todoAlgebra = new set.Algebra(
 superMap({
     Map: Todo,
     algebra: todoAlgebra,
-    ...
+    // ...
 })
 ```
 
@@ -220,7 +220,7 @@ const Todo = DefineMap.extend({
     complete: QueryLogic.makeEnum([true, false]),
     status: QueryLogic.makeEnum(["new","pending","resolved"])
 });
-Todo.List = DefineList.extend({"#": Todo, ...});
+Todo.List = DefineList.extend({"#": Todo, /* ... */});
 
 let todoQueryLogic = new QueryLogic(Todo,{
     toQuery(params){
@@ -234,7 +234,7 @@ let todoQueryLogic = new QueryLogic(Todo,{
 superModel({
     Map: Todo,
     queryLogic: todoQueryLogic,
-    ...
+    // ...
 })
 ```
 
@@ -256,7 +256,7 @@ import DefineMap from "can-define/map/map";
 
 const Todo = DefineMap.extend({
     id: "number",
-    ...
+    // ...
 });
 
 const todoConnection = connect( [ dataUrl, constructor, canMap ], {
@@ -279,7 +279,7 @@ import DefineList from "can-define/list/list";
 
 const Todo = DefineMap.extend({
     id: "number",
-    ...
+    // ...
 });
 const TodoList = DefineList.extend({
     "#": Todo
@@ -305,7 +305,7 @@ import DefineList from "can-define/list/list";
 
 const Todo = DefineMap.extend({
     id: "number",
-    ...
+    // ...
 });
 Todo.List = DefineList.extend({
     "#": Todo
@@ -370,7 +370,7 @@ import DefineList from "can-define/list/list";
 
 const Todo = DefineMap.extend({
     id: "number",
-    ...
+    // ...
 });
 Todo.List = DefineList.extend({
     "#": Todo
@@ -399,7 +399,7 @@ import DefineList from "can-define/list/list";
 
 const Todo = DefineMap.extend({
     _id: "number",
-    ...
+    // ...
 });
 Todo.List = DefineList.extend({
     "#": Todo
@@ -422,7 +422,7 @@ from the [can-query-logic] created by or passed to the `todoConnection`. For exa
 ```js
 const Todo = DefineMap.extend({
     _id: "number",
-    ...
+    // ...
 });
 Todo.List = DefineList.extend({
     "#": Todo
@@ -445,7 +445,7 @@ behavior to specify that `_id` is the identity property:
 ```js
 const Todo = DefineMap.extend({
     _id: {type: "number", identity: true}
-    ...
+    // ...
 });
 Todo.List = DefineList.extend({
     "#": Todo
@@ -465,7 +465,7 @@ no `queryLogic` is needed as this will happen by default.  The following is equi
 ```js
 const Todo = DefineMap.extend({
     _id: {type: "number", identity: true}
-    ...
+    // ...
 });
 Todo.List = DefineList.extend({
     "#": Todo
@@ -484,7 +484,7 @@ a `can.listQuery` symbol.  If you were setting `__listSet` on an List like the f
 
 ```js
 const ClassRoom = DefineMap.extend({
-    ...
+    // ...
     students: {
         type: Student.List
         set(students) {
@@ -499,7 +499,7 @@ You should do it as follows:
 
 ```js
 const ClassRoom = DefineMap.extend({
-    ...
+    // ...
     students: {
         type: Student.List
         set(students) {
@@ -711,7 +711,7 @@ Component.extend({
 	ViewModel: {
 		get todosPromise(){ return Todo.getList(); },
 		name: { type: "string", default: "ViewModel" },
-		edit(todo) { ... }
+		edit(todo) { /* ... */ }
 	}
 })
 ```
@@ -729,7 +729,7 @@ Component.extend({
 	ViewModel: {
 		get todosPromise(){ return Todo.getList(); },
 		name: { type: "string", default: "ViewModel" },
-		edit(todo) { ... }
+		edit(todo) { /* ... */ }
 	}
 })
 ```
@@ -755,7 +755,7 @@ Component.extend({
 	ViewModel: {
 		get todosPromise(){ return Todo.getList(); },
 		name: { type: "string", default: "ViewModel" },
-		edit(todo) { ... }
+		edit(todo) { /* ... */ }
 	}
 })
 ```


### PR DESCRIPTION
We regularly show something like `{ ... }` in our examples, but that can’t be parsed as JS and prevents the code from being codemod-ed. This commit wraps those ellipses in a comment so the rest of the code block can be parsed.