### PR TITLE
Allow todos to be deselected in the CanJS 6 CRUD guide

### DIFF
--- a/docs/can-guides/experiment/crud-beginner/8.js
+++ b/docs/can-guides/experiment/crud-beginner/8.js
@@ -2,7 +2,7 @@
 import { todoFixture } from "//unpkg.com/can-demo-models@5";
 todoFixture(3);
 
-import { realtimeRestModel, StacheDefineElement } from "//unpkg.com/can@5/everything.mjs";
+import { realtimeRestModel, StacheDefineElement, type } from "//unpkg.com/can@5/everything.mjs";
 
 const Todo = realtimeRestModel("/api/todos/{id}").Map;
 
@@ -42,7 +42,7 @@ class TodosApp extends StacheDefineElement {
     static get define() {
         return {
             newName: String,
-            selected: Todo,
+            selected: type.maybe(Todo),
 
             get todosPromise() {
                 return Todo.getList({sort: "name"});

--- a/docs/can-guides/experiment/crud-beginner/9.js
+++ b/docs/can-guides/experiment/crud-beginner/9.js
@@ -43,7 +43,7 @@ class TodosApp extends StacheDefineElement {
     static get define() {
         return {
             newName: String,
-            selected: Todo,
+            selected: type.maybe(Todo),
 
             get todosPromise() {
                 return Todo.getList({sort: "name"});

--- a/docs/can-guides/experiment/crud-beginner/crud-beginner.md
+++ b/docs/can-guides/experiment/crud-beginner/crud-beginner.md
@@ -392,9 +392,18 @@ We’ll also make it possible to click on a to-do to select it and edit its name
 After either of these changes, we’ll save the to-do to the backend API.
 
 @sourceref ./8.js
-@highlight 25-34,45,59-62,only
+@highlight 5,25-34,45,59-62,only
 
-The next four sections will more thoroughly explain the code above.
+The next five sections will more thoroughly explain the code above.
+
+### Importing type
+
+First, we import the [can-type type] module:
+
+@sourceref ./8.js
+@highlight 5,only
+
+This module gives us helpers for type checking and conversion.
 
 ### Binding to checkbox form elements
 
@@ -437,10 +446,8 @@ Let’s examine this part of the code:
 `on:click="this.selected = todo"` will cause the custom element’s `selected` property to be set
 to the `todo` when the `<span>` is clicked.
 
-Additionally, we add [can-define.types.propDefinition#function__ `selected: Todo`]
-to the custom element. In our app, we only ever set `selected` to an instance of a `Todo`,
-otherwise CanJS would throw an error. If we wanted plain objects to be converted into
-new `Todo` instances, we could use [can-type/convert type.convert(Todo)].
+Additionally, we add [can-type/maybe `selected: type.maybe(Todo)`] to the custom element.
+This allows us to set `selected` to either an instance of `Todo` or `null`.
 
 ### Editing to-do names
 


### PR DESCRIPTION
Fixes https://github.com/canjs/canjs/issues/5121

---

![Screen Shot 2019-07-15 at 2 35 32 PM](https://user-images.githubusercontent.com/10070176/61253171-e4b89f80-a714-11e9-9034-8750bcaf5c2c.png)

---

![Screen Shot 2019-07-15 at 2 35 57 PM](https://user-images.githubusercontent.com/10070176/61253172-e4b89f80-a714-11e9-9e92-977df22ccf0d.png)
