### PR TITLE
Update the CRUD guide with the renamed APIs

### DIFF
--- a/docs/can-guides/experiment/crud-beginner/2.js
+++ b/docs/can-guides/experiment/crud-beginner/2.js
@@ -2,16 +2,16 @@
 import { todoFixture } from "//unpkg.com/can-demo-models@5/index.mjs";
 todoFixture(3);
 
-import { StacheDefineElement } from "//unpkg.com/can@5/everything.mjs";
+import { StacheElement } from "//unpkg.com/can@5/everything.mjs";
 
-class TodosApp extends StacheDefineElement {
+class TodosApp extends StacheElement {
     static get view() {
         return `
             <h1>Today’s to-dos</h1>
         `;
     }
 
-    static get define() {
+    static get props() {
         return {
         };
     }

--- a/docs/can-guides/experiment/crud-beginner/3.js
+++ b/docs/can-guides/experiment/crud-beginner/3.js
@@ -2,16 +2,16 @@
 import { todoFixture } from "//unpkg.com/can-demo-models@5/index.mjs";
 todoFixture(3);
 
-import { StacheDefineElement } from "//unpkg.com/can@5/everything.mjs";
+import { StacheElement } from "//unpkg.com/can@5/everything.mjs";
 
-class TodosApp extends StacheDefineElement {
+class TodosApp extends StacheElement {
     static get view() {
         return `
             <h1>{{ this.title }}</h1>
         `;
     }
 
-    static get define() {
+    static get props() {
         return {
             get title() {
                 return "Today’s to-dos!";

--- a/docs/can-guides/experiment/crud-beginner/4.js
+++ b/docs/can-guides/experiment/crud-beginner/4.js
@@ -2,18 +2,18 @@
 import { todoFixture } from "//unpkg.com/can-demo-models@5/index.mjs";
 todoFixture(3);
 
-import { realtimeRestModel, StacheDefineElement } from "//unpkg.com/can@5/everything.mjs";
+import { realtimeRestModel, StacheElement } from "//unpkg.com/can@5/everything.mjs";
 
 const Todo = realtimeRestModel("/api/todos/{id}").Map;
 
-class TodosApp extends StacheDefineElement {
+class TodosApp extends StacheElement {
     static get view() {
         return `
             <h1>Today’s to-dos</h1>
         `;
     }
 
-    static get define() {
+    static get props() {
         return {
             get todosPromise() {
                 return Todo.getList({sort: "name"});

--- a/docs/can-guides/experiment/crud-beginner/5.js
+++ b/docs/can-guides/experiment/crud-beginner/5.js
@@ -2,11 +2,11 @@
 import { todoFixture } from "//unpkg.com/can-demo-models@5/index.mjs";
 todoFixture(3);
 
-import { realtimeRestModel, StacheDefineElement } from "//unpkg.com/can@5/everything.mjs";
+import { realtimeRestModel, StacheElement } from "//unpkg.com/can@5/everything.mjs";
 
 const Todo = realtimeRestModel("/api/todos/{id}").Map;
 
-class TodosApp extends StacheDefineElement {
+class TodosApp extends StacheElement {
     static get view() {
         return `
             <h1>Today’s to-dos</h1>
@@ -22,7 +22,7 @@ class TodosApp extends StacheDefineElement {
         `;
     }
 
-    static get define() {
+    static get props() {
         return {
             get todosPromise() {
                 return Todo.getList({sort: "name"});

--- a/docs/can-guides/experiment/crud-beginner/6.js
+++ b/docs/can-guides/experiment/crud-beginner/6.js
@@ -2,11 +2,11 @@
 import { todoFixture } from "//unpkg.com/can-demo-models@5/index.mjs";
 todoFixture(3);
 
-import { realtimeRestModel, StacheDefineElement } from "//unpkg.com/can@5/everything.mjs";
+import { realtimeRestModel, StacheElement } from "//unpkg.com/can@5/everything.mjs";
 
 const Todo = realtimeRestModel("/api/todos/{id}").Map;
 
-class TodosApp extends StacheDefineElement {
+class TodosApp extends StacheElement {
     static get view() {
         return `
             <h1>Today’s to-dos</h1>
@@ -28,7 +28,7 @@ class TodosApp extends StacheDefineElement {
         `;
     }
 
-    static get define() {
+    static get props() {
         return {
             get todosPromise() {
                 return Todo.getList({sort: "name"});

--- a/docs/can-guides/experiment/crud-beginner/7.js
+++ b/docs/can-guides/experiment/crud-beginner/7.js
@@ -2,11 +2,11 @@
 import { todoFixture } from "//unpkg.com/can-demo-models@5/index.mjs";
 todoFixture(3);
 
-import { realtimeRestModel, StacheDefineElement } from "//unpkg.com/can@5/everything.mjs";
+import { realtimeRestModel, StacheElement } from "//unpkg.com/can@5/everything.mjs";
 
 const Todo = realtimeRestModel("/api/todos/{id}").Map;
 
-class TodosApp extends StacheDefineElement {
+class TodosApp extends StacheElement {
     static get view() {
         return `
             <h1>Today’s to-dos</h1>
@@ -30,7 +30,7 @@ class TodosApp extends StacheDefineElement {
         `;
     }
 
-    static get define() {
+    static get props() {
         return {
             newName: String,
 

--- a/docs/can-guides/experiment/crud-beginner/8.js
+++ b/docs/can-guides/experiment/crud-beginner/8.js
@@ -2,11 +2,11 @@
 import { todoFixture } from "//unpkg.com/can-demo-models@5/index.mjs";
 todoFixture(3);
 
-import { realtimeRestModel, StacheDefineElement, type } from "//unpkg.com/can@5/everything.mjs";
+import { realtimeRestModel, StacheElement, type } from "//unpkg.com/can@5/everything.mjs";
 
 const Todo = realtimeRestModel("/api/todos/{id}").Map;
 
-class TodosApp extends StacheDefineElement {
+class TodosApp extends StacheElement {
     static get view() {
         return `
             <h1>Today’s to-dos</h1>
@@ -39,7 +39,7 @@ class TodosApp extends StacheDefineElement {
         `;
     }
 
-    static get define() {
+    static get props() {
         return {
             newName: String,
             selected: type.maybe(Todo),

--- a/docs/can-guides/experiment/crud-beginner/9.js
+++ b/docs/can-guides/experiment/crud-beginner/9.js
@@ -2,11 +2,11 @@
 import { todoFixture } from "//unpkg.com/can-demo-models@5/index.mjs";
 todoFixture(3);
 
-import { realtimeRestModel, StacheDefineElement } from "//unpkg.com/can@5/everything.mjs";
+import { realtimeRestModel, StacheElement, type } from "//unpkg.com/can@5/everything.mjs";
 
 const Todo = realtimeRestModel("/api/todos/{id}").Map;
 
-class TodosApp extends StacheDefineElement {
+class TodosApp extends StacheElement {
     static get view() {
         return `
             <h1>Today’s to-dos</h1>
@@ -40,7 +40,7 @@ class TodosApp extends StacheDefineElement {
         `;
     }
 
-    static get define() {
+    static get props() {
         return {
             newName: String,
             selected: type.maybe(Todo),

--- a/docs/can-guides/experiment/crud-beginner/crud-beginner.md
+++ b/docs/can-guides/experiment/crud-beginner/crud-beginner.md
@@ -91,25 +91,25 @@ With one line of code, we load CanJS from a CDN and import one of its modules:
 Here’s what the different parts mean:
 
 - `import` is a keyword that [loads modules from files](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import).
-- `StacheDefineElement` is the _named export_ from CanJS that lets us [can-stache-define-element create custom element constructors].
+- `StacheElement` is the _named export_ from CanJS that lets us [can-stache-element create custom element constructors].
 - `//unpkg.com/can@5/everything.mjs` loads the `everything.mjs` file from CanJS 5; this is explained more thoroughly in the [guides/setup#Explanationofdifferentbuilds setup guide].
 - `unpkg.com` is a CDN that hosts packages like CanJS ([can](https://www.npmjs.com/package/can)).
 
 ### Defining a custom element
 
-The `StacheDefineElement` _named export_ comes from CanJS’s [can-stache-define-element can-stache-define-element] package.
+The `StacheElement` _named export_ comes from CanJS’s [can-stache-element can-stache-element] package.
 
 CanJS is composed of dozens of different packages that are responsible for different features.
-[can-stache-define-element can-stache-define-element] is responsible for letting us define custom elements that can be
+[can-stache-element can-stache-element] is responsible for letting us define custom elements that can be
 used by the browser.
 
 @sourceref ./2.js
 @highlight 7-19,only
 
-The `StacheDefineElement` class can be extended to define a new custom element. It has two properties:
+The `StacheElement` class can be extended to define a new custom element. It has two properties:
 
-- [can-stache-define-element/static.view `static view`] is a [can-stache stache template] that gets parsed by CanJS and inserted into the custom element; more on that later.
-- [can-stache-define-element/static.define `static define`] is an object that _defines_ the properties available to the view.
+- [can-stache-element/static.view `static view`] is a [can-stache stache template] that gets parsed by CanJS and inserted into the custom element; more on that later.
+- [can-stache-element/static.props `static props`] is an object that defines the properties available to the view.
 
 After calling [customElements.define()](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define)
 with the custom element’s tag name and constructor, a new instance of the `TodosApp` class will be instantiated every time
@@ -122,7 +122,7 @@ The `view` is pretty boring right now; it just renders `<h1>Today’s to-dos</h1
 
 ## Rendering a template with data
 
-A custom element’s [can-stache-define-element/static.view] has access to all the properties in the [can-stache-define-element/static.define] object.
+A custom element’s [can-stache-element/static.view] has access to all the properties in the [can-stache-element/static.props] object.
 
 Let’s update our custom element to be a little more interesting:
 
@@ -328,14 +328,14 @@ Again, you might be wondering where we’ve defined the `save()` method in the c
 
 Earlier we said that:
 
-> [can-stache-define-element/static.define `static define`] is an object that _defines_ the properties available to the view.
+> [can-stache-element/static.props `static props`] is an object that defines the properties available to the view.
 
-This is true, although there’s more information to be known. The `static define` object is made up of [can-define-object DefineObject]-like
+This is true, although there’s more information to be known. The `static props` object is made up of [can-observable-object ObservableObject]-like
 property definitions that explicitly configure how a custom element’s properties are defined.
 
 We’ve been defining properties and methods on the custom element with the
 [standard JavaScript getter and method syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions#Defining_method_functions).
-Now we’re going to use [can-define-object/object.types.property#function__ DefineObject’s constructor syntax] to define
+Now we’re going to use [can-observable-object/object.types.property#function__ ObservableObject’s constructor syntax] to define
 a property as a [String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String):
 
 @sourceref ./7.js


### PR DESCRIPTION
The CRUD guide now shows:

- can-observable-array
- can-observable-object
- can-stache-element (with props)