### PR TITLE
update configuring requests guide to use new can-demo-models

### DIFF
--- a/docs/can-guides/topics/data/configuring-requests.md
+++ b/docs/can-guides/topics/data/configuring-requests.md
@@ -61,7 +61,7 @@ const connection = restModel({
 
 ```js
 import { restModel } from "can";
-import { Todo, todoFixture } from "//unpkg.com/can-demo-models@5/index.mjs";
+import { Todo, todoFixture } from "//unpkg.com/can-demo-models@6/index.mjs";
 
 // create mock data
 todoFixture(5);


### PR DESCRIPTION
Update to point at the Can 6 demo models in canjs/can-demo-models#6. 
No other changes.