### PR TITLE
Update can-deep-observable to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "can-control": "5.0.0",
     "can-data-types": "1.2.1",
     "can-debug": "2.0.7",
-    "can-deep-observable": "1.0.0",
+    "can-deep-observable": "1.0.1",
     "can-define": "2.8.0",
     "can-define-backup": "2.1.2",
     "can-define-lazy-value": "1.1.1",


### PR DESCRIPTION
This is the only one missing from https://github.com/canjs/canjs/issues/5365

Closes #5365