### PR TITLE
Update youtube logo in the community page

### DIFF
--- a/docs/images/community/icon-youtube-gray.svg
+++ b/docs/images/community/icon-youtube-gray.svg
@@ -1,35 +1,62 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 32 32" style="enable-background:new 0 0 32 32;" xml:space="preserve">
-<style type="text/css">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4f, 2020-05-01)"
+   sodipodi:docname="icon-youtube-gray.svg"
+   xml:space="preserve"
+   style="enable-background:new 0 0 32 32;"
+   viewBox="0 0 32 32"
+   y="0px"
+   x="0px"
+   id="Layer_1"
+   version="1.1"><metadata
+   id="metadata61"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+   id="defs59" /><sodipodi:namedview
+   inkscape:current-layer="g54"
+   inkscape:window-maximized="0"
+   inkscape:window-y="0"
+   inkscape:window-x="0"
+   inkscape:cy="87.331294"
+   inkscape:cx="63.148876"
+   inkscape:zoom="3.314563"
+   showgrid="false"
+   id="namedview57"
+   inkscape:window-height="900"
+   inkscape:window-width="1440"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0"
+   guidetolerance="10"
+   gridtolerance="10"
+   objecttolerance="10"
+   borderopacity="1"
+   bordercolor="#666666"
+   pagecolor="#ffffff" />
+<style
+   id="style36"
+   type="text/css">
 	.st0{fill:#BBBDBF;}
 </style>
-<g>
-	<path class="st0" d="M22.6,20.2c-0.2,0-0.3,0.1-0.4,0.2C22,20.5,22,20.7,22,21v0.6h1.1V21c0-0.3,0-0.5-0.1-0.6
-		C22.9,20.3,22.7,20.2,22.6,20.2z"/>
-	<g>
-		<path class="st0" d="M18.3,20.2c-0.1,0-0.2,0-0.3,0.1c-0.1,0-0.2,0.1-0.3,0.2v4c0.1,0.1,0.2,0.2,0.3,0.2c0.1,0,0.2,0.1,0.3,0.1
-			c0.2,0,0.3,0,0.3-0.1c0.1-0.1,0.1-0.2,0.1-0.4v-3.3c0-0.2,0-0.4-0.1-0.5C18.6,20.3,18.4,20.2,18.3,20.2z"/>
-		<g>
-			<path class="st0" d="M23.8,15.2H8.2c-2.5,0-4.5,2.3-4.5,4.8v3.7c0,2.5,2,4.6,4.5,4.6h15.6c2.5,0,4.5-2.1,4.5-4.6V20
-				C28.3,17.5,26.3,15.2,23.8,15.2z M11.5,18.3H10v7.3H8.6v-7.3H7.2V17h4.3V18.3z M15.6,25.6h-1.2v-0.7c-0.2,0.3-0.5,0.5-0.7,0.6
-				c-0.2,0.1-0.5,0.2-0.7,0.2c-0.3,0-0.5-0.1-0.6-0.3C12.1,25.3,12,25,12,24.6v-5.3h1.2v4.9c0,0.2,0,0.3,0.1,0.3
-				c0.1,0.1,0.1,0.1,0.3,0.1c0.1,0,0.2,0,0.3-0.1c0.1-0.1,0.3-0.2,0.4-0.3v-4.8h1.2V25.6z M20.1,24.3c0,0.4-0.1,0.8-0.3,1
-				c-0.2,0.2-0.5,0.4-0.8,0.4c-0.2,0-0.5,0-0.6-0.1c-0.2-0.1-0.4-0.2-0.5-0.4v0.5h-1.3V17h1.3v2.8c0.2-0.2,0.3-0.3,0.5-0.4
-				c0.2-0.1,0.4-0.2,0.6-0.2c0.4,0,0.7,0.1,0.9,0.4c0.2,0.3,0.3,0.7,0.3,1.2V24.3z M24.4,22.6H22v1.2c0,0.3,0,0.6,0.1,0.7
-				c0.1,0.1,0.2,0.2,0.4,0.2c0.2,0,0.3-0.1,0.4-0.2c0.1-0.1,0.1-0.4,0.1-0.7v-0.3h1.3v0.3c0,0.7-0.2,1.1-0.5,1.5
-				c-0.3,0.3-0.8,0.5-1.4,0.5c-0.6,0-1-0.2-1.3-0.5c-0.3-0.3-0.5-0.8-0.5-1.4V21c0-0.5,0.2-1,0.5-1.3c0.3-0.3,0.8-0.5,1.4-0.5
-				c0.6,0,1,0.2,1.3,0.5c0.3,0.3,0.5,0.8,0.5,1.4V22.6z"/>
-			<polygon class="st0" points="8.4,3.7 10.3,9.5 10.3,13.2 11.8,13.2 11.8,9.3 13.7,3.7 12.1,3.7 11.1,7.5 11,7.5 10,3.7 			"/>
-			<path class="st0" d="M14.3,6.5c-0.4,0.3-0.6,0.8-0.6,1.3v3.6c0,0.6,0.2,1.1,0.5,1.4c0.4,0.4,0.9,0.5,1.5,0.5
-				c0.6,0,1.1-0.2,1.5-0.5c0.4-0.3,0.5-0.8,0.5-1.4V7.9c0-0.5-0.2-1-0.6-1.3c-0.4-0.3-0.8-0.5-1.4-0.5C15.2,6.1,14.7,6.2,14.3,6.5z
-				 M16.4,7.8v3.8c0,0.2-0.1,0.3-0.2,0.4c-0.1,0.1-0.3,0.2-0.5,0.2c-0.2,0-0.3-0.1-0.4-0.2c-0.1-0.1-0.1-0.3-0.1-0.4V7.8
-				c0-0.2,0.1-0.3,0.2-0.4c0.1-0.1,0.2-0.1,0.4-0.1c0.2,0,0.3,0,0.4,0.1C16.3,7.5,16.4,7.6,16.4,7.8z"/>
-			<path class="st0" d="M22.9,13.2v-7h-1.4v5.3c-0.1,0.2-0.3,0.3-0.4,0.4c-0.2,0.1-0.3,0.1-0.4,0.1c-0.1,0-0.2,0-0.3-0.1
-				c-0.1-0.1-0.1-0.2-0.1-0.4V6.2H19v5.8c0,0.4,0.1,0.7,0.2,0.9c0.2,0.2,0.4,0.3,0.7,0.3c0.3,0,0.5-0.1,0.8-0.2
-				c0.3-0.1,0.5-0.4,0.8-0.7v0.8H22.9z"/>
-		</g>
-	</g>
-</g>
+<g
+   id="g54">
+	
+	
+<g
+   id="g1461"
+   transform="matrix(0.13977273,0,0,-0.13977273,2.581776,29.41821)"><path
+     id="path30"
+     style="fill:#bbbdbf;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     d="m 180.3223,138.6372 c -2.024,7.622 -7.987,13.624 -15.561,15.661 -13.724,3.702 -68.761,3.702 -68.761,3.702 0,0 -55.037,0 -68.762,-3.702 -7.573,-2.037 -13.537,-8.039 -15.561,-15.661 -3.677,-13.814 -3.677,-42.637 -3.677,-42.637 0,0 0,-28.822 3.677,-42.638 2.024,-7.621 7.988,-13.623 15.561,-15.661 13.725,-3.701 68.762,-3.701 68.762,-3.701 0,0 55.037,0 68.761,3.701 7.574,2.038 13.537,8.04 15.561,15.661 3.678,13.816 3.678,42.638 3.678,42.638 0,0 0,28.823 -3.678,42.637" /><g
+     id="g32"
+     transform="translate(78,69.8311)"><path
+       d="M 0,0 46,26.168 0,52.338 Z"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="path34" /></g></g></g>
 </svg>


### PR DESCRIPTION
Update YouTube logo in the community page to reflect YouTube [branding guidlines](https://developers.google.com/youtube/terms/branding-guidelines) 

Before:
<img width="573" alt="Screen Shot 2020-08-04 at 9 48 32 PM" src="https://user-images.githubusercontent.com/109013/89343497-463f0980-d69c-11ea-8a7d-ef86d1fec2ba.png">

After:
<img width="648" alt="Community___CanJS_—_Build_CRUD_apps_in_fewer_lines_of_code_" src="https://user-images.githubusercontent.com/109013/89343518-4f2fdb00-d69c-11ea-91f5-4752cff54aa9.png">
