### PR TITLE
Fix search result is obscured issue

### DIFF
--- a/docs/can-canjs/canjs.md
+++ b/docs/can-canjs/canjs.md
@@ -32,7 +32,7 @@ h3 {
   color: #282C33;
   margin-bottom: 10px;
 }
-code:before {
+code[class*=language-]:before {
   content: "";
   background-color: #f5f5f5;
   height: 25px;


### PR DESCRIPTION
Fixes https://github.com/canjs/bit-docs-html-canjs/issues/583

The result after the fix in the GIF:

![search](https://user-images.githubusercontent.com/109013/67695850-142ea780-f9a6-11e9-816c-6f166a262a4d.gif)
