### PR TITLE
fix(package): update can-observable-array to version 1.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -308,7 +308,7 @@
   "bundlesize": [
     {
       "path": "./core.min.mjs",
-      "maxSize": "105.2 kB"
+      "maxSize": "105.3 kB"
     },
     {
       "path": "./core.mjs",
@@ -316,7 +316,7 @@
     },
     {
       "path": "./dist/global/core.js",
-      "maxSize": "196.00 kB"
+      "maxSize": "196.2 kB"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "can-memory-store": "1.0.2",
     "can-namespace": "1.0.0",
     "can-ndjson-stream": "1.0.2",
-    "can-observable-array": "1.0.4",
+    "can-observable-array": "1.0.6",
     "can-observable-bindings": "1.3.3",
     "can-observable-mixin": "1.0.6",
     "can-observable-object": "1.0.1",


### PR DESCRIPTION
Closes #5428