### PR TITLE
Add tests for the size of core

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "npm run test-development && npm run test-production && npm run test-builders && npm run test-global-build",
     "test-builders": "npm run build-webpack-test && npm run testee-builders",
     "test-development": "npm run testee",
-    "test-global-build": "npm run build && npm run testee-global-build",
+    "test-global-build": "npm run build && bundlesize && npm run testee-global-build",
     "test-local": "npm run build && npm run testee",
     "test-production": "npm run build-tests && npm run testee-production",
     "test-sauce-labs": "node test/test-sauce-labs.js",
@@ -155,6 +155,7 @@
     "@feathersjs/socketio-client": "^1.2.1",
     "@octokit/rest": "^16.27.3",
     "bit-docs": "0.2.0",
+    "bundlesize": "^0.18.0",
     "can-reflect-tests": "^1.0.0",
     "can-test-helpers": "^1.1.1",
     "core-js": "^2.5.7",
@@ -296,5 +297,19 @@
         "`//unpkg.com/route-mini-app@^5.0.0/page-${this.page}.mjs`"
       ]
     ]
-  }
+  },
+  "bundlesize": [
+    {
+      "path": "./core.min.mjs",
+      "maxSize": "101 kB"
+    },
+    {
+      "path": "./core.mjs",
+      "maxSize": "311 kB"
+    },
+    {
+      "path": "./dist/global/core.js",
+      "maxSize": "182 kB"
+    }
+  ]
 }


### PR DESCRIPTION
This adds a package called `bundlesize`. Given a list of files, it gzip’s them and checks whether they’re smaller than the sizes configured in `package.json`. It also integrates with GitHub; you can see the integration in this PR!

I’ve added tests for three files:

- `core.min.mjs` (currently 100.83KB gzip’d)
- `core.mjs` (currently 310KB gzip’d)
- `dist/global/core.js` (currently 181.03KB gzip’d)

Maybe we want to test more files or fewer files, but for now I’ve added those because I’ll want automated confirmation that the core size actually decreases when https://github.com/canjs/canjs/issues/5207 is done.

Closes https://github.com/canjs/canjs/issues/3371