### PR TITLE
Add inserted/removed events to canjs6 migration guide

### DIFF
--- a/docs/can-guides/upgrade/migrating-to-canjs-6.md
+++ b/docs/can-guides/upgrade/migrating-to-canjs-6.md
@@ -534,3 +534,17 @@ class MyParent extends StacheElement {
 customElements.define("my-parent", MyParent);
 ```
 @codepen
+
+
+### inserted/removed event
+Starting from CanJS 4, __inserted__ and __removed__ events are no longer exist.
+
+If you still need to listen to those events on an element, you have to write the following:
+
+```js
+import { domEvents, domMutateDomEvents } from "can";
+
+domEvents.addEvent(domMutateDomEvents.inserted);
+domEvents.addEvent(domMutateDomEvents.removed);
+```
+

--- a/docs/can-guides/upgrade/migrating-to-canjs-6.md
+++ b/docs/can-guides/upgrade/migrating-to-canjs-6.md
@@ -537,7 +537,7 @@ customElements.define("my-parent", MyParent);
 
 
 ### inserted/removed event
-Starting from CanJS 4, __inserted__ and __removed__ events are no longer exist.
+Starting with CanJS 4, __inserted__ and __removed__ events are no longer available by default.
 
 If you still need to listen to those events on an element, you have to write the following:
 


### PR DESCRIPTION
Adds how to use inserted/removed events with canjs6.

Closes https://github.com/canjs/can-3-4-compat/issues/6