### PR TITLE
Update API page

### DIFF
--- a/docs/can-canjs/can-api.md
+++ b/docs/can-canjs/can-api.md
@@ -91,6 +91,12 @@ customElements.define("my-counter", Counter);
 
 Also, the [api#ElementBindings Element Bindings] section shows how to pass data between components.
 
+ [customElements.define](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define) allows developers to define a new custom HTML tags by taking a custom element tag name and a JavaScript class:
+ 
+ ```js
+ customElements.define("my-counter", Counter);
+ ```
+
 
 ## Observables
 
@@ -223,7 +229,8 @@ console.log(todo.serialize()); //-> {
 ```
 @codepen
 
-Define observable list types with [can-observable-array ObservableArray]:
+<details>
+<summary>Define observable list types with [can-observable-array ObservableArray]:</summary>
 
 ```js
 import { ObservableArray, type } from "can";
@@ -277,17 +284,56 @@ console.log(areSomeComplete); //-> false
 ```
 @codepen
 
-<details>
-<summary>Infrastructure APIs</summary>
-
-```js
-const fullName = new Observation(() => {
-    return person.first + " " + person.last;
-});
-```
-
 </details>
 
+## Value types
+
+[can-type] is helpful to define typed properties for models and components by doing the following:
+- Validates properties value types
+- Converts a value to a type
+- Allows `undefined` / `null` to be values 
+- Converts a value to the correct type if not `null` / `undefined`
+
+Also, you can use the defined custom types as value types, for example the following defines a `User` type 
+that has a `person` property with `Person` type:
+
+```js
+import { ObservableObject, type } from "can";
+
+class Person extends ObservableObject {
+  static props = {
+    first: type.check(String),  // type checking is the default behavior
+    last: type.maybe(String),   // maybe null, undefined or string
+    age: type.convert(Number),  // converts the value to number
+    birthday: type.maybeConvert(Date) // converts the value to date if is defined 
+  };
+};
+
+class User extends ObservableObject {
+  static props = {
+    username: type.check(String, requried: true),
+    password: type.check(String, required: true),
+    lastLogin: type.maybeConvert(Date)
+    person: type.check(Person)
+  }
+};
+
+const aPerson = new Person({
+  first: "Fibonacci",
+  last: null,
+  age: "80",
+  birthday: undefined
+})
+
+const fib = new User({
+  username: "fib",
+  password: "011235",
+  lastLogin: null,
+  person: aPerson
+});
+
+console.log(fib); // ->User{ ... }
+```
 
 ## Views
 

--- a/docs/can-canjs/can-api.md
+++ b/docs/can-canjs/can-api.md
@@ -78,7 +78,7 @@ class Counter extends StacheElement {
 	}
 }
 
-// The name of the custom element
+// Make <my-counter></my-counter> custom element works in the HTML
 customElements.define("my-counter", Counter);
 </script>
 ```
@@ -88,14 +88,7 @@ customElements.define("my-counter", Counter);
 
 - [can-stache-element/static.props properties] are defined with the [api#Observables Observables] APIs documented below.
 - [can-stache-element/static.view view] is defined with the [api#Views Views] APIs documented below.
-
-Also, the [api#ElementBindings Element Bindings] section shows how to pass data between components.
-
- [customElements.define](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define) allows developers to define a new custom HTML tags by taking a custom element tag name and a JavaScript class:
- 
- ```js
- customElements.define("my-counter", Counter);
- ```
+- tag name is defined with [customElements.define](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define).
 
 
 ## Observables
@@ -108,7 +101,7 @@ The following defines a `Todo` type with numerous property behaviors and
 a `toggleComplete` method.
 
 ```js
-import { ObservableObject, ObservableArray, type } from "can";
+import { ObservableObject, type } from "can";
 
 // -------------------------------
 // Define an observable Owner type:
@@ -123,6 +116,30 @@ class Owner extends ObservableObject {
 // -------------------------------
 // Define an observable Todo type:
 // -------------------------------
+class Todo extends ObservableObject {
+  static props = {
+    name: string,
+    complete: false
+  };
+
+    // `toggleComplete` is a method
+    toggleComplete() {
+        this.complete = !this.complete;
+    }
+}
+
+// Create a todo instance:
+const todo = new Todo({ name: "Learn Observables" });
+```
+@codepen
+
+<details>
+<summary>Define Observable and observable list types with [can-observable-object ObservableObject] and [can-observable-array ObservableArray]:</summary>
+
+```js
+import { ObservableArray, type } from "can";
+import Todo from "//canjs.com/demos/api/todo.mjs";
+
 class Todo extends ObservableObject {
 	static props = {
 		// `id` is a Number
@@ -226,15 +243,6 @@ console.log(todo.serialize()); //-> {
 //		owner: { first: "Justin", last: "Meyer" },
 //		tags: ["new"]
 // }
-```
-@codepen
-
-<details>
-<summary>Define observable list types with [can-observable-array ObservableArray]:</summary>
-
-```js
-import { ObservableArray, type } from "can";
-import Todo from "//canjs.com/demos/api/todo.mjs";
 
 // -----------------------------------
 // Define an observable TodoList type:
@@ -286,10 +294,10 @@ console.log(areSomeComplete); //-> false
 
 </details>
 
-## Value types
+## Typed properties
 
 [can-type] is helpful to define typed properties for models and components by doing the following:
-- Validates properties value types
+- Validates properties `value` types
 - Converts a value to a type
 - Allows `undefined` / `null` to be values 
 - Converts a value to the correct type if not `null` / `undefined`

--- a/docs/can-canjs/can-api.md
+++ b/docs/can-canjs/can-api.md
@@ -97,21 +97,10 @@ Define custom observable key-value types with [can-observable-object ObservableO
 `ObservableObject` is used to organize the logic of both your [can-stache-element StacheElement] props and your [api#DataModeling Data Models]. The logic
 is expressed as properties and methods.
 
-The following defines a `Todo` type with numerous property behaviors and
-a `toggleComplete` method.
+The following defines a `Todo` type with `toggleComplete` method.
 
 ```js
 import { ObservableObject, type } from "can";
-
-// -------------------------------
-// Define an observable Owner type:
-// -------------------------------
-class Owner extends ObservableObject {
-  static props = {
-    first: String,
-    last: String
-  };
-}
 
 // -------------------------------
 // Define an observable Todo type:
@@ -134,12 +123,25 @@ const todo = new Todo({ name: "Learn Observables" });
 @codepen
 
 <details>
-<summary>Define Observable and observable list types with [can-observable-object ObservableObject] and [can-observable-array ObservableArray]:</summary>
+<summary>Expand to see a larger example with numerous property behaviors:</summary>
 
 ```js
 import { ObservableArray, type } from "can";
 import Todo from "//canjs.com/demos/api/todo.mjs";
 
+// -------------------------------
+// Define an observable Owner type:
+// -------------------------------
+class Owner extends ObservableObject {
+  static props = {
+    first: String,
+    last: String
+  };
+}
+
+// -------------------------------
+// Define an observable Todo type:
+// -------------------------------
 class Todo extends ObservableObject {
 	static props = {
 		// `id` is a Number
@@ -296,13 +298,10 @@ console.log(areSomeComplete); //-> false
 
 ## Typed properties
 
-[can-type] is helpful to define typed properties for models and components by doing the following:
-- Validates properties `value` types
-- Converts a value to a type
-- Allows `undefined` / `null` to be values 
-- Converts a value to the correct type if not `null` / `undefined`
-
-Also, you can use the defined custom types as value types, for example the following defines a `User` type 
+[can-type] can be used to define typed properties in [ObservableObject] and [StacheElement]
+- Types are strict by default, which means an error will be thrown if a property is set to a value of the wrong type.
+- [can-type/convert] can be used to create a property that will always convert its value to a specific type.
+- [can-type/maybe] can be  used to create a property that can be `null` or `undefined` as well as whatever valid values the type allows
 that has a `person` property with `Person` type:
 
 ```js
@@ -312,35 +311,21 @@ class Person extends ObservableObject {
   static props = {
     first: type.check(String),  // type checking is the default behavior
     last: type.maybe(String),   // maybe null, undefined or string
-    age: type.convert(Number),  // converts the value to number
+    age: Number,                // type checking
     birthday: type.maybeConvert(Date) // converts the value to date if is defined 
   };
 };
 
-class User extends ObservableObject {
-  static props = {
-    username: type.check(String, requried: true),
-    password: type.check(String, required: true),
-    lastLogin: type.maybeConvert(Date)
-    person: type.check(Person)
-  }
-};
-
-const aPerson = new Person({
-  first: "Fibonacci",
+const farah = new Person({
+  first: 'Farah',
   last: null,
-  age: "80",
+  age: '4',
   birthday: undefined
-})
-
-const fib = new User({
-  username: "fib",
-  password: "011235",
-  lastLogin: null,
-  person: aPerson
 });
 
-console.log(fib); // ->User{ ... }
+// Uncaught Error: "4" (string) is not of type Number.
+// Property age is using "type: Number". Use "age: type.convert(Number)"
+// to automatically convert values to Numbers when setting the "age" property.
 ```
 
 ## Views

--- a/docs/can-canjs/can-api.md
+++ b/docs/can-canjs/can-api.md
@@ -111,10 +111,10 @@ class Todo extends ObservableObject {
     complete: false
   };
 
-    // `toggleComplete` is a method
-    toggleComplete() {
-        this.complete = !this.complete;
-    }
+  // `toggleComplete` is a method
+  toggleComplete() {
+    this.complete = !this.complete;
+  }
 }
 
 // Create a todo instance:
@@ -126,7 +126,7 @@ const todo = new Todo({ name: "Learn Observables" });
 <summary>Expand to see a larger example with numerous property behaviors:</summary>
 
 ```js
-import { ObservableArray, type } from "can";
+import { ObservableObject, type } from "can";
 import Todo from "//canjs.com/demos/api/todo.mjs";
 
 // -------------------------------
@@ -245,6 +245,16 @@ console.log(todo.serialize()); //-> {
 //		owner: { first: "Justin", last: "Meyer" },
 //		tags: ["new"]
 // }
+```
+@codepen
+
+</details>
+
+<details>
+<summary>Observable lists</summary>
+
+```js
+import { ObservableArray, type } from "can";
 
 // -----------------------------------
 // Define an observable TodoList type:
@@ -301,8 +311,7 @@ console.log(areSomeComplete); //-> false
 [can-type] can be used to define typed properties in [ObservableObject] and [StacheElement]
 - Types are strict by default, which means an error will be thrown if a property is set to a value of the wrong type.
 - [can-type/convert] can be used to create a property that will always convert its value to a specific type.
-- [can-type/maybe] can be  used to create a property that can be `null` or `undefined` as well as whatever valid values the type allows
-that has a `person` property with `Person` type:
+- [can-type/maybe] can be  used to create a property that can be `null` or `undefined`.
 
 ```js
 import { ObservableObject, type } from "can";


### PR DESCRIPTION
Closes #5304
Updates API main page:

- Remove the expandable section for Infrastructure APIs
- Simplify the observables section (show only the basics, put the rest in expandable sections)
- Add a section on Types
- Improve the explanation of what customElements.define does