### PR TITLE
add id attr to counter demo script

### DIFF
--- a/docs/can-guides/experiment/technology/html.md
+++ b/docs/can-guides/experiment/technology/html.md
@@ -31,7 +31,7 @@ Let's say you want to create a page that counts clicks like the following: (_cli
 <style>
   my-counter button {margin-left: 15px;}
 </style>
-<script type="text/steal-module">
+<script id="counter-demo" type="text/steal-module">
 const Component = require("can-component");
 Component.extend({
     tag: "my-counter",


### PR DESCRIPTION
Add `id` attribute to the [counter demo](https://canjs.com/doc/guides/html.html) work with the fix in this [PR](https://github.com/canjs/bit-docs-html-canjs/pull/563)

For #5115 