### PR TITLE
moving can-control to legacy

### DIFF
--- a/core.js
+++ b/core.js
@@ -80,7 +80,6 @@ export { default as stringToAny } from "./es/can-string-to-any";
 export { default as ajax } from "./es/can-ajax";
 export { default as attributeEncoder } from "./es/can-attribute-encoder";
 export { default as childNodes } from "./es/can-child-nodes";
-export { default as Control } from "./es/can-control";
 export { default as domData } from "./es/can-dom-data";
 export { default as domEvents, addJQueryEvents } from "./es/can-dom-events";
 export { default as domMutate, domMutateNode, domMutateDomEvents } from "./es/can-dom-mutate";

--- a/legacy.js
+++ b/legacy.js
@@ -12,3 +12,6 @@ export { default as Component } from './es/can-component';
 
 // Data Models
 export { default as set } from "./es/can-set-legacy";
+
+// DOM Utilities
+export { default as Control } from "./es/can-control";

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "can-connect-tag": "2.0.0-pre.4",
     "can-construct": "3.5.6",
     "can-construct-super": "3.2.1",
-    "can-control": "5.0.0-pre.1",
+    "can-control": "5.0.0-pre.2",
     "can-data-types": "1.2.1",
     "can-debug": "2.0.7",
     "can-deep-observable": "1.0.0-pre.1",
@@ -305,15 +305,15 @@
   "bundlesize": [
     {
       "path": "./core.min.mjs",
-      "maxSize": "106.15 kB"
+      "maxSize": "104.58 kB"
     },
     {
       "path": "./core.mjs",
-      "maxSize": "316 kB"
+      "maxSize": "311.07 kB"
     },
     {
       "path": "./dist/global/core.js",
-      "maxSize": "198 kB"
+      "maxSize": "194.72 kB"
     }
   ]
 }


### PR DESCRIPTION
Nothing in core depends on Control anymore, so it does not need to be in the core package.