### PR TITLE
fix(package): update can-define-mixin to version 0.3.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "can-define-array": "0.4.14",
     "can-define-backup": "2.1.2",
     "can-define-lazy-value": "1.1.1",
-    "can-define-mixin": "0.3.8",
+    "can-define-mixin": "0.3.10",
     "can-define-object": "0.1.5",
     "can-define-stream": "1.1.1",
     "can-define-stream-kefir": "1.1.1",


### PR DESCRIPTION
Closes #5131