### PR TITLE
Add docs for the .bit-docs-screenshot class to the style guide

### DIFF
--- a/docs/can-guides/contribute/site-style-guide.md
+++ b/docs/can-guides/contribute/site-style-guide.md
@@ -121,3 +121,15 @@ npm install can --save
 
 The following is a very long sentence that will hopefully go across many lines because it
 is so long and filled with <code>code elements</code>, <strong>bold elements</strong>, <em>italic elements</em>, <a href="#">link elements</a>.
+
+## Screenshots
+
+Use the `bit-docs-screenshot` class on images to center them. Add a `width` to the image to set a max width.
+
+### With width
+
+<img alt="" class="bit-docs-screenshot" src="https://canjs.com/docs/can-guides/images/devtools/panel-component-selected.png" width="600px" />
+
+### Without width
+
+<img alt="" class="bit-docs-screenshot" src="https://canjs.com/docs/can-guides/images/devtools/panel-component-selected.png" />


### PR DESCRIPTION
<img width="854" alt="Screen Shot 2019-08-01 at 11 40 37 AM" src="https://user-images.githubusercontent.com/10070176/62307228-3a00ea80-b451-11e9-90a9-5e2232f09bb1.png">
