### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/can-guides/introduction/comparison.md
+++ b/docs/can-guides/introduction/comparison.md
@@ -396,7 +396,7 @@ With **CanJS** we have a guiding principle: You shouldn’t have to rewrite your
 
 ### Modularity
 
-Sometimes, you’re not building the next Gmail, you only have a few interactive forms on your site that could use some pizzaz. Sometimes, you already have a working app, and you want to move progressively into a new framework, not do a whole re-write of what is already working.
+Sometimes, you’re not building the next Gmail, you only have a few interactive forms on your site that could use some pizzazz. Sometimes, you already have a working app, and you want to move progressively into a new framework, not do a whole re-write of what is already working.
 
 The key in these times, is to pick something you can use a piece at a time, as you need it, and pick the parts you need, without bringing in the kitchen sink. You’ll want modularity,
 

--- a/docs/can-guides/introduction/technical.md
+++ b/docs/can-guides/introduction/technical.md
@@ -101,7 +101,7 @@ core libraries:
  - [can-observable-object] - Observable objects.
 
 This section shows examples using [can-value.returnedBy value.returnedBy()].  However,
-as [can-obserable-object] and [can-observable-array] use `returnedBy()` internally for [computed getter properties](#Computedgetterproperties)
+as [can-observable-object] and [can-observable-array] use `returnedBy()` internally for [computed getter properties](#Computedgetterproperties)
 and [asynchronous computed getter properties](##Asynccomputedgetterproperties), the benefits
 of computes extend to [can-observable-object] and [can-observable-array]. In a few examples cases, we’ll use [computed getter properties](#Computedgetterproperties) to
 show the advantages of computes.
@@ -1154,7 +1154,7 @@ The following sections cover:
 
  - [The powerful syntaxes](#MustacheandHandlebarsextendedsyntax) that support the transformation of any ViewModel into HTML.
  - How [custom elements and attributes](#Customelementsandattributes) make
-   applications easer to assemble and debug.
+   applications easier to assemble and debug.
  - The [binding syntaxes](#DataandEventBindings) that allow HTML to
    call methods back on the ViewModel.
  - The strategies used to keep [DOM updates to a minimum](#MinimalDOMupdates).

--- a/docs/can-guides/topics/forms.md
+++ b/docs/can-guides/topics/forms.md
@@ -26,7 +26,7 @@ CanJS provides many useful utilities and techniques to help with these tasks. Th
 * using custom events like [guides/forms#BindingtotheEnterkey enter] and [guides/forms#Radiobutton radiochange]
 * using custom attributes such as [guides/forms#Selectmultiple values] and [guides/forms#Bindingtotemplatevariables focused]
 * validating forms using [guides/forms#Manualformvalidation virtual properties] and validation libraries like [guides/forms#Formvalidationusingaplugin validatejs]
-* indentifying and navigating [guides/forms#Bindingconflicts bindings conflicts]
+* identifying and navigating [guides/forms#Bindingconflicts bindings conflicts]
 * working with [guides/forms#Workingwithrelateddata related data], [guides/forms#Usingpromises promises], and [guides/forms#Resettingaselectionwhenitsparentlistchanges parent-child relationships]
 
 We recommend reading the [guides/forms#Bindings Bindings overview] section first before jumping to the topic that interests you—or start at the top to become an expert on it all.


### PR DESCRIPTION
There are small typos in:
- docs/can-guides/introduction/comparison.md
- docs/can-guides/introduction/technical.md
- docs/can-guides/topics/forms.md

Fixes:
- Should read `pizzazz` rather than `pizzaz`.
- Should read `observable` rather than `obserable`.
- Should read `identifying` rather than `indentifying`.
- Should read `easier` rather than `easer`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md