### PR TITLE
Fix loading can-demo-models in Edge

### DIFF
--- a/docs/can-guides/experiment/crud-beginner/1.js
+++ b/docs/can-guides/experiment/crud-beginner/1.js
@@ -1,3 +1,3 @@
 // Creates a mock backend with 3 todos
-import { todoFixture } from "//unpkg.com/can-demo-models@5";
+import { todoFixture } from "//unpkg.com/can-demo-models@5/index.mjs";
 todoFixture(3);

--- a/docs/can-guides/experiment/crud-beginner/2.js
+++ b/docs/can-guides/experiment/crud-beginner/2.js
@@ -1,5 +1,5 @@
 // Creates a mock backend with 3 todos
-import { todoFixture } from "//unpkg.com/can-demo-models@5";
+import { todoFixture } from "//unpkg.com/can-demo-models@5/index.mjs";
 todoFixture(3);
 
 import { Component } from "//unpkg.com/can@5/core.mjs";

--- a/docs/can-guides/experiment/crud-beginner/3.js
+++ b/docs/can-guides/experiment/crud-beginner/3.js
@@ -1,5 +1,5 @@
 // Creates a mock backend with 3 todos
-import { todoFixture } from "//unpkg.com/can-demo-models@5";
+import { todoFixture } from "//unpkg.com/can-demo-models@5/index.mjs";
 todoFixture(3);
 
 import { Component } from "//unpkg.com/can@5/core.mjs";

--- a/docs/can-guides/experiment/crud-beginner/4.js
+++ b/docs/can-guides/experiment/crud-beginner/4.js
@@ -1,5 +1,5 @@
 // Creates a mock backend with 3 todos
-import { todoFixture } from "//unpkg.com/can-demo-models@5";
+import { todoFixture } from "//unpkg.com/can-demo-models@5/index.mjs";
 todoFixture(3);
 
 import { Component, realtimeRestModel } from "//unpkg.com/can@5/core.mjs";

--- a/docs/can-guides/experiment/crud-beginner/5.js
+++ b/docs/can-guides/experiment/crud-beginner/5.js
@@ -1,5 +1,5 @@
 // Creates a mock backend with 3 todos
-import { todoFixture } from "//unpkg.com/can-demo-models@5";
+import { todoFixture } from "//unpkg.com/can-demo-models@5/index.mjs";
 todoFixture(3);
 
 import { Component, realtimeRestModel } from "//unpkg.com/can@5/core.mjs";

--- a/docs/can-guides/experiment/crud-beginner/6.js
+++ b/docs/can-guides/experiment/crud-beginner/6.js
@@ -1,5 +1,5 @@
 // Creates a mock backend with 3 todos
-import { todoFixture } from "//unpkg.com/can-demo-models@5";
+import { todoFixture } from "//unpkg.com/can-demo-models@5/index.mjs";
 todoFixture(3);
 
 import { Component, realtimeRestModel } from "//unpkg.com/can@5/core.mjs";

--- a/docs/can-guides/experiment/crud-beginner/7.js
+++ b/docs/can-guides/experiment/crud-beginner/7.js
@@ -1,5 +1,5 @@
 // Creates a mock backend with 3 todos
-import { todoFixture } from "//unpkg.com/can-demo-models@5";
+import { todoFixture } from "//unpkg.com/can-demo-models@5/index.mjs";
 todoFixture(3);
 
 import { Component, realtimeRestModel } from "//unpkg.com/can@5/core.mjs";

--- a/docs/can-guides/experiment/crud-beginner/8.js
+++ b/docs/can-guides/experiment/crud-beginner/8.js
@@ -1,5 +1,5 @@
 // Creates a mock backend with 3 todos
-import { todoFixture } from "//unpkg.com/can-demo-models@5";
+import { todoFixture } from "//unpkg.com/can-demo-models@5/index.mjs";
 todoFixture(3);
 
 import { Component, realtimeRestModel } from "//unpkg.com/can@5/core.mjs";

--- a/docs/can-guides/experiment/crud-beginner/9.js
+++ b/docs/can-guides/experiment/crud-beginner/9.js
@@ -1,5 +1,5 @@
 // Creates a mock backend with 3 todos
-import { todoFixture } from "//unpkg.com/can-demo-models@5";
+import { todoFixture } from "//unpkg.com/can-demo-models@5/index.mjs";
 todoFixture(3);
 
 import { Component, realtimeRestModel } from "//unpkg.com/can@5/core.mjs";

--- a/docs/can-guides/topics/data/configuring-requests.md
+++ b/docs/can-guides/topics/data/configuring-requests.md
@@ -61,7 +61,7 @@ const connection = restModel({
 
 ```js
 import { restModel } from "can";
-import { Todo, todoFixture } from "//unpkg.com/can-demo-models@5";
+import { Todo, todoFixture } from "//unpkg.com/can-demo-models@5/index.mjs";
 
 // create mock data
 todoFixture(5);


### PR DESCRIPTION
Edge was not resolving `unpkg.com/can-demo-models@5` to `unpkg.com/can-demo-models@5/index.mjs`, so this commit explicitly imports from that URL.

Fixes https://github.com/canjs/canjs/issues/5125