### PR TITLE
Fix tree-shaking with webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "release:major": "npm version major && npm run build && npm publish",
     "build": "node build.js",
     "build-tests": "node test/build.js",
-    "build-webpack-test": "webpack -o test/builders/webpack/bundle.js test/builders/webpack/index.js",
+    "build-webpack-test": "webpack --mode=production -o test/builders/webpack/bundle.js test/builders/webpack/index.js",
     "document": "./pre-document.sh && npm run deps-bundle && bit-docs",
     "document:force": "./pre-document.sh && npm run deps-bundle && bit-docs -fd",
     "deps-bundle": "node build-dev-bundle"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "can",
   "version": "6.2.1",
   "main": "can.js",
-  "module": "core.mjs",
   "scripts": {
     "preversion": "npm test",
     "version": "git commit -am \"Update dist for release\" && git checkout -b release && git add -f dist/",

--- a/test/builders/webpack/index.js
+++ b/test/builders/webpack/index.js
@@ -1,4 +1,4 @@
-import { can, StacheElement } from "../../../core.js";
+import { can, StacheElement } from "../../../can.js";
 
 window.can = can;
 


### PR DESCRIPTION
webpack will load what’s in `module` when it encounters `import can from 'can'`.

Previously, `module` was set to `core.mjs`, which can’t be tree-shaken by webpack.

This removes the field so webpack uses the `main` instead.

This also:

- Switches the webpack tests to use `can.js` instead of `core.js` (matching the `main`)
- Makes it explicit that we build the webpack tests for production

Fixes https://github.com/canjs/canjs/issues/5358