### PR TITLE
Add the can-define-realtime-rest-model and can-realtime-rest-model packages

### DIFF
--- a/es/can-define-realtime-rest-model.js
+++ b/es/can-define-realtime-rest-model.js
@@ -1,0 +1,1 @@
+export {default} from "can-define-realtime-rest-model";

--- a/es/can-define-rest-model.js
+++ b/es/can-define-rest-model.js
@@ -1,0 +1,1 @@
+export {default} from "can-define-rest-model";

--- a/legacy.js
+++ b/legacy.js
@@ -1,5 +1,7 @@
 // Observables
 export { define, DefineMap, DefineList } from "./es/can-define";
+export { default as defineRealtimeRestModel } from "./es/can-define-realtime-rest-model";
+export { default as defineRestModel } from "./es/can-define-rest-model";
 export { default as compute } from "./es/can-compute";
 export { default as CanMap } from "./es/can-map";
 export { default as CanList } from "./es/can-list";

--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "can-define": "2.8.0",
     "can-define-backup": "2.1.2",
     "can-define-lazy-value": "1.1.1",
+    "can-define-realtime-rest-model": "1.2.0",
+    "can-define-rest-model": "1.2.0",
     "can-define-stream": "1.1.1",
     "can-define-stream-kefir": "1.1.1",
     "can-define-validate-validatejs": "1.1.1",

--- a/test/test-all-ie.js
+++ b/test/test-all-ie.js
@@ -52,6 +52,8 @@ require('can-stache-converters/test/test');
 
 // Legacy tests
 require('can-compute/can-compute_test');
+require('can-define-realtime-rest-model/can-define-realtime-rest-model-test');
+require('can-define-rest-model/test');
 require('can-list/can-list_test');
 require('can-map/can-map_test');
 require('can-map-define/can-map-define_test');

--- a/test/test.js
+++ b/test/test.js
@@ -57,6 +57,8 @@ require('can-stache-converters/test/test');
 // Legacy tests
 require('can-component/test/test');
 require('can-define/test/test');
+require('can-define-realtime-rest-model/can-define-realtime-rest-model-test');
+require('can-define-rest-model/test');
 require('can-compute/can-compute_test');
 require('can-list/can-list_test');
 require('can-map/can-map_test');


### PR DESCRIPTION
Both are listed as legacy in the docs:

<img width="250" alt="Screen Shot 2019-09-03 at 9 35 28 PM" src="https://user-images.githubusercontent.com/10070176/64206667-dd9b4b80-ce92-11e9-98b3-876209811b36.png">

Part of https://github.com/canjs/canjs/issues/5207