### PR TITLE
Remove can-define usage in CanJS core

### DIFF
--- a/docs/can-canjs/canjs.md
+++ b/docs/can-canjs/canjs.md
@@ -620,7 +620,7 @@ CanJS has configuration options for you to control how it makes requests, parses
 ```js
 import { realtimeRestModel } from "can";
 
-const Todo = realtimeRestModel("/api/todos/{id}").Map;
+const Todo = realtimeRestModel("/api/todos/{id}").ObjectType;
 
 // Get todos sorted by name
 const todosPromise = Todo.getList({sort: "name"});
@@ -696,7 +696,7 @@ Save yourself time by not writing code that updates your app’s UI.
 ```js
 import { realtimeRestModel } from "can";
 
-const Todo = realtimeRestModel("/api/todos/{id}").Map;
+const Todo = realtimeRestModel("/api/todos/{id}").ObjectType;
 
 // Get completed todos
 Todo.getList({sort: "name"}).then(todos => {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "can-namespace": "1.0.0",
     "can-ndjson-stream": "1.0.2",
     "can-observable-array": "1.0.0-pre.9",
-    "can-observable-bindings": "1.2.0",
+    "can-observable-bindings": "1.2.1",
     "can-observable-mixin": "1.0.0-pre.11",
     "can-observable-object": "1.0.0-pre.3",
     "can-observation": "4.2.0",
@@ -112,15 +112,15 @@
     "can-parse-uri": "1.2.2",
     "can-query-logic": "1.2.1",
     "can-queues": "1.3.1",
-    "can-realtime-rest-model": "1.1.1",
+    "can-realtime-rest-model": "2.0.0-pre.0",
     "can-reflect": "1.18.0",
     "can-reflect-dependencies": "1.1.2",
     "can-reflect-promise": "2.2.1",
-    "can-rest-model": "1.1.1",
-    "can-route": "4.4.9",
+    "can-rest-model": "2.0.0-pre.0",
+    "can-route": "5.0.0-pre.3",
     "can-route-hash": "1.0.2",
     "can-route-mock": "1.0.2",
-    "can-route-pushstate": "5.0.13",
+    "can-route-pushstate": "6.0.0-pre.0",
     "can-set-legacy": "1.0.1",
     "can-simple-dom": "1.7.0",
     "can-simple-map": "4.3.2",
@@ -130,7 +130,7 @@
     "can-stache-converters": "5.0.0-pre.1",
     "can-stache-element": "1.0.0-pre.11",
     "can-stache-key": "1.4.3",
-    "can-stache-route-helpers": "2.0.0-pre.2",
+    "can-stache-route-helpers": "2.0.0-pre.3",
     "can-stream": "1.1.1",
     "can-stream-kefir": "1.2.1",
     "can-string": "1.1.0",
@@ -305,15 +305,15 @@
   "bundlesize": [
     {
       "path": "./core.min.mjs",
-      "maxSize": "115 kB"
+      "maxSize": "106 kB"
     },
     {
       "path": "./core.mjs",
-      "maxSize": "357 kB"
+      "maxSize": "316 kB"
     },
     {
       "path": "./dist/global/core.js",
-      "maxSize": "213 kB"
+      "maxSize": "198 kB"
     }
   ]
 }

--- a/test/index-ie.html
+++ b/test/index-ie.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
 <title>CanJS tests</title>
+<script>
+	steal = {
+		paths: {
+			"can-route/src/routedata": "node_modules/can-route/src/routedata-definemap.js"
+		}
+	};
+</script>
 <script src="../node_modules/steal/steal-with-promises.js" main="can/test/test-all-ie" env="canjs-test"></script>
 <div id="qunit-fixture"></div>

--- a/test/test-all-ie.js
+++ b/test/test-all-ie.js
@@ -95,7 +95,7 @@ require('can-view-autorender/test/test');
 require('can-connect/test/test-without-proxy');
 require("can-debug/can-debug-test");
 require('can-route/test/test-without-proxy');
-require('can-route-pushstate/test/test');
+require('can-route-pushstate/test/test-ie');
 require('can-stache/test/stache-test');
 
 // Infrastructure tests


### PR DESCRIPTION
This updates a bunch of packages that have replaced can-define with can-observable-object.

Closes https://github.com/canjs/canjs/issues/5207